### PR TITLE
fix(components): add `id` prop in Checkbox.astro

### DIFF
--- a/packages/core/src/components/checkbox/Checkbox.astro
+++ b/packages/core/src/components/checkbox/Checkbox.astro
@@ -6,6 +6,11 @@ import { tv, type VariantProps } from "tailwind-variants";
 type Props = Omit<HTMLAttributes<"input">, "type"> &
   VariantProps<typeof checkbox> & {
     /**
+     * Unique identifier (ID) for the element which must be unique in the whole document.
+     */
+    id: string;
+
+    /**
      * Optional label text to display next to the checkbox
      */
     label?: string;


### PR DESCRIPTION
Add a required id prop for the input element to ensure link between label and the input element if the label is provided. Currently when you provide label without id in the checkbox, clicking on the label does not check the checkbox because they are not linked. e.g.

```
<Checkbox label="Astro" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The checkbox component now requires a unique identifier (`id`) to be specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->