### PR TITLE
fix(button): use a real shade change for secondary hover instead of opacity reduction

### DIFF
--- a/.changeset/secondary-hover-shade.md
+++ b/.changeset/secondary-hover-shade.md
@@ -1,0 +1,7 @@
+---
+"@starwind-ui/core": patch
+---
+
+fix(button): make `secondary` variant hover a real shade change instead of an opacity reduction
+
+The `secondary` variant used `hover:bg-secondary/90` to darken on hover. Lowering opacity only blends the background through, so when `--secondary` is a near-white neutral on a near-white `--background` (the default: `neutral-200` on white) the hover is imperceptible and actually shifts the color slightly lighter. The hover now mixes the token toward black in light mode and toward white in dark mode, so it produces a visible, correct-direction shade change regardless of how light the token is.

--- a/apps/demo/src/components/starwind/button/variants.ts
+++ b/apps/demo/src/components/starwind/button/variants.ts
@@ -14,7 +14,7 @@ export const button = tv({
       primary:
         "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/50",
       secondary:
-        "bg-secondary text-secondary-foreground hover:bg-secondary/90 focus-visible:ring-secondary/50",
+        "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklab,var(--secondary),black_8%)] dark:hover:bg-[color-mix(in_oklab,var(--secondary),white_8%)] focus-visible:ring-secondary/50",
       outline:
         "dark:border-input focus-visible:ring-outline/50 bg-background dark:bg-input/30 focus-visible:border-outline hover:bg-muted dark:hover:bg-input/50 hover:text-foreground border shadow-xs",
       ghost: "hover:bg-muted hover:text-foreground focus-visible:ring-outline/50",

--- a/packages/core/src/components/button/variants.ts
+++ b/packages/core/src/components/button/variants.ts
@@ -14,7 +14,7 @@ export const button = tv({
       primary:
         "bg-primary text-primary-foreground hover:bg-primary/90 focus-visible:ring-primary/50",
       secondary:
-        "bg-secondary text-secondary-foreground hover:bg-secondary/90 focus-visible:ring-secondary/50",
+        "bg-secondary text-secondary-foreground hover:bg-[color-mix(in_oklab,var(--secondary),black_8%)] dark:hover:bg-[color-mix(in_oklab,var(--secondary),white_8%)] focus-visible:ring-secondary/50",
       outline:
         "dark:border-input focus-visible:ring-outline/50 bg-background dark:bg-input/30 focus-visible:border-outline hover:bg-muted dark:hover:bg-input/50 hover:text-foreground border shadow-xs",
       ghost: "hover:bg-muted hover:text-foreground focus-visible:ring-outline/50",


### PR DESCRIPTION
## Problem

The `Button` `secondary` variant darkens on hover purely by lowering opacity:

```
secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/90 focus-visible:ring-secondary/50"
```

`hover:bg-secondary/90` doesn't change the hue — it just lets 10% of whatever is behind the button show through. With the default theme, `--secondary` is `neutral-200` (`#e5e5e5`) sitting on `--background: white`. Compositing `#e5e5e5` at 90% over white yields about `#e8e8e8`: a ~3/255 shift per channel, and it goes *lighter*, not darker. The hover is effectively invisible.

This isn't theme-specific to one consumer — it reproduces on Starwind's own defaults (`packages/cli/src/templates/starwind.css.ts` and `apps/demo/.../starwind.css`):

- light: `--secondary: neutral-200` on `--background: white`
- dark: `--secondary: neutral-800` (`#262626`) on `--background: neutral-950` (`#0a0a0a`) → hover lands at ~`#232323`, only ~3/255 darker, also barely perceptible

For contrast, the same `/90` pattern reads fine on `primary` (blue-700) and the status variants because those base colors are far from the background — so this specifically bites filled variants whose token is near the page background.

## Fix

Make the `secondary` hover a real shade change instead of an opacity reduction, using a `color-mix` that is independent of how light the token is:

```
hover:bg-[color-mix(in_oklab,var(--secondary),black_8%)]
dark:hover:bg-[color-mix(in_oklab,var(--secondary),white_8%)]
```

- light `neutral-200` `#e5e5e5` → ~`#d3d3d3` (a clear one-step darken, roughly neutral-200 → neutral-300)
- dark `neutral-800` `#262626` → ~`#373737` (a clear lighten — the right hover direction on a dark surface)

This mirrors how the `outline` variant already uses a `dark:hover:` override for light/dark hover handling, and it works regardless of how light `--secondary` is, so it won't regress for consumers who retheme the token.

Both the canonical source (`packages/core/...`) and the synced demo copy (`apps/demo/...`) are updated, plus a patch changeset for `@starwind-ui/core`.

## Note (out of scope for this PR)

The same opacity-hover weakness will affect any other filled variant whose token is configured near the page background (it just isn't visible on the current defaults for `default`/`primary`/status variants). I kept this change focused on `secondary`, where it bites on the shipped defaults; if you'd prefer a uniform `color-mix` hover treatment across the filled variants, happy to extend it.

## Repro

1. Install with the default theme.
2. Render `<Button variant="secondary">Hover me</Button>`.
3. Hover: the background barely changes (and if anything looks slightly lighter) in light mode.

With this change the hover produces a clearly visible, correct-direction shade in both light and dark mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the secondary button hover state so it now shows a clearer shade change instead of a subtle opacity shift.
  * Hover styling now adapts correctly in both light and dark mode for better visual consistency.
* **Chores**
  * Updated the release notes entry for the button styling fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->