### PR TITLE
Delete unused parentHandler in Tabs.astro

### DIFF
--- a/packages/core/src/components/tabs/Tabs.astro
+++ b/packages/core/src/components/tabs/Tabs.astro
@@ -43,7 +43,6 @@ const { defaultValue, syncKey, class: className, ...rest } = Astro.props;
     private storageKey: string;
     private valueToTriggerMap: Map<string, HTMLButtonElement>;
     private valueToContentMap: Map<string, HTMLElement>;
-    private parentHandler: TabsHandler | null = null;
 
     constructor(tabs: HTMLElement, idx: number, parentHandler: TabsHandler | null = null) {
       this.tabs = tabs;


### PR DESCRIPTION
Fixes this type warning:

`'parentHandler' is declared but its value is never read.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code structure in the tabs component with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->