### PR TITLE
fix(carousel): initialize under client-side routing

### DIFF
--- a/.changeset/carousel-client-router-init.md
+++ b/.changeset/carousel-client-router-init.md
@@ -1,0 +1,17 @@
+---
+"@starwind-ui/core": patch
+---
+
+fix(carousel): initialize under client-side routing
+
+The carousel relied on `DOMContentLoaded` for its initial setup, which never
+fires when the component first appears via Astro's `<ClientRouter />`
+view-transition navigations. On such navigations the module script runs only
+after `DOMContentLoaded` has already fired and after `astro:after-swap` has
+been dispatched, so neither handler ran and the carousel stayed
+uninitialized.
+
+Switch to the same initialization pattern used by every other Starwind
+component: call `setupCarousels()` immediately when the script runs, and also
+listen for `astro:after-swap` and `starwind:init`. This makes the carousel
+work on initial load, hard navigations, and client-side transitions alike.

--- a/apps/demo/src/components/starwind/carousel/Carousel.astro
+++ b/apps/demo/src/components/starwind/carousel/Carousel.astro
@@ -45,8 +45,7 @@ const {
     });
   };
 
-  document.addEventListener("DOMContentLoaded", setupCarousels);
-
-  // Re-initialize after Astro page transitions
+  setupCarousels();
   document.addEventListener("astro:after-swap", setupCarousels);
+  document.addEventListener("starwind:init", setupCarousels);
 </script>

--- a/packages/core/src/components/carousel/Carousel.astro
+++ b/packages/core/src/components/carousel/Carousel.astro
@@ -45,8 +45,7 @@ const {
     });
   };
 
-  document.addEventListener("DOMContentLoaded", setupCarousels);
-
-  // Re-initialize after Astro page transitions
+  setupCarousels();
   document.addEventListener("astro:after-swap", setupCarousels);
+  document.addEventListener("starwind:init", setupCarousels);
 </script>


### PR DESCRIPTION
## Problem

The `Carousel` component is the only component in the library that relies on `DOMContentLoaded` for its initial setup:

```js
document.addEventListener("DOMContentLoaded", setupCarousels);
document.addEventListener("astro:after-swap", setupCarousels);
```

This breaks when the carousel first appears via Astro's `<ClientRouter />` view transitions. On a client-side navigation the event order is:

1. DOM is swapped in (carousel markup now present)
2. `astro:after-swap` fires — but `Carousel.astro`'s listener isn't registered yet, because its module script hasn't run in this session
3. the module script runs for the first time and registers the listeners — but `DOMContentLoaded` already fired on the original page load, and `astro:after-swap` already fired in step 2

So neither handler ever runs and the carousel stays uninitialized until a full page reload.

## Fix

Adopt the exact initialization pattern every other Starwind component already uses (`Accordion`, `Dialog`, `Tabs`, `Switch`, `Collapsible`, …):

```js
setupCarousels();
document.addEventListener("astro:after-swap", setupCarousels);
document.addEventListener("starwind:init", setupCarousels);
```

- The immediate `setupCarousels()` call runs whenever the script executes — covering initial load, hard navigation, and the client-side-routing case above (the script runs right after the swap, with the carousel DOM already present).
- `astro:after-swap` keeps re-initialization working across transitions where the script doesn't re-run.
- `starwind:init` adds the manual re-init hook the other components expose. `initCarousel` already guards on `data-initialized`, so the extra calls are idempotent.

Applied to both the core component and the demo copy.

## Notes

I hit this on a production site using `<ClientRouter />` and had to add a per-page workaround that called `initCarousel` on `astro:page-load`. Aligning the carousel with the rest of the library removes the need for any consumer-side workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed carousel initialization to work reliably with Astro client-side routing and page transitions. Carousel components now properly initialize when using dynamic routing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->