### PR TITLE
Dropdown fixes

### DIFF
--- a/apps/demo/src/components/starwind/dropdown/Dropdown.astro
+++ b/apps/demo/src/components/starwind/dropdown/Dropdown.astro
@@ -2,6 +2,9 @@
 import type { HTMLAttributes } from "astro/types";
 
 type Props = HTMLAttributes<"div"> & {
+	/**
+	 * When true, the dropdown will open on hover in addition to click
+	 */
 	openOnHover?: boolean;
 	/**
 	 * Time in milliseconds to wait before closing when hover open is enabled
@@ -112,9 +115,24 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
 				}
 			});
 
-			// Close dropdown when clicking outside
+			// Close dropdown when clicking outside for mouse
 			document.addEventListener("pointerdown", (e) => {
 				if (this.isOpen && !this.dropdown.contains(e.target as Node)) {
+					// only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
+					// but not when the control key is pressed (avoiding MacOS right click); also not for touch
+					// devices because that would open the menu on scroll. (pen devices behave as touch on iOS).
+					if (e.button === 0 && e.ctrlKey === false && e.pointerType === "mouse") {
+						this.closeDropdown();
+					}
+				}
+			});
+
+			// Handle click outside select content to close for mobile
+			document.addEventListener("click", (e) => {
+				if (
+					!(this.trigger?.contains(e.target as Node) || this.content?.contains(e.target as Node)) &&
+					this.isOpen
+				) {
 					this.closeDropdown();
 				}
 			});
@@ -137,6 +155,7 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
 				if (item && !(item as HTMLElement).hasAttribute("data-disabled")) {
 					// Close the dropdown after item selection
 					this.closeDropdown();
+					console.log("click closing");
 				}
 			});
 
@@ -157,8 +176,8 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
 			});
 
 			if (this.openOnHover) {
-				// Use mouseenter instead of mouseover to avoid flickering when moving between child elements
-				this.trigger.addEventListener("mouseenter", () => {
+				this.trigger.addEventListener("pointerenter", (e) => {
+					if (e.pointerType !== "mouse") return;
 					if (!this.isOpen) {
 						this.openDropdown();
 					} else {
@@ -167,20 +186,18 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
 					}
 				});
 
-				// Use mouseleave instead of mouseout to only trigger when leaving the entire dropdown
-				this.dropdown.addEventListener("mouseleave", () => {
+				this.dropdown.addEventListener("pointerleave", (e) => {
+					if (e.pointerType !== "mouse") return;
 					if (this.isOpen) {
 						this.closeDropdownDelayed();
 					}
 				});
 
-				// When content is available, also add mouseenter to it to cancel close timer
-				if (this.content) {
-					this.content.addEventListener("mouseenter", () => {
-						// If the user moves the mouse to the content, cancel the close timer
-						this.clearCloseTimer();
-					});
-				}
+				this.content.addEventListener("pointerenter", (e) => {
+					if (e.pointerType !== "mouse") return;
+					// If the user moves the mouse to the content, cancel the close timer
+					this.clearCloseTimer();
+				});
 			}
 		}
 

--- a/apps/demo/src/components/starwind/dropdown/Dropdown.astro
+++ b/apps/demo/src/components/starwind/dropdown/Dropdown.astro
@@ -2,10 +2,6 @@
 import type { HTMLAttributes } from "astro/types";
 
 type Props = HTMLAttributes<"div"> & {
-	name?: string;
-	/**
-	 * When true, the dropdown will open on hover in addition to click
-	 */
 	openOnHover?: boolean;
 	/**
 	 * Time in milliseconds to wait before closing when hover open is enabled
@@ -16,12 +12,11 @@ type Props = HTMLAttributes<"div"> & {
 	children: any;
 };
 
-const { class: className, name, openOnHover = false, closeDelay = 200, ...rest } = Astro.props;
+const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Astro.props;
 ---
 
 <div
 	class:list={["starwind-dropdown", "relative", className]}
-	data-name={name}
 	data-open-on-hover={openOnHover ? "true" : undefined}
 	data-close-delay={closeDelay}
 	{...rest}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "starwind",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Add beautifully designed components to your Astro applications",
 	"license": "MIT",
 	"author": {
@@ -45,7 +45,7 @@
 	},
 	"dependencies": {
 		"@clack/prompts": "^0.9.1",
-		"@starwind-ui/core": "1.5.0",
+		"@starwind-ui/core": "1.5.1",
 		"chalk": "^5.4.1",
 		"commander": "^13.0.0",
 		"execa": "^9.5.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@starwind-ui/core",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Starwind UI core components and registry",
 	"license": "MIT",
 	"author": {

--- a/packages/core/src/components/dropdown/Dropdown.astro
+++ b/packages/core/src/components/dropdown/Dropdown.astro
@@ -2,7 +2,6 @@
 import type { HTMLAttributes } from "astro/types";
 
 type Props = HTMLAttributes<"div"> & {
-	name?: string;
 	/**
 	 * When true, the dropdown will open on hover in addition to click
 	 */
@@ -16,12 +15,11 @@ type Props = HTMLAttributes<"div"> & {
 	children: any;
 };
 
-const { class: className, name, openOnHover = false, closeDelay = 200, ...rest } = Astro.props;
+const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Astro.props;
 ---
 
 <div
 	class:list={["starwind-dropdown", "relative", className]}
-	data-name={name}
 	data-open-on-hover={openOnHover ? "true" : undefined}
 	data-close-delay={closeDelay}
 	{...rest}
@@ -117,9 +115,24 @@ const { class: className, name, openOnHover = false, closeDelay = 200, ...rest }
 				}
 			});
 
