### PR TITLE
chore: clean up console.log statements in dropdown and radio-group

### DIFF
--- a/apps/demo/src/components/starwind/dropdown/Dropdown.astro
+++ b/apps/demo/src/components/starwind/dropdown/Dropdown.astro
@@ -163,7 +163,7 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
         if (item && !(item as HTMLElement).hasAttribute("data-disabled")) {
           // Close the dropdown after item selection
           this.closeDropdown();
-          console.log("click closing");
+          // console.log("click closing");
         }
       });
 

--- a/apps/demo/src/components/starwind/radio-group/RadioGroup.astro
+++ b/apps/demo/src/components/starwind/radio-group/RadioGroup.astro
@@ -104,7 +104,7 @@ const {
 
     private handleChange(e: Event) {
       const target = e.target as HTMLInputElement;
-      console.log("target", target);
+      // console.log("target", target);
       if (target.type !== "radio") return;
 
       // Update the data-value attribute

--- a/packages/core/src/components/dropdown/Dropdown.astro
+++ b/packages/core/src/components/dropdown/Dropdown.astro
@@ -163,7 +163,7 @@ const { class: className, openOnHover = false, closeDelay = 200, ...rest } = Ast
         if (item && !(item as HTMLElement).hasAttribute("data-disabled")) {
           // Close the dropdown after item selection
           this.closeDropdown();
-          console.log("click closing");
+          // console.log("click closing");
         }
       });
 

--- a/packages/core/src/components/radio-group/RadioGroup.astro
+++ b/packages/core/src/components/radio-group/RadioGroup.astro
@@ -104,7 +104,7 @@ const {
 
     private handleChange(e: Event) {
       const target = e.target as HTMLInputElement;
-      console.log("target", target);
+      // console.log("target", target);
       if (target.type !== "radio") return;
 
       // Update the data-value attribute


### PR DESCRIPTION
## Description
This PR removes debug console.log statements from the Dropdown and RadioGroup components to clean up the codebase and prevent unnecessary console output in production.

## Changes
- Commented out `console.log("click closing")` in Dropdown component click handler
- Commented out `console.log("target", target)` in RadioGroup component change handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed debug logging statements from component handlers across dropdown and radio group components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->