### PR TITLE
fix(dialog): ensure only the topmost dialog closes on interactions

### DIFF
--- a/apps/demo/src/components/starwind/dialog/Dialog.astro
+++ b/apps/demo/src/components/starwind/dialog/Dialog.astro
@@ -90,7 +90,11 @@ const { class: className, ...rest } = Astro.props;
 			// Add click handlers to all close buttons
 			this.closeButtons?.forEach((button) => {
 				button.addEventListener("click", () => {
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				});
 			});
 
@@ -104,7 +108,11 @@ const { class: className, ...rest } = Astro.props;
 					e.clientY <= dialogDimensions.bottom;
 
 				if (!clickedInDialog) {
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				}
 			});
 
@@ -113,7 +121,11 @@ const { class: className, ...rest } = Astro.props;
 				if (e.key === "Escape") {
 					// prevent default dialog closing behavior so we can add closing animation
 					e.preventDefault();
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				}
 			});
 
@@ -130,7 +142,11 @@ const { class: className, ...rest } = Astro.props;
 					 */
 					if (form.method === "dialog") {
 						e.preventDefault();
-						this.close();
+						// Only close if this is the topmost dialog
+						const openDialogs = document.querySelectorAll("dialog[open]");
+						if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+							this.close();
+						}
 					}
 				});
 			});

--- a/apps/demo/src/pages/index.astro
+++ b/apps/demo/src/pages/index.astro
@@ -586,5 +586,49 @@ import SwitchListenerTest from "@/components/forms/SwitchListenerTest.astro";
 				</Alert>
 			</section>
 		</section>
+
+		<!-- Nested Dialog Demo -->
+		<section class="mx-auto mt-10 max-w-lg">
+			<h2 class="mb-4 text-2xl font-bold">Nested Dialog Demo</h2>
+			<Dialog>
+				<DialogTrigger asChild>
+					<Button variant="primary">Open Parent Dialog</Button>
+				</DialogTrigger>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Parent Dialog</DialogTitle>
+						<DialogDescription>
+							This is the parent dialog. You can open a nested dialog from here.
+						</DialogDescription>
+					</DialogHeader>
+					<div class="mt-4 flex flex-col gap-4">
+						<Dialog>
+							<DialogTrigger asChild>
+								<Button variant="secondary">Open Nested Dialog</Button>
+							</DialogTrigger>
+							<DialogContent>
+								<DialogHeader>
+									<DialogTitle>Nested Dialog</DialogTitle>
+									<DialogDescription>
+										This is the nested dialog. Only the topmost dialog should close when pressing
+										Escape or clicking outside.
+									</DialogDescription>
+								</DialogHeader>
+								<DialogFooter>
+									<DialogClose asChild>
+										<Button variant="outline">Close Nested Dialog</Button>
+									</DialogClose>
+								</DialogFooter>
+							</DialogContent>
+						</Dialog>
+						<DialogFooter>
+							<DialogClose asChild>
+								<Button variant="outline">Close Parent Dialog</Button>
+							</DialogClose>
+						</DialogFooter>
+					</div>
+				</DialogContent>
+			</Dialog>
+		</section>
 	</div>
 </Layout>

--- a/packages/core/src/components/dialog/Dialog.astro
+++ b/packages/core/src/components/dialog/Dialog.astro
@@ -90,7 +90,11 @@ const { class: className, ...rest } = Astro.props;
 			// Add click handlers to all close buttons
 			this.closeButtons?.forEach((button) => {
 				button.addEventListener("click", () => {
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				});
 			});
 
@@ -104,7 +108,11 @@ const { class: className, ...rest } = Astro.props;
 					e.clientY <= dialogDimensions.bottom;
 
 				if (!clickedInDialog) {
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				}
 			});
 
@@ -113,7 +121,11 @@ const { class: className, ...rest } = Astro.props;
 				if (e.key === "Escape") {
 					// prevent default dialog closing behavior so we can add closing animation
 					e.preventDefault();
-					this.close();
+					// Only close if this is the topmost dialog
+					const openDialogs = document.querySelectorAll("dialog[open]");
+					if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+						this.close();
+					}
 				}
 			});
 
@@ -130,7 +142,11 @@ const { class: className, ...rest } = Astro.props;
 					 */
 					if (form.method === "dialog") {
 						e.preventDefault();
-						this.close();
+						// Only close if this is the topmost dialog
+						const openDialogs = document.querySelectorAll("dialog[open]");
+						if (openDialogs.length > 0 && openDialogs[openDialogs.length - 1] === this.dialog) {
+							this.close();
+						}
 					}
 				});
 			});


### PR DESCRIPTION
When a dialog is opened from another dialog, only the topmost one will close on user interactions