### PR TITLE
fix: allow style passthrough for DialogTrigger min container

### DIFF
--- a/.changeset/beige-hornets-crash.md
+++ b/.changeset/beige-hornets-crash.md
@@ -1,0 +1,5 @@
+---
+"@starwind-ui/core": patch
+---
+
+Dialog trigger now correctly preserves its default styling while appending user-provided class names when used as a child component. This ensures custom styles work without overriding core styles and maintains consistent appearance across usage patterns. No API changes; improved compatibility with theming and design systems.

--- a/apps/demo/src/components/starwind/alert-dialog/AlertDialogAction.astro
+++ b/apps/demo/src/components/starwind/alert-dialog/AlertDialogAction.astro
@@ -21,7 +21,11 @@ if (Astro.slots.has("default")) {
 
 {
   asChild && hasChildren ? (
-    <div class="starwind-alert-dialog-action" data-slot="alert-dialog-action" data-as-child>
+    <div
+      class:list={["starwind-alert-dialog-action", className]}
+      data-slot="alert-dialog-action"
+      data-as-child
+    >
       <slot />
     </div>
   ) : (

--- a/apps/demo/src/components/starwind/alert-dialog/AlertDialogCancel.astro
+++ b/apps/demo/src/components/starwind/alert-dialog/AlertDialogCancel.astro
@@ -22,7 +22,11 @@ if (Astro.slots.has("default")) {
 
 {
   asChild && hasChildren ? (
-    <div class="starwind-alert-dialog-close" data-slot="alert-dialog-cancel" data-as-child>
+    <div
+      class:list={["starwind-alert-dialog-close", className]}
+      data-slot="alert-dialog-cancel"
+      data-as-child
+    >
       <slot />
     </div>
   ) : (

--- a/apps/demo/src/components/starwind/alert-dialog/AlertDialogTrigger.astro
+++ b/apps/demo/src/components/starwind/alert-dialog/AlertDialogTrigger.astro
@@ -25,7 +25,7 @@ if (Astro.slots.has("default")) {
 {
   asChild && hasChildren ? (
     <div
-      class="starwind-alert-dialog-trigger"
+      class:list={["starwind-alert-dialog-trigger", className]}
       data-slot="alert-dialog-trigger"
       data-as-child
       data-dialog-for={dialogFor}

--- a/apps/demo/src/components/starwind/dialog/DialogTrigger.astro
+++ b/apps/demo/src/components/starwind/dialog/DialogTrigger.astro
@@ -25,7 +25,7 @@ if (Astro.slots.has("default")) {
 {
   asChild && hasChildren ? (
     <div
-      class="starwind-dialog-trigger"
+      class:list={["starwind-dialog-trigger", className]}
       data-slot="dialog-trigger"
       data-as-child
       data-dialog-for={dialogFor}

--- a/packages/core/src/components/alert-dialog/AlertDialogAction.astro
+++ b/packages/core/src/components/alert-dialog/AlertDialogAction.astro
@@ -21,7 +21,11 @@ if (Astro.slots.has("default")) {
 
 {
   asChild && hasChildren ? (
-    <div class="starwind-alert-dialog-action" data-slot="alert-dialog-action" data-as-child>
+    <div
+      class:list={["starwind-alert-dialog-action", className]}
+      data-slot="alert-dialog-action"
+      data-as-child
+    >
       <slot />
     </div>
   ) : (

--- a/packages/core/src/components/alert-dialog/AlertDialogCancel.astro
+++ b/packages/core/src/components/alert-dialog/AlertDialogCancel.astro
@@ -22,7 +22,11 @@ if (Astro.slots.has("default")) {
 
 {
   asChild && hasChildren ? (
-    <div class="starwind-alert-dialog-close" data-slot="alert-dialog-cancel" data-as-child>
+    <div
+      class:list={["starwind-alert-dialog-close", className]}
+      data-slot="alert-dialog-cancel"
+      data-as-child
+    >
       <slot />
     </div>
   ) : (

--- a/packages/core/src/components/alert-dialog/AlertDialogTrigger.astro
+++ b/packages/core/src/components/alert-dialog/AlertDialogTrigger.astro
@@ -25,7 +25,7 @@ if (Astro.slots.has("default")) {
 {
   asChild && hasChildren ? (
     <div
-      class="starwind-alert-dialog-trigger"
+      class:list={["starwind-alert-dialog-trigger", className]}
       data-slot="alert-dialog-trigger"
       data-as-child
       data-dialog-for={dialogFor}

--- a/packages/core/src/components/dialog/DialogTrigger.astro
+++ b/packages/core/src/components/dialog/DialogTrigger.astro
@@ -25,7 +25,7 @@ if (Astro.slots.has("default")) {
 {
   asChild && hasChildren ? (
     <div
-      class="starwind-dialog-trigger"
+      class:list={["starwind-dialog-trigger", className]}
       data-slot="dialog-trigger"
       data-as-child
       data-dialog-for={dialogFor}


### PR DESCRIPTION
Mostly to allow the trigger to be an inline link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dialog trigger now correctly preserves its default styling while appending user-provided class names when used as a child component. This ensures custom styles work without overriding core styles and maintains consistent appearance across usage patterns. No API changes; improved compatibility with theming and design systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->