### PR TITLE
feat(select): add `focusOnTouchDevices` prop to prevent search auto-f…

### DIFF
--- a/.changeset/wise-papers-report.md
+++ b/.changeset/wise-papers-report.md
@@ -1,0 +1,5 @@
+---
+"@starwind-ui/core": patch
+---
+
+feat(select): add `focusOnTouchDevices` prop to prevent search auto-focus on touch devices by default

--- a/apps/demo/src/components/starwind/select/Select.astro
+++ b/apps/demo/src/components/starwind/select/Select.astro
@@ -559,9 +559,14 @@ const { class: className, name, defaultValue, required, ...rest } = Astro.props;
           this.setActiveItem(initialItem);
         }
 
-        requestAnimationFrame(() => {
-          this.searchInput?.focus();
-        });
+        const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
+        const focusOnTouch =
+          this.searchInput?.getAttribute("data-focus-on-touch-devices") === "true";
+        if (!isTouchDevice || focusOnTouch) {
+          requestAnimationFrame(() => {
+            this.searchInput?.focus();
+          });
+        }
       } else {
         // set active on the current selected item
         if (this.selectedItem) {

--- a/apps/demo/src/components/starwind/select/SelectSearch.astro
+++ b/apps/demo/src/components/starwind/select/SelectSearch.astro
@@ -10,12 +10,18 @@ type Props = Omit<HTMLAttributes<"input">, "type" | "autocomplete"> & {
    * @default "No results found."
    */
   emptyText?: string;
+  /**
+   * Whether the search input should be auto-focused on touch devices.
+   * @default false
+   */
+  focusOnTouchDevices?: boolean;
 };
 
 const {
   class: className,
   placeholder = "Search...",
   emptyText = "No results found.",
+  focusOnTouchDevices = false,
   ...rest
 } = Astro.props;
 ---
@@ -35,6 +41,7 @@ const {
     aria-label={placeholder}
     {...rest}
     data-slot="select-search"
+    data-focus-on-touch-devices={focusOnTouchDevices}
   />
 </div>
 

--- a/packages/core/src/components/select/Select.astro
+++ b/packages/core/src/components/select/Select.astro
@@ -559,9 +559,14 @@ const { class: className, name, defaultValue, required, ...rest } = Astro.props;
           this.setActiveItem(initialItem);
         }
 
-        requestAnimationFrame(() => {
-          this.searchInput?.focus();
-        });
+        const isTouchDevice = window.matchMedia("(pointer: coarse)").matches;
+        const focusOnTouch =
+          this.searchInput?.getAttribute("data-focus-on-touch-devices") === "true";
+        if (!isTouchDevice || focusOnTouch) {
+          requestAnimationFrame(() => {
+            this.searchInput?.focus();
+          });
+        }
       } else {
         // set active on the current selected item
         if (this.selectedItem) {

--- a/packages/core/src/components/select/SelectSearch.astro
+++ b/packages/core/src/components/select/SelectSearch.astro
@@ -10,12 +10,18 @@ type Props = Omit<HTMLAttributes<"input">, "type" | "autocomplete"> & {
    * @default "No results found."
    */
   emptyText?: string;
+  /**
+   * Whether the search input should be auto-focused on touch devices.
+   * @default false
+   */
+  focusOnTouchDevices?: boolean;
 };
 
 const {
   class: className,
   placeholder = "Search...",
   emptyText = "No results found.",
+  focusOnTouchDevices = false,
   ...rest
 } = Astro.props;
 ---
@@ -35,6 +41,7 @@ const {
     aria-label={placeholder}
     {...rest}
     data-slot="select-search"
+    data-focus-on-touch-devices={focusOnTouchDevices}
   />
 </div>
 

--- a/packages/core/src/registry.json
+++ b/packages/core/src/registry.json
@@ -100,7 +100,7 @@
       "version": "1.0.0",
       "dependencies": []
     },
-    { "name": "select", "type": "component", "version": "1.8.5", "dependencies": [] },
+    { "name": "select", "type": "component", "version": "1.9.0", "dependencies": [] },
     { "name": "separator", "type": "component", "version": "1.0.2", "dependencies": [] },
     {
       "name": "sheet",


### PR DESCRIPTION
…ocus on touch devices by default. Closes #146

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional "focus on touch devices" setting to control whether the search input auto-focuses when opening a select (defaults to off).
* **Chores**
  * Bumped select component version and added a release changeset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/starwind-ui/starwind-ui/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->