-			// Close dropdown when clicking outside
+			// Close dropdown when clicking outside for mouse
 			document.addEventListener("pointerdown", (e) => {
 				if (this.isOpen && !this.dropdown.contains(e.target as Node)) {
+					// only call handler if it's the left button (mousedown gets triggered by all mouse buttons)
+					// but not when the control key is pressed (avoiding MacOS right click); also not for touch
+					// devices because that would open the menu on scroll. (pen devices behave as touch on iOS).
+					if (e.button === 0 && e.ctrlKey === false && e.pointerType === "mouse") {
+						this.closeDropdown();
+					}
+				}
+			});
+
+			// Handle click outside select content to close for mobile
+			document.addEventListener("click", (e) => {
+				if (
+					!(this.trigger?.contains(e.target as Node) || this.content?.contains(e.target as Node)) &&
+					this.isOpen
+				) {
 					this.closeDropdown();
 				}
 			});
@@ -142,6 +155,7 @@ const { class: className, name, openOnHover = false, closeDelay = 200, ...rest }
 				if (item && !(item as HTMLElement).hasAttribute("data-disabled")) {
 					// Close the dropdown after item selection
 					this.closeDropdown();
+					console.log("click closing");
 				}
 			});
 
@@ -162,8 +176,8 @@ const { class: className, name, openOnHover = false, closeDelay = 200, ...rest }
 			});
 
 			if (this.openOnHover) {
-				// Use mouseenter instead of mouseover to avoid flickering when moving between child elements
-				this.trigger.addEventListener("mouseenter", () => {
+				this.trigger.addEventListener("pointerenter", (e) => {
+					if (e.pointerType !== "mouse") return;
 					if (!this.isOpen) {
 						this.openDropdown();
 					} else {
@@ -172,20 +186,18 @@ const { class: className, name, openOnHover = false, closeDelay = 200, ...rest }
 					}
 				});
 
-				// Use mouseleave instead of mouseout to only trigger when leaving the entire dropdown
-				this.dropdown.addEventListener("mouseleave", () => {
+				this.dropdown.addEventListener("pointerleave", (e) => {
+					if (e.pointerType !== "mouse") return;
 					if (this.isOpen) {
 						this.closeDropdownDelayed();
 					}
 				});
 
-				// When content is available, also add mouseenter to it to cancel close timer
-				if (this.content) {
-					this.content.addEventListener("mouseenter", () => {
-						// If the user moves the mouse to the content, cancel the close timer
-						this.clearCloseTimer();
-					});
-				}
+				this.content.addEventListener("pointerenter", (e) => {
+					if (e.pointerType !== "mouse") return;
+					// If the user moves the mouse to the content, cancel the close timer
+					this.clearCloseTimer();
+				});
 			}
 		}
 

--- a/packages/core/src/registry.json
+++ b/packages/core/src/registry.json
@@ -10,7 +10,7 @@
 		{ "name": "card", "type": "component", "version": "1.1.0", "dependencies": [] },
 		{ "name": "checkbox", "type": "component", "version": "1.2.0", "dependencies": [] },
 		{ "name": "dialog", "type": "component", "version": "1.1.1", "dependencies": [] },
-		{ "name": "dropdown", "type": "component", "version": "1.0.0", "dependencies": [] },
+		{ "name": "dropdown", "type": "component", "version": "1.0.1", "dependencies": [] },
 		{ "name": "input", "type": "component", "version": "1.1.1", "dependencies": [] },
 		{ "name": "label", "type": "component", "version": "1.1.1", "dependencies": [] },
 		{ "name": "pagination", "type": "component", "version": "2.0.1", "dependencies": [] },


### PR DESCRIPTION
- Fix dropdown hover bug on mobile - change from mouse events to pointer events and ensure hover events do not fire for touch devices
- Allow scrolling on touch devices without closing the dropdown menu by using pointerdown event only for mouse and using click event otherwise
- Remove unused "name" prop from Dropdown.astro