### PR TITLE
feat(components): add chart component

### DIFF
--- a/.changeset/feat-chart-component.md
+++ b/.changeset/feat-chart-component.md
@@ -1,0 +1,17 @@
+---
+"@starwind-ui/core": minor
+---
+
+feat(components): add chart component
+
+A faithful, dependency-free Astro/SVG port of shadcn's chart system. Adds a
+themeable `Chart` container (per-instance `--color-*` injection via `ChartConfig`),
+a shared hover `ChartTooltip` and `ChartLegend`, `--chart-1..5` design tokens
+(light + dark), and seven gallery families: `BarChart` (single/grouped/stacked/
+horizontal/labelled), `LineChart` (linear/monotone/step, dots, labels),
+`AreaChart` (gradient/linear/stacked), `PieChart` (pie/donut/center-text/labels/
+pad-angle), `RadarChart` (polygon/circle grid, multiple series), `RadialChart`
+(gauge/bars/stacked), and Tooltip examples. Bar, Line, and Area share pure-TS
+`curves`, `scale`, and `uid` helpers. Pure vanilla JS for interactivity (WeakMap +
+`astro:after-swap`/`starwind:init`), `role="img"`/`aria-label` on every chart, no
+runtime dependencies.

--- a/apps/demo/src/components/starwind/chart/AreaChart.astro
+++ b/apps/demo/src/components/starwind/chart/AreaChart.astro
@@ -1,0 +1,454 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { buildArea, buildPath, type Point } from "./curves";
+import { niceMax, tightMax, xLabelStep } from "./scale";
+import { nextUid } from "./uid";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  curve?: "linear" | "monotone" | "step" | "natural";
+  stacked?: boolean;
+  gradient?: boolean;
+  gradientOpacity?: number;
+  showDots?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  yTickCount?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  curve = "monotone",
+  stacked = false,
+  gradient = true,
+  gradientOpacity,
+  showDots = false,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLegend = false,
+  showTooltip = true,
+  yTickCount = 6,
+  marginLeft = 0,
+  marginRight,
+  width = 640,
+  height = 360,
+} = Astro.props;
+
+// Internal coordinate space — defaults to aspect-video; callers can override for wide containers
+const W = width;
+const H = height;
+
+// Domain maximum
+const domainVals = stacked
+  ? data.map((d) => series.reduce((sum, s) => sum + Number(d[s] ?? 0), 0))
+  : data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+const isWideChart = W > 800;
+const basePadX = isWideChart ? 8 : 26;
+// "Stacked expand" mode (data pre-normalised to sum ~100, e.g. Stacked Expanded):
+// oracle renders the bottom-most series at fillOpacity 0.1, the rest at 0.4.
+const expandStack = stacked && rawMax <= 100.0001;
+const padTop = expandStack ? (isWideChart ? 12 : 26) : 5;
+const padRight = basePadX + (marginRight ?? 0);
+const padBottom = showXAxis ? (showLegend ? (isWideChart ? 63 : 124) : isWideChart ? 63 : 64) : 10;
+const padLeft = (showYAxis ? (isWideChart ? 40 : 86) : basePadX) + marginLeft;
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+const domainMax = stacked
+  ? rawMax <= 100.0001
+    ? 100
+    : niceMax(rawMax)
+  : showYAxis
+    ? niceMax(rawMax)
+    : tightMax(rawMax);
+
+const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+const ticks = Array.from({ length: yTickCount }, (_, i) => (i * domainMax) / (yTickCount - 1));
+
+// X positions evenly across the plot width.
+const xOf = (i: number) =>
+  data.length <= 1 ? plotLeft + plotW / 2 : plotLeft + (i / (data.length - 1)) * plotW;
+
+// X-axis label thinning — approximates Recharts minTickGap for dense daily data.
+const labelStride = xLabelStep(data.length, W);
+
+// Cumulative sums per data point for stacking
+const cumSums: number[][] = data.map(() => new Array(series.length + 1).fill(0));
+if (stacked) {
+  for (let si = 0; si < series.length; si++) {
+    for (let di = 0; di < data.length; di++) {
+      cumSums[di][si + 1] = cumSums[di][si] + Number(data[di][series[si]] ?? 0);
+    }
+  }
+}
+
+type SeriesData = {
+  key: string;
+  areaPath: string;
+  linePath: string;
+  topPts: Point[];
+};
+
+const seriesData: SeriesData[] = series.map((key, si) => {
+  const topPts: Point[] = data.map((d, di) => ({
+    x: xOf(di),
+    y: stacked ? yOf(cumSums[di][si + 1]) : yOf(Number(d[key] ?? 0)),
+  }));
+  const bottomPts: Point[] = data.map((_d, di) => ({
+    x: xOf(di),
+    y: stacked ? yOf(cumSums[di][si]) : plotBottom,
+  }));
+  return {
+    key,
+    areaPath: buildArea(topPts, bottomPts, curve),
+    linePath: buildPath(topPts, curve),
+    topPts,
+  };
+});
+
+const hitBands = data.map((d, di) => {
+  const x = xOf(di);
+  const left = di === 0 ? plotLeft : (xOf(di - 1) + x) / 2;
+  const right = di === data.length - 1 ? plotRight : (x + xOf(di + 1)) / 2;
+  return {
+    x: left,
+    width: right - left,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(Number(d[key] ?? 0)),
+    })),
+    dots: seriesData.map(({ key, topPts }) => ({ key, point: topPts[di] })),
+  };
+});
+
+// Per-instance suffix so gradient ids don't collide with other AreaChart instances
+// on the same page — a shared id like "grad-desktop" is invalid HTML with >1 chart,
+// and some browsers fail to paint a url(#id) fill when the first same-id element
+// they resolve to sits in a hidden subtree (e.g. an inactive tab/panel elsewhere).
+const gid = nextUid("area-grad");
+
+const ariaLabel = `Area chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+const legendInset = isWideChart ? 5 : 12;
+const legendBottom = isWideChart ? 5 : 0;
+---
+
+<svg
+  data-area-chart
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="none"
+  overflow="visible"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <style>
+    [data-area-hit] [data-active-dot] {
+      opacity: 0;
+      pointer-events: none;
+    }
+    [data-area-hit]:hover [data-active-dot] {
+      opacity: 1;
+    }
+  </style>
+
+  <defs>
+    {
+      series.map((key) => (
+        <linearGradient id={`grad-${key}-${gid}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stop-color={`var(--color-${key})`} stop-opacity="0.8" />
+          <stop offset="95%" stop-color={`var(--color-${key})`} stop-opacity="0.1" />
+        </linearGradient>
+      ))
+    }
+  </defs>
+
+  <!-- Gridlines -->
+  {
+    showGrid &&
+      ticks.map((t) => (
+        <line
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels -->
+  {
+    showYAxis &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 30}
+          y={yOf(t) + 8}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels -->
+  {
+    showXAxis &&
+      data.map(
+        (d, i) =>
+          (data.length > 30 || i % labelStride === 0) && (
+            <text
+              data-area-x-label
+              data-index={i}
+              data-count={data.length}
+              x={xOf(i)}
+              y={plotBottom + 20}
+              dy="0.71em"
+              text-anchor="middle"
+              fill="var(--muted-foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {String(d[categoryKey])}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Area fills (back to front so later series render on top) -->
+  {
+    seriesData.map(({ key, areaPath }, i) => (
+      <path
+        d={areaPath}
+        fill={gradient ? `url(#grad-${key}-${gid})` : `var(--color-${key})`}
+        fill-opacity={gradient ? gradientOpacity : expandStack ? (i === 0 ? "0.1" : "0.4") : "0.4"}
+        stroke="none"
+      />
+    ))
+  }
+
+  <!-- Line strokes on top of fills -->
+  {
+    seriesData.map(({ key, linePath }) => (
+      <path
+        d={linePath}
+        fill="none"
+        stroke={`var(--color-${key})`}
+        stroke-width="1"
+        data-sw="1"
+        vector-effect="non-scaling-stroke"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    ))
+  }
+
+  <!-- Optional dots at each data point -->
+  {
+    showDots &&
+      seriesData.map(({ key, topPts }) =>
+        topPts.map((p) => (
+          <circle
+            cx={p.x}
+            cy={p.y}
+            r="6"
+            data-r="4"
+            fill={`var(--color-${key})`}
+            stroke="var(--background)"
+            stroke-width="2"
+            data-sw="2"
+          />
+        )),
+      )
+  }
+
+  <!-- Full-height hit bands — Recharts tooltip follows the nearest x-axis point. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <g data-area-hit>
+          <rect
+            x={band.x}
+            y={plotTop}
+            width={band.width}
+            height={plotH}
+            fill="transparent"
+            pointer-events="all"
+            data-series={band.items[0]?.series}
+            data-category={band.category}
+            data-items={JSON.stringify(band.items)}
+          />
+          {band.dots.map(({ key, point }) => (
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r="6"
+              data-r="4"
+              fill={`var(--color-${key})`}
+              stroke="var(--background)"
+              stroke-width="2"
+              data-sw="2"
+              data-active-dot
+            />
+          ))}
+        </g>
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div
+      style={`position:absolute;left:${legendInset}px;right:${legendInset}px;bottom:${legendBottom}px;`}
+    >
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  // Which x-axis labels to show for dense (daily) data, matched to shadcn's Recharts
+  // output: same first label + count + last-label position per breakpoint, spread
+  // EVENLY so nothing crowds the right edge. shadcn's last visible label sits ~1 band
+  // inset from the plot edge (Recharts right margin), so we end on total-2, not total-1.
+  const pickAreaLabelIndices = (total: number, width: number) => {
+    if (total <= 30) return null;
+    const [first, count] = width < 500 ? [14, 5] : width < 900 ? [4, 10] : [2, 15];
+    // shadcn's last visible label sits a fixed ~13px in from the plot edge (Recharts
+    // right margin). With mine's data spanning to the edge, that inset is ~1 band on
+    // desktop/tablet but ~3 on the much narrower mobile bands — so end further in there.
+    const last = total - (width < 500 ? 4 : 2);
+    const indices = new Set<number>();
+    for (let k = 0; k < count; k++) {
+      indices.add(Math.round(first + (k * (last - first)) / (count - 1)));
+    }
+    return indices;
+  };
+
+  const scaleAreaSvgMetrics = (svg: SVGSVGElement) => {
+    const vb = svg.viewBox?.baseVal;
+    if (!vb?.width || !vb?.height) return;
+    const box = svg.getBoundingClientRect();
+    if (!box.width || !box.height) return;
+
+    // preserveAspectRatio="none" on a fluid-width/fixed-height container lets
+    // sx and sy diverge (interactive card: sx≈0.36, sy≈1 at narrow widths).
+    // Counter-scale each text/dot about its own anchor with independent kx/ky
+    // so glyphs and dots render at their natural aspect instead of squished.
+    // For aspect-video cards sx===sy, so this collapses to the old uniform scale.
+    const sx = box.width / vb.width;
+    const sy = box.height / vb.height;
+    const kx = 1 / (sx || 1);
+    const ky = 1 / (sy || 1);
+
+    const anchorTransform = (ax: number, ay: number) =>
+      `translate(${(ax * (1 - kx)).toFixed(3)} ${(ay * (1 - ky)).toFixed(3)}) scale(${kx.toFixed(4)} ${ky.toFixed(4)})`;
+
+    svg.querySelectorAll<SVGTextElement>("[data-fs]").forEach((el) => {
+      const px = Number(el.getAttribute("data-fs")) || 12;
+      el.setAttribute("font-size", String(px));
+      const ax = Number(el.getAttribute("x")) || 0;
+      const ay = Number(el.getAttribute("y")) || 0;
+      el.setAttribute("transform", anchorTransform(ax, ay));
+    });
+
+    svg.querySelectorAll<SVGCircleElement>("[data-r]").forEach((el) => {
+      const px = Number(el.getAttribute("data-r")) || 4;
+      el.setAttribute("r", String(px));
+      const ax = Number(el.getAttribute("cx")) || 0;
+      const ay = Number(el.getAttribute("cy")) || 0;
+      el.setAttribute("transform", anchorTransform(ax, ay));
+    });
+
+    // Strokes (area/line paths) intentionally fill the width — just keep
+    // their on-screen thickness constant vertically. Dots carry data-r, so a
+    // counter-scale transform already cancels the viewport stretch and their
+    // stroke renders at natural size — they must NOT get the extra ky factor
+    // (that double-scales it and makes hover dots come out ~1.7× too heavy).
+    svg.querySelectorAll<SVGElement>("[data-sw]").forEach((el) => {
+      const px = Number(el.getAttribute("data-sw")) || 1;
+      // Transformed dots (data-r) and non-scaling-stroke line paths already
+      // render at a true screen px; only the width-filling gridlines still
+      // need the ky factor to hold their on-screen thickness.
+      const natural =
+        el.hasAttribute("data-r") || el.getAttribute("vector-effect") === "non-scaling-stroke";
+      el.setAttribute("stroke-width", natural ? String(px) : (px * ky).toFixed(2));
+    });
+    svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+  };
+
+  const updateAreaLabels = (svg: SVGSVGElement) => {
+    const labels = Array.from(svg.querySelectorAll<SVGTextElement>("[data-area-x-label]"));
+    if (!labels.length) return;
+    const total = Number(labels[0]?.dataset.count) || labels.length;
+    const chosen = pickAreaLabelIndices(
+      total,
+      svg.clientWidth || svg.getBoundingClientRect().width,
+    );
+    for (const label of labels) {
+      const index = Number(label.dataset.index);
+      label.style.display = !chosen || chosen.has(index) ? "" : "none";
+    }
+  };
+
+  const areaObserved = new WeakSet<SVGSVGElement>();
+  const areaResizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const svg = entry.target as SVGSVGElement;
+      requestAnimationFrame(() => {
+        updateAreaLabels(svg);
+        scaleAreaSvgMetrics(svg);
+      });
+    }
+  });
+
+  const setupAreaCharts = () => {
+    document.querySelectorAll<SVGSVGElement>("svg[data-area-chart]").forEach((svg) => {
+      updateAreaLabels(svg);
+      scaleAreaSvgMetrics(svg);
+      requestAnimationFrame(() => {
+        updateAreaLabels(svg);
+        scaleAreaSvgMetrics(svg);
+      });
+      if (!areaObserved.has(svg)) {
+        areaObserved.add(svg);
+        areaResizeObserver.observe(svg);
+      }
+    });
+  };
+
+  setupAreaCharts();
+  document.addEventListener("astro:after-swap", setupAreaCharts);
+  document.addEventListener("starwind:init", setupAreaCharts);
+</script>

--- a/apps/demo/src/components/starwind/chart/BarChart.astro
+++ b/apps/demo/src/components/starwind/chart/BarChart.astro
@@ -1,0 +1,874 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { niceDomain, xLabelStep } from "./scale";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  layout?: "vertical" | "horizontal";
+  stacked?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLabels?: boolean;
+  showCategoryLabels?: boolean;
+  barRadius?: number;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  colorByCategory?: boolean;
+  activeIndex?: number;
+  labelInside?: boolean;
+  negativeColor?: string;
+  showCursor?: boolean;
+  hideTooltipLabel?: boolean;
+  hideTooltipIndicator?: boolean;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  layout = "vertical",
+  stacked = false,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLabels = false,
+  showCategoryLabels = false,
+  barRadius = 4,
+  showLegend = false,
+  showTooltip = true,
+  colorByCategory = false,
+  activeIndex,
+  labelInside = false,
+  negativeColor,
+  showCursor = false,
+  hideTooltipLabel = false,
+  hideTooltipIndicator = false,
+  width = 640,
+  height = 360,
+} = Astro.props;
+
+const isHorizontal = layout === "horizontal";
+const isDenseVertical = !isHorizontal && data.length > 30;
+
+// Internal coordinate space — driven by props so wide containers don't letterbox.
+const W = width;
+const H = height;
+
+// Padding (logical px) tuned to Recharts' plot box for the shadcn bar examples.
+// Negative/stacked+legend padTop/padBottom and horizontal padLeft/padRight were
+// re-derived from the oracle's real margin/CartesianGrid geometry — the old
+// values had been tuned to compensate for domainMax previously being raw
+// (un-nice-rounded); with the domain fix they left far too much dead margin.
+// Label overflow (month names, value labels) still fits: Recharts renders
+// these past the nominal margin via SVG overflow, and bars stop short of the
+// plot edge anyway once the domain is nice-rounded, leaving room for the
+// label offsets without needing extra padding to compensate.
+const padTop = isHorizontal
+  ? 3
+  : isDenseVertical
+    ? 37
+    : showCategoryLabels
+      ? 9
+      : showLabels
+        ? 55
+        : stacked && showLegend
+          ? 9
+          : 24;
+const padRight = isHorizontal ? (labelInside ? 29 : colorByCategory ? 8 : 0) : 12;
+const padBottom = isHorizontal
+  ? showXAxis
+    ? 28
+    : 3
+  : isDenseVertical
+    ? 30
+    : stacked && showLegend
+      ? 115
+      : showCategoryLabels
+        ? 9
+        : showLabels
+          ? 64
+          : showXAxis
+            ? 75
+            : 35;
+const padLeft = isHorizontal ? (labelInside ? 0 : colorByCategory ? 111 : 73) : showYAxis ? 50 : 12;
+
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+// Compute domain — auto-detect negatives
+const allVals = stacked
+  ? data.map((d) => series.reduce((sum, s) => sum + Number(d[s] ?? 0), 0))
+  : data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...allVals, 0);
+const rawMin = Math.min(...allVals, 0);
+
+// Faithful port of Recharts' default axis "nice" domain algorithm
+// (recharts-scale's getNiceTickValues/calculateStep, tickCount=5). Recharts
+// mutates a numeric axis' scale domain to this nice-rounded range EVEN WHEN
+// the axis is hidden — confirmed by reading generateCategoricalChart.js's
+// getTicksOfScale, which runs unconditionally per axis. That's the actual
+// root cause of shadcn's bars leaving headroom / stopping short of the plot
+// edges instead of touching them exactly at the raw data min/max.
+const [domainMin, domainMax] = niceDomain(rawMin, rawMax);
+const domainRange = domainMax - domainMin;
+
+// Unified scale helpers — backward-compatible when domainMin === 0
+const yOf = (v: number) => plotBottom - ((v - domainMin) / domainRange) * plotH;
+const xOf = (v: number) => plotLeft + (v / domainMax) * plotW;
+const baselineY = yOf(0); // = plotBottom when domainMin === 0
+
+// X-axis label thinning — approximates Recharts minTickGap for dense daily data.
+const labelStride = xLabelStep(data.length, W);
+
+// Grid ticks — Recharts' implicit-axis default: 5 evenly-spaced lines from
+// domainMin to domainMax (confirmed against oracle gridline y-positions).
+const tickCount = 5;
+const ticks = Array.from(
+  { length: tickCount },
+  (_, i) => domainMin + (i * domainRange) / (tickCount - 1),
+);
+
+// Shape helpers — used only for stacked segments
+function topRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, w / 2, h);
+  return (
+    `M${x},${y + h} L${x},${y + cr} Q${x},${y} ${x + cr},${y} ` +
+    `L${x + w - cr},${y} Q${x + w},${y} ${x + w},${y + cr} L${x + w},${y + h} Z`
+  );
+}
+
+// Rounds only the bottom two corners (for negative stacked bars growing downward)
+function bottomRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, w / 2, h);
+  return (
+    `M${x},${y} L${x + w},${y} L${x + w},${y + h - cr} ` +
+    `Q${x + w},${y + h} ${x + w - cr},${y + h} ` +
+    `L${x + cr},${y + h} Q${x},${y + h} ${x},${y + h - cr} L${x},${y} Z`
+  );
+}
+
+// Rounds only the right two corners (for horizontal stacked segments)
+function rightRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, h / 2, w);
+  return (
+    `M${x},${y} L${x + w - cr},${y} Q${x + w},${y} ${x + w},${y + cr} ` +
+    `L${x + w},${y + h - cr} Q${x + w},${y + h} ${x + w - cr},${y + h} L${x},${y + h} Z`
+  );
+}
+
+type BarItem = {
+  path: string;
+  // Non-stacked bars use a rect instead of a path (all-four-corner rounding via rx/ry).
+  rect?: { x: number; y: number; w: number; h: number; r: number };
+  fill: string;
+  labelText: string;
+  labelX: number;
+  labelY: number;
+  labelAnchor: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  dataIndex: number;
+  isActive: boolean;
+  catLabelText: string;
+  catLabelX: number;
+  catLabelY: number;
+  catLabelFill: string;
+  // Screen-space vertical offset (px) applied by the counter-scaler. Used for
+  // negative-bar month labels so the gap below the bar stays constant on screen
+  // instead of shrinking with the viewBox scale (which made labels touch bars).
+  catLabelDyPx?: number;
+  insideLabel?: { text: string; x: number; y: number };
+};
+
+const bars: BarItem[] = [];
+
+// Resolve fill for a single bar
+function resolveFill(key: string, val: number, category: string): string {
+  if (colorByCategory) return `var(--color-${category})`;
+  if (val < 0 && negativeColor) return negativeColor;
+  return `var(--color-${key})`;
+}
+
+if (!isHorizontal) {
+  const bandW = plotW / data.length;
+
+  if (stacked) {
+    const stackBarW = bandW * 0.75;
+    for (let di = 0; di < data.length; di++) {
+      const bandCenter = plotLeft + bandW * (di + 0.5);
+      const x = bandCenter - stackBarW / 2;
+      let currentBottom = baselineY;
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const h = (val / domainMax) * plotH;
+        const y = currentBottom - h;
+        const category = String(data[di][categoryKey]);
+        // Top segment: top corners rounded. Bottom segment: bottom corners rounded
+        // (matching shadcn radius={[0,0,4,4]} / radius={[4,4,0,0]}). Non-top
+        // segments extend 2px upward under the segment above to kill the
+        // antialiasing seam; bottomRoundRect inherits that trick via y-2/h+2.
+        const isTopSeg = si === series.length - 1;
+        const isBottomSeg = si === 0 && series.length > 1;
+        const segTop = y - 2;
+        const path = isTopSeg
+          ? topRoundRect(x, y, stackBarW, h, barRadius)
+          : isBottomSeg
+            ? bottomRoundRect(x, y - 2, stackBarW, h + 2, barRadius)
+            : `M${x},${y + h} L${x},${segTop} L${x + stackBarW},${segTop} L${x + stackBarW},${y + h} Z`;
+
+        bars.push({
+          path: path || "",
+          fill: resolveFill(key, val, category),
+          labelText: String(val),
+          labelX: x + stackBarW / 2,
+          labelY: y - 4,
+          labelAnchor: "middle",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: false,
+          catLabelText: category,
+          catLabelX: x + stackBarW / 2,
+          catLabelY: y - 8,
+          catLabelFill: "var(--foreground)",
+        });
+        currentBottom = y;
+      }
+    }
+  } else {
+    // Grouped vertical — Recharts uses ONE bar-width ratio regardless of
+    // whether LabelList is present; measured ~0.794 on the oracle (default
+    // and active bars agree to within 0.02%). Grouped pair fills ~0.9.
+    const groupFrac = series.length === 1 ? 0.79 : 0.9;
+    const groupW = bandW * groupFrac;
+    const barSlotW = groupW / series.length;
+    const actualBarW = series.length === 1 ? barSlotW : barSlotW * 0.92;
+    const barOffset = (barSlotW - actualBarW) / 2;
+
+    for (let di = 0; di < data.length; di++) {
+      const bandCenter = plotLeft + bandW * (di + 0.5);
+      const groupLeft = bandCenter - groupW / 2;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const x = groupLeft + si * barSlotW + barOffset;
+        const isNeg = val < 0;
+        const fill = resolveFill(key, val, category);
+
+        let rect: BarItem["rect"];
+        let labelY: number;
+        let catLabelY: number;
+        let catLabelDyPx: number | undefined;
+
+        if (isNeg) {
+          // Bar grows downward from baseline
+          const h = yOf(val) - baselineY;
+          const r = Math.min(barRadius, actualBarW / 2, h / 2);
+          rect = { x, y: baselineY, w: actualBarW, h, r };
+          labelY = baselineY - 4;
+          // Anchor at the bar's outer (bottom) edge; push the label down a
+          // constant 14px on screen (matches shadcn's LabelList gap). A viewBox
+          // offset would shrink under scaling and collapse the gap.
+          catLabelY = yOf(val);
+          catLabelDyPx = 14;
+        } else {
+          const barTop = yOf(val);
+          const h = baselineY - barTop;
+          const r = Math.min(barRadius, actualBarW / 2, h / 2);
+          rect = { x, y: barTop, w: actualBarW, h, r };
+          labelY = barTop - 8;
+          catLabelY = barTop - 6;
+        }
+
+        bars.push({
+          path: "",
+          rect,
+          fill,
+          labelText: String(val),
+          labelX: x + actualBarW / 2,
+          labelY,
+          labelAnchor: "middle",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: activeIndex !== undefined && di === activeIndex,
+          catLabelText: category,
+          catLabelX: x + actualBarW / 2,
+          catLabelY,
+          catLabelFill: fill,
+          catLabelDyPx,
+        });
+      }
+    }
+  }
+} else {
+  // Horizontal bars
+  const bandH = plotH / data.length;
+
+  if (stacked) {
+    const stackBarH = bandH * 0.6;
+    for (let di = 0; di < data.length; di++) {
+      const bandMidY = plotTop + bandH * (di + 0.5);
+      const y = bandMidY - stackBarH / 2;
+      let currentLeft = plotLeft;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const w = (val / domainMax) * plotW;
+        // Only the rightmost segment gets rounded corners. Non-rightmost
+        // segments extend ~0.75px right under the next so fills overlap and
+        // the antialiasing seam between colors disappears.
+        const isRightmost = si === series.length - 1;
+        const segRight = currentLeft + w + 0.75;
+        const path = isRightmost
+          ? rightRoundRect(currentLeft, y, w, stackBarH, barRadius)
+          : `M${currentLeft},${y} L${segRight},${y} L${segRight},${y + stackBarH} L${currentLeft},${y + stackBarH} Z`;
+
+        bars.push({
+          path: path || "",
+          fill: resolveFill(key, val, category),
+          labelText: String(val),
+          labelX: currentLeft + w + 4,
+          labelY: y + stackBarH / 2 + 4,
+          labelAnchor: "start",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: false,
+          catLabelText: category,
+          catLabelX: plotLeft + 8,
+          catLabelY: y + stackBarH / 2 + 4,
+          catLabelFill: "var(--foreground)",
+        });
+        currentLeft += w;
+      }
+    }
+  } else {
+    // Grouped horizontal — single bar ~0.7 of band; grouped pair fills ~0.8
+    const groupFrac = series.length === 1 ? 0.8 : 0.8;
+    const groupH = bandH * groupFrac;
+    const barSlotH = groupH / series.length;
+    const actualBarH = series.length === 1 ? barSlotH : barSlotH * 0.9;
+    const barOffset = (barSlotH - actualBarH) / 2;
+
+    for (let di = 0; di < data.length; di++) {
+      const bandMidY = plotTop + bandH * (di + 0.5);
+      const groupTop = bandMidY - groupH / 2;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const w = xOf(val) - plotLeft;
+        const y = groupTop + si * barSlotH + barOffset;
+        // True bar center — text uses dominant-baseline="central" at render
+        // time instead of an alphabetic-baseline fudge offset (measured on
+        // the oracle: LabelList text centers within ~0.25px of bar center).
+        const midY = y + actualBarH / 2;
+        const fill = resolveFill(key, val, category);
+        const r = Math.min(barRadius, actualBarH / 2, w / 2);
+
+        bars.push({
+          path: "",
+          rect: { x: plotLeft, y, w, h: actualBarH, r },
+          fill,
+          labelText: String(val),
+          labelX: plotLeft + w + 6,
+          labelY: midY,
+          labelAnchor: "start",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: activeIndex !== undefined && di === activeIndex,
+          catLabelText: category,
+          catLabelX: plotLeft + 8,
+          catLabelY: midY,
+          catLabelFill: fill,
+          // labelInside: category name inside bar (left) + value at right end
+          insideLabel: labelInside ? { text: category, x: plotLeft + 8, y: midY } : undefined,
+        });
+      }
+    }
+  }
+}
+
+const hitBands = data.map((d, di) => {
+  const category = String(d[categoryKey]);
+  const items = series.map((key) => ({
+    series: key,
+    label: config[key]?.label ?? key,
+    value: String(d[key] ?? 0),
+    // Resolved bar color CSS string — lets the tooltip swatch render even
+    // for series without a --color-<key> var (e.g. colorByCategory bars).
+    color: resolveFill(key, Number(d[key] ?? 0), category),
+  }));
+
+  if (isHorizontal) {
+    const bandH = plotH / data.length;
+    return {
+      index: di,
+      x: plotLeft,
+      y: plotTop + bandH * di,
+      width: plotW,
+      height: bandH,
+      category,
+      items,
+    };
+  }
+
+  const bandW = plotW / data.length;
+  return {
+    index: di,
+    x: plotLeft + bandW * di,
+    y: plotTop,
+    width: bandW,
+    height: plotH,
+    category,
+    items,
+  };
+});
+
+const ariaLabel = `Bar chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="xMidYMid meet"
+  overflow="visible"
+  data-bar-dense={isDenseVertical ? "true" : undefined}
+  data-bar-cursor={showCursor ? "true" : undefined}
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Gridlines -->
+  {
+    showGrid &&
+      !isHorizontal &&
+      ticks.map((t) => (
+        <line
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showGrid &&
+      isHorizontal &&
+      ticks.map((t) => (
+        <line
+          x1={xOf(t)}
+          x2={xOf(t)}
+          y1={plotTop}
+          y2={plotBottom}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels (vertical layout) -->
+  {
+    showYAxis &&
+      !isHorizontal &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 6}
+          y={yOf(t) + 4}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels (vertical layout) — thinned for dense datasets -->
+  {
+    showXAxis &&
+      !isHorizontal &&
+      data.map((d, i) => {
+        if (!isDenseVertical && i % labelStride !== 0) return null;
+        const bandW = plotW / data.length;
+        const cx = plotLeft + bandW * (i + 0.5);
+        return (
+          <text
+            x={cx}
+            y={plotBottom + 20}
+            dy="0.71em"
+            text-anchor="middle"
+            fill="var(--muted-foreground)"
+            font-size="12"
+            data-fs="12"
+            data-dense-x-label={isDenseVertical ? "true" : undefined}
+            data-index={isDenseVertical ? i : undefined}
+          >
+            {config[String(d[categoryKey])]?.label ?? String(d[categoryKey])}
+          </text>
+        );
+      })
+  }
+
+  <!-- Y-axis category labels (horizontal layout) — hidden when labelInside -->
+  {
+    !labelInside &&
+      isHorizontal &&
+      data.map((d, i) => {
+        const bandH = plotH / data.length;
+        const midY = plotTop + bandH * (i + 0.5);
+        const cat = String(d[categoryKey]);
+        return (
+          <text
+            x={plotLeft - 28}
+            y={midY + 4}
+            text-anchor="end"
+            fill="var(--muted-foreground)"
+            font-size="12"
+            data-fs="12"
+          >
+            {config[cat]?.label ?? cat}
+          </text>
+        );
+      })
+  }
+
+  <!-- X-axis value labels (horizontal layout) -->
+  {
+    showXAxis &&
+      isHorizontal &&
+      ticks.map((t) => (
+        <text
+          x={xOf(t)}
+          y={plotBottom + 16}
+          text-anchor="middle"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- Hover cursor band — shadcn only shows this on charts that don't set
+       cursor={false} (stacked, interactive). Hidden by default; toggled by
+       the script below on hover of the matching hit band. Rendered before
+       bars so bars paint on top of it, matching Recharts' z-order. -->
+  {
+    showCursor &&
+      hitBands.map((band) => (
+        <rect
+          x={band.x}
+          y={band.y}
+          width={band.width}
+          height={band.height}
+          fill="var(--muted)"
+          opacity="0"
+          pointer-events="none"
+          data-cursor-index={band.index}
+        />
+      ))
+  }
+
+  <!-- Bars — data-* attrs drive tooltip content.
+       Non-stacked bars use <rect rx/ry> for all-four-corner rounding (matches
+       Recharts radius={N}). Stacked segments keep <path> for per-corner control. -->
+  {
+    bars.map((b) =>
+      b.rect ? (
+        <rect
+          x={b.rect.x}
+          y={b.rect.y}
+          width={b.rect.w}
+          height={b.rect.h}
+          rx={b.rect.r}
+          ry={b.rect.r}
+          data-rxy={barRadius}
+          fill={b.fill}
+          fill-opacity={b.isActive ? 0.8 : 1}
+          stroke={b.isActive ? b.fill : "none"}
+          stroke-width={b.isActive ? 2 : 0}
+          data-sw={b.isActive ? "2" : undefined}
+          stroke-dasharray={b.isActive ? "4 4" : undefined}
+          stroke-dashoffset={b.isActive ? 4 : undefined}
+          data-series={b.seriesKey}
+          data-category={b.category}
+          data-value={b.value}
+          data-label={config[b.seriesKey]?.label ?? b.seriesKey}
+        />
+      ) : (
+        b.path && (
+          <path
+            d={b.path}
+            fill={b.fill}
+            fill-opacity={b.isActive ? 0.8 : 1}
+            stroke={b.isActive ? b.fill : "none"}
+            stroke-width={b.isActive ? 2 : 0}
+            data-sw={b.isActive ? "2" : undefined}
+            stroke-dasharray={b.isActive ? "4 4" : undefined}
+            stroke-dashoffset={b.isActive ? 4 : undefined}
+            data-series={b.seriesKey}
+            data-category={b.category}
+            data-value={b.value}
+            data-label={config[b.seriesKey]?.label ?? b.seriesKey}
+          />
+        )
+      ),
+    )
+  }
+
+  <!-- Optional per-bar value labels (above bar for vertical, right end for horizontal) -->
+  {
+    showLabels &&
+      !labelInside &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) && (
+            <text
+              x={b.labelX}
+              y={b.labelY}
+              text-anchor={b.labelAnchor}
+              fill="var(--foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {b.labelText}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Category key labels above/below bars (e.g. month names on the negative chart).
+       Each label is colored to match its bar and sits at the outer end of the bar. -->
+  {
+    showCategoryLabels &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) && (
+            <text
+              x={b.catLabelX}
+              y={b.catLabelY}
+              text-anchor={b.labelAnchor}
+              fill={b.catLabelFill}
+              font-size="12"
+              data-fs="12"
+              data-dy-px={b.catLabelDyPx}
+            >
+              {b.catLabelText}
+            </text>
+          ),
+      )
+  }
+
+  <!-- labelInside: category name inside bar (left) + value at right end -->
+  {
+    labelInside &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) &&
+          b.insideLabel && (
+            <>
+              <text
+                x={b.insideLabel.x}
+                y={b.insideLabel.y}
+                text-anchor="start"
+                dominant-baseline="central"
+                fill="var(--background)"
+                font-size="12"
+                font-weight="500"
+                data-fs="12"
+              >
+                {b.insideLabel.text}
+              </text>
+              <text
+                x={b.labelX}
+                y={b.labelY}
+                text-anchor="start"
+                dominant-baseline="central"
+                fill="var(--foreground)"
+                font-size="12"
+                font-weight="500"
+                data-fs="12"
+              >
+                {b.labelText}
+              </text>
+            </>
+          ),
+      )
+  }
+
+  <!-- Full-band hit targets — Recharts tooltip follows the nearest category, not just painted bars. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <rect
+          x={band.x}
+          y={band.y}
+          width={band.width}
+          height={band.height}
+          fill="transparent"
+          pointer-events="all"
+          data-index={band.index}
+          data-series={band.items[0]?.series}
+          data-category={band.category}
+          data-items={JSON.stringify(band.items)}
+          data-hide-label={hideTooltipLabel ? "1" : undefined}
+          data-hide-indicator={hideTooltipIndicator ? "1" : undefined}
+        />
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div class="pointer-events-none absolute inset-x-0 bottom-0">
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  const normalizeDenseBars = () => {
+    requestAnimationFrame(() => {
+      document.querySelectorAll<SVGSVGElement>('svg[data-bar-dense="true"]').forEach((svg) => {
+        const width = svg.clientWidth || svg.getBoundingClientRect().width;
+        const height = svg.clientHeight || svg.getBoundingClientRect().height;
+        if (!width || !height) return;
+
+        const left = 13;
+        const right = 13;
+        const top = 37;
+        const bottom = 30;
+        const plotWidth = width - left - right;
+        const plotHeight = height - top - bottom;
+        const plotBottom = top + plotHeight;
+        const bars = Array.from(
+          svg.querySelectorAll<SVGRectElement>("rect[data-value]:not([data-items])"),
+        );
+        if (!bars.length || plotWidth <= 0 || plotHeight <= 0) return;
+
+        svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+        const values = bars.map((bar) => Number(bar.dataset.value) || 0);
+        const max = Math.max(...values, 10);
+        const bandWidth = plotWidth / bars.length;
+        const barWidth = bandWidth * 0.78;
+
+        bars.forEach((bar, index) => {
+          const value = values[index] || 0;
+          const barHeight = (value / max) * plotHeight;
+          bar.setAttribute("x", String(left + bandWidth * index + (bandWidth - barWidth) / 2));
+          bar.setAttribute("y", String(plotBottom - barHeight));
+          bar.setAttribute("width", String(barWidth));
+          bar.setAttribute("height", String(barHeight));
+        });
+
+        const gridLines = Array.from(svg.querySelectorAll<SVGLineElement>("line[data-sw]"));
+        gridLines.forEach((line, index) => {
+          const ratio = gridLines.length > 1 ? index / (gridLines.length - 1) : 0;
+          const y = plotBottom - ratio * plotHeight;
+          line.setAttribute("x1", String(left));
+          line.setAttribute("x2", String(width - right));
+          line.setAttribute("y1", String(y));
+          line.setAttribute("y2", String(y));
+        });
+
+        Array.from(svg.querySelectorAll<SVGRectElement>("rect[data-items]")).forEach(
+          (hit, index) => {
+            hit.setAttribute("x", String(left + bandWidth * index));
+            hit.setAttribute("y", String(top));
+            hit.setAttribute("width", String(bandWidth));
+            hit.setAttribute("height", String(plotHeight));
+          },
+        );
+
+        const labels = Array.from(
+          svg.querySelectorAll<SVGTextElement>('text[data-dense-x-label="true"]'),
+        );
+        const first = width < 500 ? 11 : 2;
+        const step = width < 500 ? 20 : width < 900 ? 10 : 6;
+        labels.forEach((label, index) => {
+          const visible =
+            index === labels.length - 1 || (index >= first && (index - first) % step === 0);
+          label.style.display = visible ? "" : "none";
+          label.setAttribute("x", String(left + bandWidth * (index + 0.5)));
+          label.setAttribute("y", String(plotBottom + (width < 500 ? 12 : 20)));
+          label.setAttribute("font-size", "12");
+        });
+
+        svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+      });
+    });
+  };
+
+  // Hover cursor band (stacked/interactive) — self-contained here so it
+  // doesn't require changes to ChartTooltip.astro. Binds once per svg (guarded
+  // via dataset.cursorBound) since the interactive card toggles panels via
+  // `hidden` without recreating the DOM, so this can re-run harmlessly.
+  const setupBarCursor = () => {
+    document.querySelectorAll<SVGSVGElement>('svg[data-bar-cursor="true"]').forEach((svg) => {
+      if (svg.dataset.cursorBound === "true") return;
+      svg.dataset.cursorBound = "true";
+      const cursors = Array.from(svg.querySelectorAll<SVGRectElement>("rect[data-cursor-index]"));
+      svg.querySelectorAll<SVGRectElement>("rect[data-items]").forEach((hit) => {
+        const cursor = cursors.find((c) => c.dataset.cursorIndex === hit.dataset.index);
+        if (!cursor) return;
+        hit.addEventListener("mouseenter", () => {
+          for (const attr of ["x", "y", "width", "height"]) {
+            const v = hit.getAttribute(attr);
+            if (v !== null) cursor.setAttribute(attr, v);
+          }
+          cursor.setAttribute("opacity", "1");
+        });
+        hit.addEventListener("mouseleave", () => cursor.setAttribute("opacity", "0"));
+      });
+    });
+  };
+
+  normalizeDenseBars();
+  setupBarCursor();
+  window.addEventListener("resize", normalizeDenseBars);
+  document.addEventListener("astro:after-swap", normalizeDenseBars);
+  document.addEventListener("astro:after-swap", setupBarCursor);
+  document.addEventListener("starwind:init", normalizeDenseBars);
+  document.addEventListener("starwind:init", setupBarCursor);
+</script>

--- a/apps/demo/src/components/starwind/chart/Chart.astro
+++ b/apps/demo/src/components/starwind/chart/Chart.astro
@@ -1,0 +1,159 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+import type { ChartConfig } from "./variants";
+import { chart } from "./variants";
+
+type Props = HTMLAttributes<"div"> & {
+  config: ChartConfig;
+  id?: string;
+};
+
+// ponytail: module-level counter for stable SSR IDs; no Date/random = deterministic across renders
+let chartCounter = 0;
+
+const { config, id, class: className, ...rest } = Astro.props;
+const chartId = id ?? `starwind-chart-${chartCounter++}`;
+
+// Inject per-series color vars via inline style so SVG bars inherit them through CSS custom property cascade.
+// ponytail: inline style > [data-chart] <style is:inline set:html> — add the latter when light/dark theme
+// split per-series is needed (shadcn's themeObject config shape).
+const combinedStyle =
+  Object.entries(config)
+    .filter(([, cfg]) => cfg.color)
+    .map(([key, cfg]) => `--color-${key}: ${cfg.color}`)
+    .join("; ") || undefined;
+---
+
+<div
+  class={chart({ class: className })}
+  data-slot="chart"
+  data-chart={chartId}
+  style={combinedStyle}
+  {...rest}
+>
+  <slot />
+  {
+    /* Pre-paint counter-scale: runs synchronously during HTML parse (forcing a
+      layout read) so axis/value labels render at their final pixel size on the
+      FIRST paint instead of rendering tiny then jumping when the deferred module
+      script below runs. Uniform scale is exact for every chart except the two
+      anisotropic "interactive" area cards (factor≈1 there), which the module
+      scaler refines a frame later. ponytail: is:inline duplicates ~1KB/chart but
+      avoids a shared-global load-order dance; fine for a demo gallery. */
+  }
+  <script is:inline>
+    (function () {
+      var root = document.currentScript.parentElement;
+      var svgs = root.querySelectorAll("svg");
+      for (var i = 0; i < svgs.length; i++) {
+        var svg = svgs[i];
+        var vb = svg.viewBox && svg.viewBox.baseVal && svg.viewBox.baseVal.width;
+        if (!vb) continue;
+        // Prefer the container div's width — it resolves earlier than the SVG's
+        // own box mid-parse, so the pre-paint pass lands more often on the busy
+        // live page. Falls back to the SVG box; 0 → skip (module scaler + the
+        // hide-until-scaled CSS cover it a frame later).
+        var w = root.clientWidth || svg.clientWidth || svg.getBoundingClientRect().width;
+        if (!w) continue;
+        var f = vb / w;
+        svg.querySelectorAll("[data-fs]").forEach(function (t) {
+          t.setAttribute("font-size", ((Number(t.getAttribute("data-fs")) || 12) * f).toFixed(2));
+          var dy = t.getAttribute("data-dy-px");
+          if (dy !== null) t.setAttribute("dy", (Number(dy) * f).toFixed(2));
+        });
+        svg.querySelectorAll("[data-sw]").forEach(function (el) {
+          el.setAttribute(
+            "stroke-width",
+            ((Number(el.getAttribute("data-sw")) || 1) * f).toFixed(2),
+          );
+        });
+        svg.querySelectorAll("[data-r]").forEach(function (el) {
+          el.setAttribute("r", ((Number(el.getAttribute("data-r")) || 4) * f).toFixed(2));
+        });
+        svg.querySelectorAll("[data-rxy]").forEach(function (el) {
+          var v = ((Number(el.getAttribute("data-rxy")) || 0) * f).toFixed(2);
+          el.setAttribute("rx", v);
+          el.setAttribute("ry", v);
+        });
+        svg.setAttribute("data-scaled", ""); // reveal labels (hidden until now by CSS)
+      }
+    })();
+  </script>
+</div>
+
+<script>
+  // Keep axis/value labels a constant pixel size regardless of the chart's
+  // rendered width. Our SVGs use a fixed viewBox that scales to fit, so raw
+  // <text> would shrink/grow with the container (Recharts keeps it fixed).
+  // Counter-scale: font-size(userUnits) = targetPx * viewBoxWidth / clientWidth.
+  // Only glyph size changes; x/y positions stay anchored to data points.
+  const scaleSvgMetrics = (svg: SVGSVGElement) => {
+    const vb = svg.viewBox?.baseVal?.width;
+    if (!vb) return;
+    const w = svg.clientWidth || svg.getBoundingClientRect().width;
+    if (!w) return; // hidden panel (display:none) → skip until visible
+    const factor = vb / w;
+    svg.querySelectorAll<SVGTextElement>("[data-fs]").forEach((t) => {
+      const px = Number(t.getAttribute("data-fs")) || 12;
+      t.setAttribute("font-size", (px * factor).toFixed(2));
+      // Screen-constant vertical offset (px → viewBox units), e.g. negative-bar
+      // month labels that must keep a fixed gap below the bar at any width.
+      const dyPx = t.getAttribute("data-dy-px");
+      if (dyPx !== null) t.setAttribute("dy", (Number(dyPx) * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGElement>("[data-sw]").forEach((el) => {
+      const px = Number(el.getAttribute("data-sw")) || 1;
+      el.setAttribute("stroke-width", (px * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGCircleElement>("[data-r]").forEach((el) => {
+      const px = Number(el.getAttribute("data-r")) || 4;
+      el.setAttribute("r", (px * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGRectElement>("[data-rxy]").forEach((el) => {
+      const px = Number(el.getAttribute("data-rxy")) || 0;
+      const value = (px * factor).toFixed(2);
+      el.setAttribute("rx", value);
+      el.setAttribute("ry", value);
+    });
+    svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+  };
+
+  const observed = new WeakSet<SVGSVGElement>();
+  const ro = new ResizeObserver((entries) => {
+    for (const e of entries) scaleSvgMetrics(e.target as SVGSVGElement);
+  });
+
+  const setupAxisScaling = () => {
+    document
+      .querySelectorAll<SVGSVGElement>('[data-slot="chart"] svg:not([data-area-chart])')
+      .forEach((svg) => {
+        scaleSvgMetrics(svg);
+        if (!observed.has(svg)) {
+          observed.add(svg);
+          ro.observe(svg);
+        }
+      });
+  };
+
+  setupAxisScaling();
+  document.addEventListener("astro:after-swap", setupAxisScaling);
+  document.addEventListener("starwind:init", setupAxisScaling);
+
+  // Safety net: never leave labels hidden. If any svg reached full load without
+  // a scaler running (e.g. an unforeseen path), reveal it — a flash beats
+  // permanently-invisible labels. Area/dense scalers set data-scaled themselves.
+  window.addEventListener("load", () => {
+    document
+      .querySelectorAll<SVGSVGElement>('[data-slot="chart"] svg:not([data-scaled])')
+      .forEach((svg) => {
+        // Only reveal svgs that are actually on-screen. A hidden-tab svg
+        // (width 0) can't be scaled yet; marking it data-scaled here would flash
+        // unscaled labels the moment its tab is opened. The ResizeObserver
+        // scales and reveals it when the panel becomes visible.
+        if (!(svg.clientWidth || svg.getBoundingClientRect().width)) return;
+        scaleSvgMetrics(svg);
+        svg.setAttribute("data-scaled", "");
+      });
+  });
+</script>

--- a/apps/demo/src/components/starwind/chart/ChartLegend.astro
+++ b/apps/demo/src/components/starwind/chart/ChartLegend.astro
@@ -1,0 +1,54 @@
+---
+import type { ChartConfig } from "./variants";
+import { chartLegend } from "./variants";
+
+type Props = {
+  config: ChartConfig;
+  series: string[];
+};
+
+const { config, series } = Astro.props;
+
+// Inline lucide icon paths for the variants whose legend uses icons instead of
+// colour swatches (area-icons, radar-icons). Keyed by the config `icon` name.
+const ICONS: Record<string, string> = {
+  "trending-up":
+    '<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/>',
+  "trending-down":
+    '<polyline points="22 17 13.5 8.5 8.5 13.5 2 7"/><polyline points="16 17 22 17 22 11"/>',
+  "arrow-up-from-line": '<path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/>',
+  "arrow-down-from-line": '<path d="M19 3H5"/><path d="M12 21V7"/><path d="m6 15 6 6 6-6"/>',
+};
+---
+
+<div data-slot="chart-legend" class={chartLegend()}>
+  {
+    series.map((key) => {
+      const icon = config[key]?.icon;
+      return (
+        <div class="flex items-center gap-1.5">
+          {icon && ICONS[icon] ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="text-muted-foreground h-3 w-3 shrink-0"
+              aria-hidden="true"
+              set:html={ICONS[icon]}
+            />
+          ) : (
+            <span
+              class="inline-block h-2 w-2 shrink-0 rounded-[2px]"
+              style={`background: var(--color-${key})`}
+            />
+          )}
+          <span>{config[key]?.label ?? key}</span>
+        </div>
+      );
+    })
+  }
+</div>

--- a/apps/demo/src/components/starwind/chart/ChartTooltip.astro
+++ b/apps/demo/src/components/starwind/chart/ChartTooltip.astro
@@ -8,6 +8,13 @@
 <script>
   type TooltipItem = { series: string; label: string; value: string; color?: string };
 
+  // Escape chart-derived text before it is spliced into innerHTML (XSS-safe with untrusted data).
+  const escapeHtml = (s: string) =>
+    String(s).replace(
+      /[&<>"']/g,
+      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+    );
+
   class ChartTooltipHandler {
     private chart: HTMLElement;
     private tooltip: HTMLElement;
@@ -87,13 +94,13 @@
             (item.color && item.color.trim()) || color || `var(--color-${item.series})`;
           const dot = hideIndicator
             ? ""
-            : `<span style="width:10px;height:10px;border-radius:2px;background:${swatch};flex-shrink:0"></span>`;
+            : `<span style="width:10px;height:10px;border-radius:2px;background:${escapeHtml(swatch)};flex-shrink:0"></span>`;
           return `
             <div style="display:flex;width:100%;align-items:center;gap:8px">
               ${dot}
               <div style="display:flex;flex:1;align-items:center;justify-content:space-between;line-height:1">
-                <span style="color:var(--muted-foreground)">${item.label}</span>
-                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${item.value}</span>
+                <span style="color:var(--muted-foreground)">${escapeHtml(item.label)}</span>
+                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${escapeHtml(item.value)}</span>
               </div>
             </div>
           `;
@@ -102,7 +109,7 @@
 
       this.content.innerHTML = `
         <div style="display:grid;gap:6px">
-          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${category}</div>`}
+          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${escapeHtml(category)}</div>`}
           ${rows}
         </div>
       `;

--- a/apps/demo/src/components/starwind/chart/ChartTooltip.astro
+++ b/apps/demo/src/components/starwind/chart/ChartTooltip.astro
@@ -1,0 +1,153 @@
+<div
+  data-slot="chart-tooltip"
+  class="border-border/50 bg-background pointer-events-none absolute z-50 hidden min-w-[8rem] items-start rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
+>
+  <div data-chart-tooltip-content></div>
+</div>
+
+<script>
+  type TooltipItem = { series: string; label: string; value: string; color?: string };
+
+  class ChartTooltipHandler {
+    private chart: HTMLElement;
+    private tooltip: HTMLElement;
+    private content: HTMLElement;
+
+    constructor(chart: HTMLElement) {
+      this.chart = chart;
+      this.tooltip = chart.querySelector('[data-slot="chart-tooltip"]')!;
+      this.content = this.tooltip.querySelector("[data-chart-tooltip-content]")!;
+      this.setup();
+    }
+
+    private setup(): void {
+      const svg = this.chart.querySelector("svg");
+      if (!svg || !this.tooltip || !this.content) return;
+
+      svg.addEventListener("mouseover", (e) => {
+        const target = (e.target as Element).closest(
+          "[data-series],[data-items]",
+        ) as HTMLElement | null;
+        if (!target) {
+          this.hide();
+          return;
+        }
+        this.show(target, e as MouseEvent);
+      });
+
+      svg.addEventListener("mousemove", (e) => {
+        if (!this.tooltip.classList.contains("hidden")) {
+          this.position(e as MouseEvent);
+        }
+      });
+
+      svg.addEventListener("mouseleave", () => this.hide());
+    }
+
+    private getItems(target: HTMLElement): TooltipItem[] {
+      if (target.dataset.items) {
+        try {
+          const parsed = JSON.parse(target.dataset.items);
+          if (Array.isArray(parsed)) {
+            return parsed
+              .map((item) => ({
+                series: String(item.series ?? ""),
+                label: String(item.label ?? item.series ?? ""),
+                value: String(item.value ?? ""),
+                color: String(item.color ?? ""),
+              }))
+              .filter((item) => item.series);
+          }
+        } catch {}
+      }
+
+      const series = target.dataset.series ?? "";
+      return [
+        {
+          series,
+          label: target.dataset.label ?? series,
+          value: target.dataset.value ?? "",
+          color: target.dataset.color ?? "",
+        },
+      ];
+    }
+
+    private show(target: HTMLElement, e: MouseEvent): void {
+      const category = target.dataset.category ?? "";
+      // Match shadcn's ChartTooltipContent hideLabel / hideIndicator flags.
+      const hideLabel = target.dataset.hideLabel === "1";
+      const hideIndicator = target.dataset.hideIndicator === "1";
+      const items = this.getItems(target);
+      const rows = items
+        .map((item) => {
+          const color = getComputedStyle(this.chart)
+            .getPropertyValue(`--color-${item.series}`)
+            .trim();
+          const swatch =
+            (item.color && item.color.trim()) || color || `var(--color-${item.series})`;
+          const dot = hideIndicator
+            ? ""
+            : `<span style="width:10px;height:10px;border-radius:2px;background:${swatch};flex-shrink:0"></span>`;
+          return `
+            <div style="display:flex;width:100%;align-items:center;gap:8px">
+              ${dot}
+              <div style="display:flex;flex:1;align-items:center;justify-content:space-between;line-height:1">
+                <span style="color:var(--muted-foreground)">${item.label}</span>
+                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${item.value}</span>
+              </div>
+            </div>
+          `;
+        })
+        .join("");
+
+      this.content.innerHTML = `
+        <div style="display:grid;gap:6px">
+          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${category}</div>`}
+          ${rows}
+        </div>
+      `;
+
+      this.tooltip.classList.remove("hidden");
+      this.position(e);
+    }
+
+    private position(e: MouseEvent): void {
+      const chartRect = this.chart.getBoundingClientRect();
+      const tooltipW = this.tooltip.offsetWidth || 140;
+      const tooltipH = this.tooltip.offsetHeight || 60;
+      let x = e.clientX - chartRect.left + 8;
+      let y = e.clientY - chartRect.top - tooltipH - 8;
+
+      // Flip horizontally if would overflow right edge
+      if (x + tooltipW > chartRect.width) {
+        x = e.clientX - chartRect.left - tooltipW - 8;
+      }
+      // Clamp vertically
+      if (y + tooltipH > chartRect.height) {
+        y = e.clientY - chartRect.top - tooltipH - 8;
+      }
+      if (y < 0) y = 4;
+
+      this.tooltip.style.left = `${x}px`;
+      this.tooltip.style.top = `${y}px`;
+    }
+
+    private hide(): void {
+      this.tooltip.classList.add("hidden");
+    }
+  }
+
+  const tooltipInstances = new WeakMap<HTMLElement, ChartTooltipHandler>();
+
+  const setupChartTooltips = () => {
+    document.querySelectorAll<HTMLElement>('[data-slot="chart"]').forEach((chart) => {
+      if (chart.querySelector('[data-slot="chart-tooltip"]') && !tooltipInstances.has(chart)) {
+        tooltipInstances.set(chart, new ChartTooltipHandler(chart));
+      }
+    });
+  };
+
+  setupChartTooltips();
+  document.addEventListener("astro:after-swap", setupChartTooltips);
+  document.addEventListener("starwind:init", setupChartTooltips);
+</script>

--- a/apps/demo/src/components/starwind/chart/LineChart.astro
+++ b/apps/demo/src/components/starwind/chart/LineChart.astro
@@ -1,0 +1,483 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { buildPath, type Point } from "./curves";
+import { rechartsAutoMax, xLabelStep } from "./scale";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  curve?: "linear" | "monotone" | "natural" | "step";
+  showDots?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLabels?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  strokeWidth?: number;
+  /** Per-point dot color: name of a data field holding a CSS color string (e.g. "fill"). */
+  dotColorKey?: string;
+  /** "diamond" renders a git-commit-vertical style dot (vertical line + hollow circle). */
+  dotShape?: "circle" | "diamond";
+  /** Custom label key: data field whose value is looked up in config for the label text. */
+  labelKey?: string;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  curve = "monotone",
+  showDots = true,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLabels = false,
+  showLegend = false,
+  showTooltip = true,
+  strokeWidth = 2,
+  dotColorKey,
+  dotShape = "circle",
+  labelKey,
+  width = 297,
+  height = 167,
+} = Astro.props;
+
+// Internal coordinate space — defaults to Recharts' rendered aspect-video size.
+const W = width;
+const H = height;
+
+const padTop = showLabels ? (showXAxis ? 20 : 24) : showXAxis ? 0 : 24;
+const padRight = showXAxis ? 12 : 24;
+const padBottom = showXAxis ? 30 : 0;
+const padLeft = showYAxis ? 50 : showXAxis ? 12 : 24;
+
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+const domainVals = data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+const domainMax = rechartsAutoMax(rawMax);
+
+// Points spread evenly across plot width; single-point case centers it
+const xOf = (i: number) =>
+  data.length > 1 ? plotLeft + (i / (data.length - 1)) * plotW : plotLeft + plotW / 2;
+const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+
+const tickCount = 5;
+const ticks = Array.from({ length: tickCount + 1 }, (_, i) => (i * domainMax) / tickCount);
+
+// Thin x-axis labels — approximates Recharts minTickGap for dense daily data.
+const isDenseXAxis = data.length > 20;
+const labelStride = xLabelStep(data.length, W);
+const xLabelStart = isDenseXAxis ? 2 : 0;
+const shouldShowXLabel = (i: number) =>
+  !isDenseXAxis ||
+  i === data.length - 1 ||
+  (i >= xLabelStart && i < data.length - labelStride && (i - xLabelStart) % labelStride === 0);
+
+type LinePoint = {
+  x: number;
+  y: number;
+  category: string;
+  value: string;
+  dotFill: string;
+  labelText: string;
+};
+type LineData = { key: string; pathD: string; points: LinePoint[] };
+
+const lines: LineData[] = series.map((key) => {
+  const pts: Point[] = data.map((d, i) => ({ x: xOf(i), y: yOf(Number(d[key] ?? 0)) }));
+  return {
+    key,
+    pathD: buildPath(pts, curve),
+    points: data.map((d, i) => ({
+      x: xOf(i),
+      y: yOf(Number(d[key] ?? 0)),
+      category: String(d[categoryKey]),
+      value: String(d[key] ?? 0),
+      dotFill: dotColorKey ? String(d[dotColorKey]) : `var(--color-${key})`,
+      labelText: labelKey
+        ? (config[String(d[labelKey])]?.label ?? String(d[labelKey]))
+        : String(d[key] ?? 0),
+    })),
+  };
+});
+
+const hitBands = data.map((d, di) => {
+  const x = xOf(di);
+  const left = di === 0 ? plotLeft : (xOf(di - 1) + x) / 2;
+  const right = di === data.length - 1 ? plotRight : (x + xOf(di + 1)) / 2;
+  return {
+    x: left,
+    width: right - left,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(d[key] ?? 0),
+    })),
+    dots: lines.map((line) => ({ key: line.key, point: line.points[di] })),
+  };
+});
+
+const ariaLabel = `Line chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+const denseValues = isDenseXAxis
+  ? JSON.stringify(data.map((d) => series.map((key) => Number(d[key] ?? 0))))
+  : undefined;
+---
+
+<svg
+  data-line-dense={isDenseXAxis ? "true" : undefined}
+  data-line-values={denseValues}
+  data-line-domain={isDenseXAxis ? domainMax : undefined}
+  data-line-curve={isDenseXAxis ? curve : undefined}
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="none"
+  overflow="visible"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <style>
+    [data-line-hit] [data-active-dot] {
+      opacity: 0;
+      pointer-events: none;
+    }
+    [data-line-hit]:hover [data-active-dot] {
+      opacity: 1;
+    }
+  </style>
+
+  <!-- Horizontal gridlines -->
+  {
+    showGrid &&
+      ticks.map((t, i) => (
+        <line
+          data-grid-line={i}
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels -->
+  {
+    showYAxis &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 6}
+          y={yOf(t) + 4}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels -->
+  {
+    showXAxis &&
+      data.map(
+        (d, i) =>
+          (isDenseXAxis || shouldShowXLabel(i)) && (
+            <text
+              data-x-label={i}
+              x={xOf(i)}
+              y={plotBottom + 14}
+              dy="0.71em"
+              text-anchor="middle"
+              fill="var(--muted-foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {String(d[categoryKey])}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Line paths — one per series -->
+  {
+    lines.map((line) => (
+      <path
+        data-line-path={line.key}
+        d={line.pathD}
+        fill="none"
+        stroke={`var(--color-${line.key})`}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth}
+        stroke-linejoin="round"
+        stroke-linecap="round"
+      />
+    ))
+  }
+
+  <!-- Visible dots (optional) -->
+  {
+    showDots &&
+      lines.map((line) =>
+        dotShape === "diamond"
+          ? line.points.map((pt) => (
+              <g>
+                <line
+                  x1={pt.x}
+                  y1={pt.y - 12}
+                  x2={pt.x}
+                  y2={pt.y + 12}
+                  stroke={`var(--color-${line.key})`}
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  data-sw="2"
+                />
+                <circle
+                  cx={pt.x}
+                  cy={pt.y}
+                  r="3"
+                  fill="var(--foreground)"
+                  stroke="var(--background)"
+                  stroke-width="2"
+                  data-r="3"
+                  data-sw="2"
+                />
+              </g>
+            ))
+          : line.points.map((pt) => (
+              <circle
+                cx={pt.x}
+                cy={pt.y}
+                r={dotColorKey ? "5" : "3"}
+                data-r={dotColorKey ? "5" : "3"}
+                fill={pt.dotFill}
+                stroke={pt.dotFill}
+                stroke-width={dotColorKey ? "1" : "2"}
+                data-sw={dotColorKey ? "1" : "2"}
+              />
+            )),
+      )
+  }
+
+  <!-- Full-height hit bands — Recharts tooltip follows the nearest x-axis point. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <g data-line-hit>
+          <rect
+            x={band.x}
+            y={plotTop}
+            width={band.width}
+            height={plotH}
+            fill="transparent"
+            pointer-events="all"
+            data-series={band.items[0]?.series}
+            data-category={band.category}
+            data-items={JSON.stringify(band.items)}
+          />
+          {band.dots.map(({ key, point }) => (
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r="6"
+              data-r="6"
+              fill={`var(--color-${key})`}
+              stroke="var(--background)"
+              stroke-width="2"
+              data-sw="2"
+              data-active-dot
+            />
+          ))}
+        </g>
+      ))
+  }
+
+  <!-- Value/custom labels — pointer-events none so they don't block tooltip hit targets -->
+  {
+    showLabels &&
+      lines.map((line) =>
+        line.points.map((pt, i) => (
+          <text
+            x={pt.x}
+            y={pt.y - 10}
+            text-anchor={i === 0 ? "start" : i === line.points.length - 1 ? "end" : "middle"}
+            fill="var(--foreground)"
+            font-size="12"
+            font-weight="500"
+            pointer-events="none"
+            data-fs="12"
+          >
+            {pt.labelText}
+          </text>
+        )),
+      )
+  }
+</svg>
+
+{showLegend && <ChartLegend config={config} series={series} />}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  const installDenseLineReflow = () => {
+    const win = window as typeof window & { __starwindDenseLineReflow?: boolean };
+    if (win.__starwindDenseLineReflow) return;
+    win.__starwindDenseLineReflow = true;
+
+    const linePath = (pts: number[][]) =>
+      pts.length
+        ? `M${pts[0][0]},${pts[0][1]}` +
+          pts
+            .slice(1)
+            .map((p) => ` L${p[0]},${p[1]}`)
+            .join("")
+        : "";
+
+    const stepPath = (pts: number[][]) => {
+      if (!pts.length) return "";
+      let d = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 1; i < pts.length; i++) d += ` H${pts[i][0]} V${pts[i][1]}`;
+      return d;
+    };
+
+    const monotonePath = (pts: number[][]) => {
+      if (pts.length < 2) return pts.length === 1 ? `M${pts[0][0]},${pts[0][1]}` : "";
+      const n = pts.length;
+      const dxs = pts.slice(0, -1).map((p, i) => pts[i + 1][0] - p[0]);
+      const dys = pts.slice(0, -1).map((p, i) => pts[i + 1][1] - p[1]);
+      const tan = new Array(n).fill(0);
+      tan[0] = dxs[0] ? dys[0] / dxs[0] : 0;
+      tan[n - 1] = dxs[n - 2] ? dys[n - 2] / dxs[n - 2] : 0;
+      for (let i = 1; i < n - 1; i++) {
+        const s0 = dxs[i - 1] ? dys[i - 1] / dxs[i - 1] : 0;
+        const s1 = dxs[i] ? dys[i] / dxs[i] : 0;
+        tan[i] = s0 * s1 <= 0 ? 0 : (s0 + s1) / 2;
+      }
+      for (let i = 0; i < n - 1; i++) {
+        const s = dxs[i] ? dys[i] / dxs[i] : 0;
+        if (Math.abs(s) < 1e-10) {
+          tan[i] = tan[i + 1] = 0;
+          continue;
+        }
+        const a = tan[i] / s;
+        const b = tan[i + 1] / s;
+        const h = Math.sqrt(a * a + b * b);
+        if (h > 3) {
+          tan[i] = (3 / h) * a * s;
+          tan[i + 1] = (3 / h) * b * s;
+        }
+      }
+      let d = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 0; i < n - 1; i++) {
+        const dx = dxs[i];
+        const cp1x = pts[i][0] + dx / 3;
+        const cp1y = pts[i][1] + (tan[i] * dx) / 3;
+        const cp2x = pts[i + 1][0] - dx / 3;
+        const cp2y = pts[i + 1][1] - (tan[i + 1] * dx) / 3;
+        d += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${pts[i + 1][0].toFixed(1)},${pts[i + 1][1].toFixed(1)}`;
+      }
+      return d;
+    };
+
+    const buildPath = (pts: number[][], curve: string) => {
+      if (curve === "linear") return linePath(pts);
+      if (curve === "step") return stepPath(pts);
+      return monotonePath(pts);
+    };
+
+    const labelPlan = (width: number, count: number) => {
+      if (width < 500) return { start: 11, step: 20, last: count - 1 };
+      if (width < 800) return { start: 2, step: 10, last: count - 1 };
+      return { start: 2, step: 6, last: count - 1 };
+    };
+
+    const reflow = (svg: SVGSVGElement) => {
+      const box = svg.getBoundingClientRect();
+      const width = box.width;
+      const height = box.height;
+      if (!width || !height) return;
+
+      const values = JSON.parse(svg.dataset.lineValues || "[]") as number[][];
+      const domainMax = Number(svg.dataset.lineDomain) || 1;
+      if (!values.length) return;
+
+      const padLeft = 12;
+      const padRight = 12;
+      const padTop = 0;
+      const padBottom = 30;
+      const plotW = width - padLeft - padRight;
+      const plotH = height - padTop - padBottom;
+      const plotBottom = padTop + plotH;
+      const xOf = (i: number) => padLeft + (i / (values.length - 1)) * plotW;
+      const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+      const curve = svg.dataset.lineCurve || "monotone";
+
+      svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+      svg.querySelectorAll<SVGLineElement>("[data-grid-line]").forEach((line) => {
+        const i = Number(line.dataset.gridLine) || 0;
+        const y = yOf((i * domainMax) / 5);
+        line.setAttribute("x1", String(padLeft));
+        line.setAttribute("x2", String(width - padRight));
+        line.setAttribute("y1", String(y));
+        line.setAttribute("y2", String(y));
+      });
+
+      svg.querySelectorAll<SVGPathElement>("[data-line-path]").forEach((path, seriesIndex) => {
+        const pts = values.map((row, i) => [xOf(i), yOf(Number(row[seriesIndex] ?? 0))]);
+        path.setAttribute("d", buildPath(pts, curve));
+        path.setAttribute("stroke-width", "2");
+      });
+
+      const plan = labelPlan(width, values.length);
+      svg.querySelectorAll<SVGTextElement>("[data-x-label]").forEach((text) => {
+        const i = Number(text.dataset.xLabel);
+        const visible =
+          i === plan.last ||
+          (i >= plan.start && i < plan.last - plan.step / 2 && (i - plan.start) % plan.step === 0);
+        text.style.display = visible ? "" : "none";
+        text.setAttribute("x", String(xOf(i)));
+        text.setAttribute("y", String(plotBottom + 14));
+        text.setAttribute("font-size", "12");
+      });
+    };
+
+    const reflowAll = () => {
+      document.querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]').forEach(reflow);
+    };
+    const schedule = () => requestAnimationFrame(reflowAll);
+
+    const ro = new ResizeObserver(schedule);
+    document
+      .querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]')
+      .forEach((svg) => ro.observe(svg));
+    schedule();
+    document.addEventListener("starwind:init", schedule);
+    document.addEventListener("astro:after-swap", () => {
+      document
+        .querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]')
+        .forEach((svg) => ro.observe(svg));
+      schedule();
+    });
+  };
+
+  installDenseLineReflow();
+</script>

--- a/apps/demo/src/components/starwind/chart/PieChart.astro
+++ b/apps/demo/src/components/starwind/chart/PieChart.astro
@@ -149,12 +149,15 @@ function buildSlicesFor(
   // unchanged but slices land exactly where shadcn's do.
   let theta = 0; // Recharts angle (radians), CCW from 3 o'clock
   const halfPad = padRad / 2;
-  let idx = 0;
+  let dataIdx = 0;
 
   for (const d of sliceData) {
     const name = String(d[nameKey]);
     const val = Number(d[sliceDataKey] ?? 0);
-    if (val <= 0) continue;
+    if (val <= 0) {
+      dataIdx++;
+      continue;
+    }
     const pct = sliceTotal > 0 ? val / sliceTotal : 0;
     const sweep = pct * 2 * Math.PI;
     const thetaStart = theta + halfPad;
@@ -164,7 +167,7 @@ function buildSlicesFor(
     const midA = -(thetaStart + thetaEnd) / 2;
 
     // Active slice gets a 10px outer-radius bump (donut-active / interactive).
-    const sliceOuter = activIdx === idx ? oR + 10 : oR;
+    const sliceOuter = activIdx === dataIdx ? oR + 10 : oR;
 
     const labelR = sliceOuter + 16;
     const lx = fmt(cx + Math.cos(midA) * labelR);
@@ -198,7 +201,7 @@ function buildSlicesFor(
     });
 
     theta += sweep;
-    idx++;
+    dataIdx++;
   }
   return result;
 }

--- a/apps/demo/src/components/starwind/chart/PieChart.astro
+++ b/apps/demo/src/components/starwind/chart/PieChart.astro
@@ -1,0 +1,363 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  nameKey: string;
+  dataKey: string;
+  donut?: boolean;
+  innerRadiusRatio?: number;
+  showLabels?: boolean;
+  labelLine?: boolean;
+  /** What outside labels display: visitor count (default), config name, or percent. */
+  labelContent?: "value" | "name" | "percent";
+  /** Inside-slice labels (label-list variant). */
+  showInnerLabels?: boolean;
+  centerText?: string;
+  centerLabel?: string;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  padAngle?: number;
+  /** Stroke width on slice borders; set to 0 for separator-none. */
+  strokeWidth?: number;
+  /** If set, this slice index gets outerRadius + 10 (donut-active/interactive). */
+  activeIndex?: number;
+  /** Second ring data for stacked variant (outer ring). Requires dataKey2. */
+  data2?: Record<string, string | number>[];
+  dataKey2?: string;
+};
+
+const {
+  data,
+  config,
+  nameKey,
+  dataKey,
+  donut = false,
+  innerRadiusRatio = 0.6,
+  showLabels = false,
+  labelLine = false,
+  labelContent = "value",
+  showInnerLabels = false,
+  centerText,
+  centerLabel,
+  showLegend = true,
+  showTooltip = true,
+  padAngle = 0,
+  // No separator by default: shadcn's ChartContainer maps Recharts' default
+  // stroke='#fff' to stroke-transparent, so slices touch seamlessly.
+  strokeWidth = 0,
+  activeIndex,
+  data2,
+  dataKey2,
+} = Astro.props;
+
+// Square viewBox — use <Chart class="mx-auto aspect-square max-w-[300px]"> in the demo.
+const W = 260;
+const H = 260;
+const cx = W / 2;
+const cy = showLegend ? 108 : H / 2;
+// ~80% of the viewBox half (130) matches shadcn's plain pie proportion. Recharts
+// reserves vertical space for an in-chart legend, so the legend variant uses a
+// smaller radius inside the same square SVG.
+const outerR = showLegend ? 82.5 : 104;
+const innerR = donut ? outerR * innerRadiusRatio : 0;
+const padRad = (padAngle * Math.PI) / 180;
+
+// Round to 2 dp to keep SVG path strings tidy.
+function fmt(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type Slice = {
+  path: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  labelX: number;
+  labelY: number;
+  labelLineStartX: number;
+  labelLineStartY: number;
+  labelLineEndX: number;
+  labelLineEndY: number;
+  labelAnchor: "start" | "middle" | "end";
+  percent: string;
+  innerLabelX: number;
+  innerLabelY: number;
+};
+
+// Builds an arc path. Outer arc CW, inner arc CCW (nonzero winding for donut holes).
+function buildArcPath(startA: number, endA: number, oR: number, iR: number): string {
+  const sweep = endA - startA;
+  const isFull = sweep >= 2 * Math.PI - 0.0001;
+
+  if (isFull) {
+    const ox1 = fmt(cx - oR),
+      ox2 = fmt(cx + oR),
+      oy = fmt(cy);
+    const outer = `M ${ox1} ${oy} A ${oR} ${oR} 0 1 1 ${ox2} ${oy} A ${oR} ${oR} 0 1 1 ${ox1} ${oy} Z`;
+    if (iR > 0) {
+      const ix1 = fmt(cx - iR),
+        ix2 = fmt(cx + iR);
+      const inner = `M ${ix1} ${oy} A ${iR} ${iR} 0 1 0 ${ix2} ${oy} A ${iR} ${iR} 0 1 0 ${ix1} ${oy} Z`;
+      return `${outer} ${inner}`;
+    }
+    return outer;
+  }
+
+  const largeArc = sweep > Math.PI ? 1 : 0;
+  const cos1 = Math.cos(startA),
+    sin1 = Math.sin(startA);
+  const cos2 = Math.cos(endA),
+    sin2 = Math.sin(endA);
+  const osx = fmt(cx + oR * cos1),
+    osy = fmt(cy + oR * sin1);
+  const oex = fmt(cx + oR * cos2),
+    oey = fmt(cy + oR * sin2);
+
+  if (iR > 0) {
+    const iex = fmt(cx + iR * cos2),
+      iey = fmt(cy + iR * sin2);
+    const isx = fmt(cx + iR * cos1),
+      isy = fmt(cy + iR * sin1);
+    return (
+      `M ${osx} ${osy} A ${oR} ${oR} 0 ${largeArc} 1 ${oex} ${oey} ` +
+      `L ${iex} ${iey} A ${iR} ${iR} 0 ${largeArc} 0 ${isx} ${isy} Z`
+    );
+  }
+
+  return `M ${fmt(cx)} ${fmt(cy)} L ${osx} ${osy} A ${oR} ${oR} 0 ${largeArc} 1 ${oex} ${oey} Z`;
+}
+
+function buildSlicesFor(
+  sliceData: Record<string, string | number>[],
+  sliceDataKey: string,
+  oR: number,
+  iR: number,
+  activIdx?: number,
+): Slice[] {
+  const sliceTotal = sliceData.reduce((s, d) => s + Number(d[sliceDataKey] ?? 0), 0);
+  const result: Slice[] = [];
+  // Recharts <Pie> defaults: startAngle=0 (3 o'clock) sweeping COUNTERclockwise
+  // (endAngle=360). Its polarToCartesian uses -angle, so a Recharts angle θ maps
+  // to SVG angle -θ (SVG y is down). We accumulate θ CCW from 0, then hand each
+  // slice's [θStart,θEnd] to buildArcPath as the equivalent positive-sweep SVG
+  // arc (-θEnd → -θStart) so the existing winding / largeArc logic is reused
+  // unchanged but slices land exactly where shadcn's do.
+  let theta = 0; // Recharts angle (radians), CCW from 3 o'clock
+  const halfPad = padRad / 2;
+  let idx = 0;
+
+  for (const d of sliceData) {
+    const name = String(d[nameKey]);
+    const val = Number(d[sliceDataKey] ?? 0);
+    if (val <= 0) continue;
+    const pct = sliceTotal > 0 ? val / sliceTotal : 0;
+    const sweep = pct * 2 * Math.PI;
+    const thetaStart = theta + halfPad;
+    const thetaEnd = theta + sweep - halfPad;
+    const startA = -thetaEnd;
+    const endA = -thetaStart;
+    const midA = -(thetaStart + thetaEnd) / 2;
+
+    // Active slice gets a 10px outer-radius bump (donut-active / interactive).
+    const sliceOuter = activIdx === idx ? oR + 10 : oR;
+
+    const labelR = sliceOuter + 16;
+    const lx = fmt(cx + Math.cos(midA) * labelR);
+    const ly = fmt(cy + Math.sin(midA) * labelR);
+    const cosM = Math.cos(midA);
+    const anchor: "start" | "middle" | "end" =
+      cosM > 0.1 ? "start" : cosM < -0.1 ? "end" : "middle";
+    const labelLineEndX = fmt(lx + (anchor === "start" ? -4 : anchor === "end" ? 4 : 0));
+
+    // Inner label at midpoint of the slice's radial depth (label-list variant).
+    const innerLabelR = iR > 0 ? (iR + sliceOuter) / 2 : sliceOuter * 0.6;
+    const ilx = fmt(cx + Math.cos(midA) * innerLabelR);
+    const ily = fmt(cy + Math.sin(midA) * innerLabelR);
+
+    result.push({
+      path: buildArcPath(startA, endA, sliceOuter, iR),
+      seriesKey: name,
+      category: name,
+      value: String(val),
+      label: config[name]?.label ?? name,
+      labelX: lx,
+      labelY: ly + 4,
+      labelLineStartX: fmt(cx + Math.cos(midA) * sliceOuter),
+      labelLineStartY: fmt(cy + Math.sin(midA) * sliceOuter),
+      labelLineEndX,
+      labelLineEndY: ly,
+      labelAnchor: anchor,
+      percent: `${Math.round(pct * 100)}%`,
+      innerLabelX: ilx,
+      innerLabelY: ily + 4,
+    });
+
+    theta += sweep;
+    idx++;
+  }
+  return result;
+}
+
+// ponytail: stacked uses fixed radii (60 inner, 70/90 outer) matching shadcn proportions.
+const isStacked = data2 !== undefined && dataKey2 !== undefined;
+const mainOuterR = isStacked ? 60 : outerR;
+const mainInnerR = isStacked ? 0 : innerR;
+
+const slices = buildSlicesFor(
+  data,
+  dataKey,
+  mainOuterR,
+  mainInnerR,
+  isStacked ? undefined : activeIndex,
+);
+const slices2 =
+  isStacked && data2 && dataKey2 ? buildSlicesFor(data2, dataKey2, 90, 70, undefined) : [];
+
+const seriesKeys = slices.map((s) => s.seriesKey);
+const ariaLabel = `Pie chart: ${seriesKeys.map((k) => `${config[k]?.label ?? k} ${slices.find((s) => s.seriesKey === k)?.value}`).join(", ")}`;
+
+function getLabelText(s: Slice): string {
+  if (labelContent === "name") return s.label;
+  if (labelContent === "percent") return s.percent;
+  return s.value;
+}
+
+const strokeAttr = strokeWidth > 0 ? "transparent" : "none";
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Main slices (or inner ring for stacked) — data-* attrs drive tooltip -->
+  {
+    slices.map((s) => (
+      <path
+        d={s.path}
+        fill={`var(--color-${s.seriesKey})`}
+        stroke={strokeAttr}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth > 0 ? strokeWidth : undefined}
+        data-series={s.seriesKey}
+        data-category={s.category}
+        data-value={s.value}
+        data-label={s.label}
+      />
+    ))
+  }
+
+  <!-- Outer ring (stacked variant) -->
+  {
+    slices2.map((s) => (
+      <path
+        d={s.path}
+        fill={`var(--color-${s.seriesKey})`}
+        stroke={strokeAttr}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth > 0 ? strokeWidth : undefined}
+        data-series={s.seriesKey}
+        data-category={s.category}
+        data-value={s.value}
+        data-label={s.label}
+      />
+    ))
+  }
+
+  <!-- Outside labels (label / label-custom variants) -->
+  {
+    showLabels &&
+      labelLine &&
+      slices.map((s) => (
+        <polyline
+          points={`${s.labelLineStartX},${s.labelLineStartY} ${s.labelLineEndX},${s.labelLineEndY}`}
+          fill="none"
+          stroke={`var(--color-${s.seriesKey})`}
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showLabels &&
+      slices.map((s) => (
+        <text
+          x={s.labelX}
+          y={s.labelY}
+          text-anchor={s.labelAnchor}
+          fill="var(--foreground)"
+          font-size="12"
+          font-weight="500"
+          data-fs="12"
+        >
+          {getLabelText(s)}
+        </text>
+      ))
+  }
+
+  <!-- Inside labels (label-list variant — browser name centred in each slice) -->
+  {
+    showInnerLabels &&
+      slices.map((s) => (
+        <text
+          x={s.innerLabelX}
+          y={s.innerLabelY}
+          text-anchor="middle"
+          fill="var(--background)"
+          font-size="12"
+          font-weight="500"
+          data-fs="12"
+        >
+          {s.label}
+        </text>
+      ))
+  }
+
+  <!-- Donut center text (donut-text / interactive variants) -->
+  {
+    donut && centerText && (
+      <g>
+        <text
+          x={cx}
+          y={cy}
+          text-anchor="middle"
+          dominant-baseline="middle"
+          font-size="12"
+          data-fs="12"
+        >
+          <tspan
+            x={cx}
+            y={centerLabel ? cy : cy + 8}
+            fill="var(--foreground)"
+            font-size="30"
+            font-weight="700"
+            data-fs="30"
+          >
+            {centerText}
+          </tspan>
+          {centerLabel && (
+            <tspan x={cx} y={cy + 24} fill="var(--muted-foreground)" font-size="12" data-fs="12">
+              {centerLabel}
+            </tspan>
+          )}
+        </text>
+      </g>
+    )
+  }
+</svg>
+
+{
+  showLegend && (
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 [&_[data-slot=chart-legend]]:-translate-y-2 [&_[data-slot=chart-legend]>div]:basis-1/4 [&_[data-slot=chart-legend]>div]:justify-center">
+      <ChartLegend config={config} series={seriesKeys} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}

--- a/apps/demo/src/components/starwind/chart/RadarChart.astro
+++ b/apps/demo/src/components/starwind/chart/RadarChart.astro
@@ -1,0 +1,420 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  gridType?: "polygon" | "circle";
+  gridLevels?: number;
+  showAxisLabels?: boolean;
+  fillOpacity?: number;
+  showDots?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  /** Hide both grid rings and spokes (grid-none variant). */
+  showGrid?: boolean;
+  /** Hide radial spokes while keeping rings (lines-only, grid-custom, grid-circle-no-lines). */
+  showSpokes?: boolean;
+  /** Fill grid rings with the primary series color at 0.2 opacity, outermost-first for additive center effect (grid-fill, grid-circle-fill). */
+  gridFill?: boolean;
+  /** Explicit grid radii, matching Recharts PolarGrid polarRadius. */
+  polarRadius?: number[];
+  /** Show numeric value ticks along the axis between axis 0 and axis 1 (radius-axis variant). */
+  showRadiusAxis?: boolean;
+  /** Replace axis labels with value/value + month-name two-line labels (label-custom variant). */
+  showDataLabels?: boolean;
+  /** Per-series fill-opacity overrides. Index 0 = first series. Falls back to fillOpacity for unspecified indices. */
+  fillOpacities?: number[];
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  gridType = "polygon",
+  gridLevels = 4,
+  showAxisLabels = true,
+  fillOpacity: fillOpacityProp,
+  fillOpacities,
+  showDots = true,
+  showLegend = false,
+  showTooltip = true,
+  showGrid = true,
+  showSpokes = true,
+  gridFill = false,
+  polarRadius,
+  showRadiusAxis = false,
+  showDataLabels = false,
+} = Astro.props;
+
+// Default opacity: single series looks richer at 0.6; overlapping polygons need less
+const fillOpacity = fillOpacityProp ?? (series.length > 1 ? 0.4 : 0.6);
+
+const W = 250;
+const H = 250;
+const cx = W / 2;
+const cy = H / 2;
+const maxR = showDataLabels ? 92 : 96;
+
+const N = data.length;
+
+// Compute domain max across all plotted values
+const domainVals = data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+// Recharts' PolarRadiusAxis defaults to domain [0, dataMax] when the axis is
+// hidden, so the largest value sits ON the outer ring (don't nice-round, or the
+// polygon shrinks). When the radius axis IS shown, Recharts nice-rounds the
+// domain so ticks are round (305 -> 320 = 4 × 80), and the polygon sits ~0.95.
+const domainMax = showRadiusAxis
+  ? Math.max(10, Math.ceil(rawMax / gridLevels / 10) * 10 * gridLevels)
+  : rawMax > 0
+    ? rawMax
+    : 10;
+
+// Polar → cartesian; axis 0 starts at top (-π/2), proceeds clockwise
+function polarToXY(r: number, axisIndex: number): [number, number] {
+  const angle = -Math.PI / 2 + axisIndex * ((2 * Math.PI) / N);
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)];
+}
+
+// Points string for a grid ring at a given radius
+function ringPoints(r: number): string {
+  return Array.from({ length: N }, (_, k) => polarToXY(r, k).join(",")).join(" ");
+}
+
+// Points string for a series polygon
+function seriesPoints(key: string): string {
+  return data
+    .map((d, k) => {
+      const r = (Number(d[key] ?? 0) / domainMax) * maxR;
+      return polarToXY(r, k).join(",");
+    })
+    .join(" ");
+}
+
+type Vertex = {
+  x: number;
+  y: number;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+};
+
+// Pre-compute all vertices for dots and tooltip hit areas
+const vertices: Vertex[] = series.flatMap((key) =>
+  data.map((d, k) => {
+    const val = Number(d[key] ?? 0);
+    const [x, y] = polarToXY((val / domainMax) * maxR, k);
+    return {
+      x,
+      y,
+      seriesKey: key,
+      category: String(d[categoryKey]),
+      value: String(val),
+      label: config[key]?.label ?? key,
+    };
+  }),
+);
+
+// Axis labels just outside the outer ring
+const labelR = maxR + 8;
+const axisLabels = data.map((d, k) => {
+  const [x, y] = polarToXY(labelR, k);
+  return {
+    x,
+    y,
+    anchor: x > cx + 1 ? "start" : x < cx - 1 ? "end" : "middle",
+    text: String(d[categoryKey]),
+    // seriesVals used by showDataLabels to render value/value above the month name
+    seriesVals: series.map((s) => String(d[s] ?? "")),
+  };
+});
+
+const hitWedges = data.map((d, k) => {
+  const [x1, y1] = polarToXY(labelR + 16, k - 0.5);
+  const [x2, y2] = polarToXY(labelR + 16, k + 0.5);
+  return {
+    points: `${cx},${cy} ${x1},${y1} ${x2},${y2}`,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(d[key] ?? 0),
+    })),
+  };
+});
+
+// Radius axis: ticks placed between axis 0 and axis 1 (~30° from top, matching recharts angle=60)
+const radiusAxisAngle = -Math.PI / 2 + 0.5 * ((2 * Math.PI) / N);
+// gridLevels+1 ticks: 0 at center through domainMax at outer ring (matches recharts PolarRadiusAxis default)
+const radiusTicks = showRadiusAxis
+  ? Array.from({ length: gridLevels + 1 }, (_, i) => {
+      const r = (i / gridLevels) * maxR;
+      return {
+        x: cx + r * Math.cos(radiusAxisAngle),
+        y: cy + r * Math.sin(radiusAxisAngle),
+        tickValue: Math.round((i / gridLevels) * domainMax),
+      };
+    })
+  : ([] as { x: number; y: number; tickValue: number }[]);
+
+// gridFill: render outermost ring first so inner rings layer on top → additive center opacity
+const gridRadii =
+  polarRadius ?? Array.from({ length: gridLevels + 1 }, (_, i) => (i / gridLevels) * maxR);
+const visibleGridRadii = gridFill ? [...gridRadii].reverse() : gridRadii;
+
+const ariaLabel = `Radar chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+  style="display:block"
+>
+  <!-- Concentric grid rings -->
+  {
+    showGrid &&
+      visibleGridRadii.map((r) => {
+        // gridFill: filled shapes, no stroke; normal: stroked outline, no fill
+        return gridType === "circle" ? (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={r}
+            fill={gridFill ? `var(--color-${series[0]})` : "none"}
+            fill-opacity={gridFill ? 0.2 : undefined}
+            stroke={gridFill ? "none" : "var(--border)"}
+            stroke-width="1"
+            data-sw="1"
+          />
+        ) : (
+          <polygon
+            points={ringPoints(r)}
+            fill={gridFill ? `var(--color-${series[0]})` : "none"}
+            fill-opacity={gridFill ? 0.2 : undefined}
+            stroke={gridFill ? "none" : "var(--border)"}
+            stroke-width="1"
+            data-sw="1"
+          />
+        );
+      })
+  }
+
+  <!-- Radial spokes: center → outer ring tip -->
+  {
+    showGrid &&
+      showSpokes &&
+      data.map((_, k) => {
+        const [x, y] = polarToXY(maxR, k);
+        return (
+          <line x1={cx} y1={cy} x2={x} y2={y} stroke="var(--border)" stroke-width="1" data-sw="1" />
+        );
+      })
+  }
+
+  <!-- Series polygons — fill + stroke share the series color -->
+  {
+    series.map((key, i) => {
+      const opacity = fillOpacities?.[i] ?? fillOpacity;
+      return (
+        <polygon
+          points={seriesPoints(key)}
+          fill={`var(--color-${key})`}
+          fill-opacity={opacity}
+          stroke={opacity === 0 ? `var(--color-${key})` : "none"}
+          stroke-width="2"
+          data-sw={opacity === 0 ? "2" : undefined}
+          stroke-linejoin="round"
+        />
+      );
+    })
+  }
+
+  <!-- Optional vertex dots on top of polygons -->
+  {
+    showDots &&
+      vertices.map((v) => (
+        <circle cx={v.x} cy={v.y} r="4" data-r="4" fill={`var(--color-${v.seriesKey})`} />
+      ))
+  }
+
+  <!-- Hover dots: recharts' default activeDot (r=4, white 2px stroke) appears at the hovered
+       category's vertex per series, even when the permanent dot (showDots) is off. Skipped when
+       showDots is on — a permanent dot already sits there, so an identical one would just double-draw. -->
+  {
+    !showDots &&
+      vertices.map((v) => (
+        <circle
+          cx={v.x}
+          cy={v.y}
+          r="4"
+          data-r="4"
+          data-hover-dot="1"
+          data-category={v.category}
+          fill={`var(--color-${v.seriesKey})`}
+          stroke="#fff"
+          stroke-width="2"
+          data-sw="2"
+          pointer-events="none"
+          style="display:none"
+        />
+      ))
+  }
+
+  <!-- Transparent hit areas — carry data-* for the shared ChartTooltip -->
+  {
+    showTooltip &&
+      vertices.map((v) => (
+        <circle
+          cx={v.x}
+          cy={v.y}
+          r="10"
+          fill="transparent"
+          data-series={v.seriesKey}
+          data-category={v.category}
+          data-value={v.value}
+          data-label={v.label}
+        />
+      ))
+  }
+
+  <!-- Radius axis ticks (between axis 0 and axis 1, no axis line per recharts source) -->
+  {
+    radiusTicks.map(({ x, y, tickValue }) => (
+      <text
+        x={x}
+        y={y}
+        text-anchor="middle"
+        dominant-baseline="central"
+        fill="var(--foreground)"
+        font-size="12"
+        data-fs="12"
+      >
+        {tickValue}
+      </text>
+    ))
+  }
+
+  <!-- Custom value+month labels (label-custom variant: shows "val1/val2" + month name) -->
+  {
+    showDataLabels &&
+      axisLabels.map(({ x, y, anchor, seriesVals }) => (
+        <text
+          x={x}
+          y={y - 10}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="currentColor"
+          font-size="13"
+          font-weight="500"
+          data-fs="13"
+        >
+          {seriesVals.slice(0, 2).join("/")}
+        </text>
+      ))
+  }
+  {
+    showDataLabels &&
+      axisLabels.map(({ x, y, anchor, text }) => (
+        <text
+          x={x}
+          y={y + 8}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {text}
+        </text>
+      ))
+  }
+
+  <!-- Standard angular axis labels, rendered last so they sit above grid lines -->
+  {
+    !showDataLabels &&
+      showAxisLabels &&
+      axisLabels.map(({ x, y, anchor, text }) => (
+        <text
+          x={x}
+          y={y}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {text}
+        </text>
+      ))
+  }
+
+  <!-- Angular hit wedges — Recharts tooltip tracks the nearest polar category. -->
+  {
+    showTooltip &&
+      hitWedges.map((hit) => (
+        <polygon
+          points={hit.points}
+          fill="transparent"
+          pointer-events="all"
+          data-series={hit.items[0]?.series}
+          data-category={hit.category}
+          data-items={JSON.stringify(hit.items)}
+        />
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div style="position:absolute;left:0;right:0;bottom:-10px;height:60px;padding-top:32px;display:flex;align-items:flex-start;justify-content:center">
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  // Reveal per-series [data-hover-dot] circles for the hovered category (recharts activeDot),
+  // reusing the same hit targets ([data-category] on hitWedges/vertex circles) as ChartTooltip.
+  const initialized = new WeakSet<SVGSVGElement>();
+  const setupRadarHoverDots = () => {
+    document.querySelectorAll<HTMLElement>('[data-slot="chart"]').forEach((chart) => {
+      const svg = chart.querySelector("svg");
+      if (!svg || initialized.has(svg)) return;
+      const dots = svg.querySelectorAll<SVGCircleElement>("[data-hover-dot]");
+      if (!dots.length) return;
+      initialized.add(svg);
+
+      const hideAll = () => dots.forEach((dot) => (dot.style.display = "none"));
+
+      svg.addEventListener("mouseover", (e) => {
+        const target = (e.target as Element).closest("[data-category]") as HTMLElement | null;
+        if (!target) {
+          hideAll();
+          return;
+        }
+        const category = target.dataset.category ?? "";
+        dots.forEach(
+          (dot) => (dot.style.display = dot.dataset.category === category ? "" : "none"),
+        );
+      });
+
+      svg.addEventListener("mouseleave", hideAll);
+    });
+  };
+
+  setupRadarHoverDots();
+  document.addEventListener("astro:after-swap", setupRadarHoverDots);
+  document.addEventListener("starwind:init", setupRadarHoverDots);
+</script>

--- a/apps/demo/src/components/starwind/chart/RadialChart.astro
+++ b/apps/demo/src/components/starwind/chart/RadialChart.astro
@@ -1,0 +1,645 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  mode?: "bars" | "stacked" | "gauge";
+  // bars / gauge: one arc per data row
+  nameKey?: string;
+  dataKey?: string;
+  // stacked: one arc band, segments end-to-end
+  series?: string[];
+  categoryKey?: string;
+  // geometry
+  startAngle?: number;
+  endAngle?: number;
+  innerRadiusRatio?: number;
+  /** Explicit outer radius in SVG units (matches shadcn outerRadius prop). */
+  outerRadius?: number;
+  /** Explicit inner radius in SVG units (matches shadcn innerRadius prop). */
+  innerRadius?: number;
+  /** Override ring-background radii [outer, inner] (matches shadcn PolarGrid polarRadius). */
+  polarRadius?: [number, number];
+  barGap?: number;
+  maxValue?: number;
+  // display
+  showLabels?: boolean;
+  /** "value" = numeric value at arc tip; "name" = capitalized series name inside arc start. */
+  labelMode?: "value" | "name";
+  centerText?: string;
+  centerLabel?: string;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  cornerRadius?: number;
+  /** Hide the muted background track behind each arc (set false for grid variant). */
+  showTrack?: boolean;
+  /** Draw concentric circle grid lines at each arc radius (grid variant). */
+  showGrid?: boolean;
+  /** Draw a muted-filled outer ring + background-filled inner circle behind the arc (text / shape variants). */
+  ringBackground?: boolean;
+};
+
+const {
+  data,
+  config,
+  mode = "bars",
+  nameKey = "name",
+  dataKey = "value",
+  series = [],
+  categoryKey,
+  startAngle = 0,
+  endAngle = 360,
+  innerRadiusRatio = 0.3,
+  outerRadius: outerRadiusProp,
+  innerRadius: innerRadiusProp,
+  polarRadius: polarRadiusProp,
+  barGap = 2,
+  maxValue,
+  showLabels = false,
+  labelMode = "value",
+  centerText,
+  centerLabel,
+  showLegend = false,
+  showTooltip = true,
+  cornerRadius = 0,
+  showTrack = true,
+  showGrid = false,
+  ringBackground = false,
+} = Astro.props;
+
+// Recharts radial examples render into the 250px chart box with 1 SVG unit = 1px.
+const W = 250;
+const H = 250;
+const cx = W / 2;
+const cy = H / 2;
+const outerR = outerRadiusProp ?? 108;
+const innerR =
+  innerRadiusProp !== undefined ? innerRadiusProp : outerR * Math.max(innerRadiusRatio, 0.1);
+// Whether explicit radii were given (affects gauge strokeW and stack geometry)
+const hasExplicitRadii = outerRadiusProp !== undefined && innerRadiusProp !== undefined;
+// Angle direction: Recharts endAngle > startAngle → CCW on screen (SVG sweep-flag 0)
+const isCCW = endAngle > startAngle;
+const sf: 0 | 1 = isCCW ? 0 : 1; // SVG sweep-flag: 1=CW, 0=CCW
+const totalSweep = Math.abs(startAngle - endAngle);
+// Ring background support (text / shape variants): outer fill = muted, inner fill = background.
+// polarRadiusProp overrides; otherwise use outerR / innerR (or fallback outerR-24 for gauge).
+const ringBgOuterR = polarRadiusProp ? polarRadiusProp[0] : outerR;
+const ringBgInnerR = polarRadiusProp
+  ? polarRadiusProp[1]
+  : innerRadiusProp !== undefined
+    ? innerR
+    : outerR - 24;
+
+// Format to 2dp, drop trailing zeros — keeps SVG path strings compact
+function f(n: number): string {
+  return Number(n.toFixed(2)).toString();
+}
+
+// Recharts angle convention: 90 = top, clockwise = decreasing angle.
+// Maps to SVG coordinates where y increases downward.
+// x = cx + r·cos(θ), y = cy − r·sin(θ)  (standard math, y-flipped for SVG screen)
+function polarToXY(r: number, angleDeg: number): [number, number] {
+  const rad = (angleDeg * Math.PI) / 180;
+  return [cx + r * Math.cos(rad), cy - r * Math.sin(rad)];
+}
+
+// Stroked arc path from sa → ea.
+// sweepFlag: 1 = CW on screen (sa > ea), 0 = CCW on screen (sa < ea).
+// Handles the degenerate ≥360° case by splitting into two semicircles.
+// large-arc-flag: 1 when sweep > 180° (must take the major arc), else 0.
+function arcD(r: number, sa: number, ea: number, sweepFlag: 0 | 1 = 1): string {
+  const sweep = Math.abs(sa - ea);
+  if (sweep <= 0) return "";
+  if (sweep >= 360) {
+    // Full circle: single-arc from/to the same point is degenerate in SVG —
+    // split into two semicircles joined end-to-end.
+    const [x1, y1] = polarToXY(r, sa);
+    const [x2, y2] = polarToXY(r, sweepFlag === 1 ? sa - 180 : sa + 180);
+    return (
+      `M${f(x1)},${f(y1)} A${r},${r},0,1,${sweepFlag},${f(x2)},${f(y2)}` +
+      ` A${r},${r},0,1,${sweepFlag},${f(x1)},${f(y1)}`
+    );
+  }
+  const [x1, y1] = polarToXY(r, sa);
+  const [x2, y2] = polarToXY(r, ea);
+  const large = sweep > 180 ? 1 : 0;
+  return `M${f(x1)},${f(y1)} A${r},${r},0,${large},${sweepFlag},${f(x2)},${f(y2)}`;
+}
+
+function sectorD(inner: number, outer: number, sa: number, ea: number): string {
+  if (Math.abs(ea - sa) >= 360) {
+    const dir = ea >= sa ? 1 : -1;
+    const mid = sa + dir * 180;
+    const outerSweep: 0 | 1 = dir > 0 ? 0 : 1;
+    const innerSweep: 0 | 1 = dir > 0 ? 1 : 0;
+    const [osx, osy] = polarToXY(outer, sa);
+    const [omx, omy] = polarToXY(outer, mid);
+    const [isx, isy] = polarToXY(inner, sa);
+    const [imx, imy] = polarToXY(inner, mid);
+    return (
+      `M${f(osx)},${f(osy)} A${outer},${outer},0,1,${outerSweep},${f(omx)},${f(omy)}` +
+      ` A${outer},${outer},0,1,${outerSweep},${f(osx)},${f(osy)}` +
+      ` L${f(isx)},${f(isy)} A${inner},${inner},0,1,${innerSweep},${f(imx)},${f(imy)}` +
+      ` A${inner},${inner},0,1,${innerSweep},${f(isx)},${f(isy)} Z`
+    );
+  }
+
+  const signedSweep = Math.sign(ea - sa || 1) * Math.min(Math.abs(ea - sa), 359.999);
+  const end = sa + signedSweep;
+  const [osx, osy] = polarToXY(outer, sa);
+  const [oex, oey] = polarToXY(outer, end);
+  const [isx, isy] = polarToXY(inner, sa);
+  const [iex, iey] = polarToXY(inner, end);
+  const large = Math.abs(signedSweep) > 180 ? 1 : 0;
+  const outerSweep = sa > end ? 1 : 0;
+  const innerSweep = sa <= end ? 1 : 0;
+  return `M${f(osx)},${f(osy)} A${outer},${outer},0,${large},${outerSweep},${f(oex)},${f(oey)} L${f(iex)},${f(iey)} A${inner},${inner},0,${large},${innerSweep},${f(isx)},${f(isy)} Z`;
+}
+
+function niceMax(v: number): number {
+  if (v <= 0) return 10;
+  const exp = Math.floor(Math.log10(v));
+  const step = Math.pow(10, exp);
+  return Math.ceil(v / step) * step;
+}
+
+// ── bars / gauge ─────────────────────────────────────────────────────────────
+// Each data row becomes one concentric arc (outermost = index 0).
+type ArcItem = {
+  midR: number;
+  strokeW: number;
+  trackD: string;
+  valueD: string;
+  color: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  valueAngle: number;
+  filled: boolean;
+};
+
+const arcs: ArcItem[] = [];
+const legendKeys: string[] = [];
+const gridRadii: number[] = [];
+const gridSpokeAngles: number[] = [];
+
+if (mode === "bars" || mode === "gauge") {
+  const N = data.length;
+  if (N > 0) {
+    const rawVals = data.map((d) => Number(d[dataKey] ?? 0));
+    const maxVal = maxValue ?? (Math.max(...rawVals, 0) || 10);
+    const isGauge = mode === "gauge";
+    const gaugeW = hasExplicitRadii ? Math.max(4, Math.min(12, (outerR - innerR) * 0.4)) : 24;
+    const slotW = isGauge ? gaugeW : (outerR - innerR) / N;
+    const strokeW = isGauge ? gaugeW : Math.max(Math.floor(slotW * 0.8), 2);
+    const usesStroke = isGauge && cornerRadius > 0;
+
+    if (showGrid && !isGauge) {
+      for (let i = 0; i < N; i++) gridRadii.push(innerR + i * slotW);
+      const step = maxVal > 200 ? 20 : Math.max(1, Math.ceil(maxVal / 12));
+      for (let v = 0; v < maxVal; v += step) {
+        const spokeSweep = (v / maxVal) * totalSweep;
+        gridSpokeAngles.push(isCCW ? startAngle + spokeSweep : startAngle - spokeSweep);
+      }
+    }
+
+    for (let i = 0; i < N; i++) {
+      const row = data[i];
+      const val = Number(row[dataKey] ?? 0);
+      const key = String(row[nameKey] ?? i);
+      const midR = isGauge
+        ? hasExplicitRadii
+          ? innerR
+          : outerR - strokeW / 2
+        : innerR - slotW / 2 + slotW * 0.1 + strokeW / 2 + i * slotW;
+      const innerEdge = Math.max(midR - strokeW / 2, 0);
+      const outerEdge = midR + strokeW / 2;
+      const valueSweep = maxVal > 0 ? (val / maxVal) * totalSweep : 0;
+      // CCW: angle increases from startAngle; CW: angle decreases
+      const valueEnd = isCCW ? startAngle + valueSweep : startAngle - valueSweep;
+
+      arcs.push({
+        midR,
+        strokeW,
+        trackD: usesStroke
+          ? arcD(midR, startAngle, endAngle, sf)
+          : sectorD(innerEdge, outerEdge, startAngle, endAngle),
+        valueD: usesStroke
+          ? arcD(midR, startAngle, valueEnd, sf)
+          : sectorD(innerEdge, outerEdge, startAngle, valueEnd),
+        color: `var(--color-${key})`,
+        seriesKey: key,
+        category: String(row[nameKey] ?? key),
+        value: String(val),
+        label: config[key]?.label ?? key,
+        valueAngle: valueEnd,
+        filled: !usesStroke,
+      });
+      legendKeys.push(key);
+    }
+  }
+}
+
+// ── stacked ───────────────────────────────────────────────────────────────────
+// Single arc band; multiple series fill it end-to-end like a pie-on-a-ring.
+type StackedSeg = {
+  d: string;
+  trackD: string;
+  midR: number;
+  strokeW: number;
+  color: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  linecap: "round" | "butt";
+};
+
+const stackedSegs: StackedSeg[] = [];
+let stackedTotal = 0;
+
+if (mode === "stacked" && data.length > 0 && series.length > 0) {
+  const row = data[0];
+  const strokeW = hasExplicitRadii
+    ? Math.max(4, Math.min(12, (outerR - innerR) * 0.4))
+    : Math.max(outerR - outerR * 0.72, 2);
+  const midR = hasExplicitRadii ? innerR : outerR - strokeW / 2;
+  const stackLinecap = cornerRadius > 0 ? "round" : "butt";
+  const cat = categoryKey ? String(row[categoryKey] ?? "") : "";
+  const vals = series.map((s) => Number(row[s] ?? 0));
+  stackedTotal = vals.reduce((a, b) => a + b, 0);
+  const maxVal = maxValue ?? (stackedTotal || 10);
+  const trackD = arcD(midR, startAngle, endAngle, sf);
+  let currentA = startAngle;
+
+  for (let i = 0; i < series.length; i++) {
+    const key = series[i];
+    const val = vals[i];
+    const segSweep = maxVal > 0 ? (val / maxVal) * totalSweep : 0;
+    const segEnd = isCCW ? currentA + segSweep : currentA - segSweep;
+    const innerEdge = Math.max(midR - strokeW / 2, 0);
+    const outerEdge = midR + strokeW / 2;
+
+    stackedSegs.push({
+      d: sectorD(innerEdge, outerEdge, currentA, segEnd),
+      trackD: i === 0 ? trackD : "", // draw full track once, behind all segments
+      midR,
+      strokeW,
+      color: `var(--color-${key})`,
+      seriesKey: key,
+      category: cat,
+      value: String(val),
+      label: config[key]?.label ?? key,
+      linecap: stackLinecap,
+    });
+    currentA = segEnd;
+    legendKeys.push(key);
+  }
+}
+
+// Label just outside the arc end (radially outward by half stroke + margin)
+function labelXY(midR: number, strokeW: number, angle: number): [number, number] {
+  return polarToXY(midR + strokeW / 2 + 10, angle);
+}
+
+// Unique per-instance id prefix for the insideStart label textPaths (multiple radial
+// charts can share a page, so path ids must not collide).
+const gid = Math.random().toString(36).slice(2, 9);
+// shadcn's insideStart LabelList rides a circular textPath at the bar's own mid-radius,
+// starting 5deg into the sweep from startAngle (Recharts' Label default `offset`).
+const nameLabelStart = startAngle + (isCCW ? 1 : -1) * 5;
+const nameLabelEnd = nameLabelStart + (isCCW ? 1 : -1) * 359;
+
+// Center value: explicit prop, or auto-inferred for gauge (single row) / stacked total
+const autoCenter =
+  centerText ??
+  (mode === "gauge" && data.length === 1
+    ? Number(data[0][dataKey] ?? 0).toLocaleString("en-US")
+    : mode === "stacked" && stackedTotal > 0
+      ? stackedTotal.toLocaleString("en-US")
+      : undefined);
+
+const ariaLabel =
+  mode === "stacked"
+    ? `Radial stacked chart: ${series.map((s) => config[s]?.label ?? s).join(", ")}`
+    : `Radial ${mode} chart: ${data.map((d) => String(d[nameKey] ?? "")).join(", ")}`;
+
+// ponytail: stroke-linecap="round" gives cap shape for free; no manual cap path math needed
+const linecap = cornerRadius > 0 ? "round" : "butt";
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Ring background: muted outer disk + background inner disk → visible ring (text / shape variants) -->
+  {ringBackground && <circle cx={cx} cy={cy} r={ringBgOuterR} fill="var(--muted)" />}
+  {ringBackground && <circle cx={cx} cy={cy} r={ringBgInnerR} fill="var(--background)" />}
+
+  <!-- Concentric grid circles at each arc radius (grid variant) -->
+  {
+    showGrid &&
+      gridRadii.map((r) => (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke="var(--border)"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showGrid &&
+      gridSpokeAngles.map((angle) => {
+        const [x1, y1] = polarToXY(innerR, angle);
+        const [x2, y2] = polarToXY(outerR, angle);
+        return (
+          <line
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke="var(--border)"
+            stroke-width="1"
+            data-sw="1"
+          />
+        );
+      })
+  }
+
+  <!-- Fallback hover surface for empty radial space; exact arc paths render later and win on top. -->
+  {
+    showTooltip && arcs.length > 0 && (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={outerR + 16}
+        fill="transparent"
+        pointer-events="all"
+        data-series={arcs[0]?.seriesKey}
+        data-category={arcs[0]?.category}
+        data-items={JSON.stringify(
+          arcs.map((arc) => ({
+            series: arc.seriesKey,
+            label: arc.label,
+            value: arc.value,
+          })),
+        )}
+      />
+    )
+  }
+  {
+    showTooltip && arcs.length === 0 && stackedSegs.length > 0 && (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={outerR + 16}
+        fill="transparent"
+        pointer-events="all"
+        data-series={stackedSegs[0]?.seriesKey}
+        data-category={stackedSegs[0]?.category}
+        data-items={JSON.stringify(
+          stackedSegs.map((seg) => ({
+            series: seg.seriesKey,
+            label: seg.label,
+            value: seg.value,
+          })),
+        )}
+      />
+    )
+  }
+
+  <!-- Background tracks (bars / gauge) -->
+  {
+    showTrack &&
+      arcs.map(
+        (arc) =>
+          arc.trackD &&
+          (arc.filled ? (
+            <path d={arc.trackD} fill="var(--muted)" stroke="none" />
+          ) : (
+            <path
+              d={arc.trackD}
+              fill="none"
+              stroke="var(--muted)"
+              stroke-width={arc.strokeW}
+              stroke-linecap={linecap}
+            />
+          )),
+      )
+  }
+
+  <!-- Background track (stacked — drawn once, behind all segments) -->
+  {
+    showTrack &&
+      stackedSegs.map(
+        (seg) =>
+          seg.trackD && (
+            <path
+              d={seg.trackD}
+              fill="none"
+              stroke="var(--muted)"
+              stroke-width={seg.strokeW}
+              stroke-linecap="butt"
+            />
+          ),
+      )
+  }
+
+  <!-- Value arcs (bars / gauge) — data-* attrs drive the shared tooltip -->
+  {
+    arcs.map(
+      (arc) =>
+        arc.valueD &&
+        (arc.filled ? (
+          <path
+            d={arc.valueD}
+            fill={arc.color}
+            stroke="none"
+            data-series={arc.seriesKey}
+            data-category={arc.category}
+            data-value={arc.value}
+            data-label={arc.label}
+          />
+        ) : (
+          <path
+            d={arc.valueD}
+            fill="none"
+            stroke={arc.color}
+            stroke-width={arc.strokeW}
+            stroke-linecap={linecap}
+            data-series={arc.seriesKey}
+            data-category={arc.category}
+            data-value={arc.value}
+            data-label={arc.label}
+          />
+        )),
+    )
+  }
+
+  <!-- Value arcs (stacked) -->
+  {
+    stackedSegs.map(
+      (seg) =>
+        seg.d && (
+          <path
+            d={seg.d}
+            fill={seg.color}
+            stroke="transparent"
+            stroke-width={cornerRadius > 0 ? "2" : "0"}
+            stroke-linecap={seg.linecap}
+            data-series={seg.seriesKey}
+            data-category={seg.category}
+            data-value={seg.value}
+            data-label={seg.label}
+          />
+        ),
+    )
+  }
+
+  <!-- Invisible full-ring hit paths for tooltip parity with Recharts. -->
+  {
+    showTooltip &&
+      arcs.map(
+        (arc) =>
+          arc.trackD &&
+          (arc.filled ? (
+            <path
+              d={arc.trackD}
+              fill="transparent"
+              stroke="none"
+              pointer-events="all"
+              data-series={arc.seriesKey}
+              data-category={arc.category}
+              data-value={arc.value}
+              data-label={arc.label}
+            />
+          ) : (
+            <path
+              d={arc.trackD}
+              fill="none"
+              stroke="transparent"
+              stroke-width={arc.strokeW + 6}
+              stroke-linecap={linecap}
+              pointer-events="stroke"
+              data-series={arc.seriesKey}
+              data-category={arc.category}
+              data-value={arc.value}
+              data-label={arc.label}
+            />
+          )),
+      )
+  }
+  {
+    showTooltip &&
+      stackedSegs.map(
+        (seg) =>
+          seg.trackD && (
+            <path
+              d={seg.trackD}
+              fill="none"
+              stroke="transparent"
+              stroke-width={seg.strokeW + 6}
+              stroke-linecap="butt"
+              pointer-events="stroke"
+              data-series={stackedSegs[0]?.seriesKey}
+              data-category={seg.category}
+              data-items={JSON.stringify(
+                stackedSegs.map((item) => ({
+                  series: item.seriesKey,
+                  label: item.label,
+                  value: item.value,
+                })),
+              )}
+            />
+          ),
+      )
+  }
+
+  <!-- Per-arc value labels at arc end (optional) -->
+  {
+    showLabels &&
+      arcs.map((arc, i) => {
+        if (labelMode === "name") {
+          // Capitalized series name riding the arc's own ring, starting just inside
+          // its sweep (shadcn insideStart — a curved textPath, not a fixed point).
+          const pathId = `radial-label-${gid}-${i}`;
+          return (
+            <text
+              fill="#fff"
+              font-size="11"
+              data-fs="11"
+              dominant-baseline="central"
+              style="text-transform: capitalize; mix-blend-mode: luminosity;"
+            >
+              <defs>
+                <path id={pathId} d={arcD(arc.midR, nameLabelStart, nameLabelEnd, sf)} />
+              </defs>
+              <textPath xlink:href={`#${pathId}`}>{arc.label}</textPath>
+            </text>
+          );
+        }
+        const [lx, ly] = labelXY(arc.midR, arc.strokeW, arc.valueAngle);
+        return (
+          <text
+            x={lx}
+            y={ly}
+            text-anchor="middle"
+            dominant-baseline="middle"
+            fill="var(--foreground)"
+            font-size="11"
+            font-weight="500"
+            data-fs="11"
+          >
+            {arc.value}
+          </text>
+        );
+      })
+  }
+
+  <!-- Center value (gauge single-value or stacked total) -->
+  {
+    autoCenter && (
+      <text
+        x={cx}
+        y={mode === "stacked" ? cy - 16 : cy}
+        text-anchor="middle"
+        dominant-baseline="middle"
+        fill="var(--foreground)"
+      >
+        <tspan
+          x={cx}
+          y={mode === "stacked" ? cy - 16 : cy}
+          font-size={mode === "stacked" ? "24" : "36"}
+          font-weight="700"
+        >
+          {autoCenter}
+        </tspan>
+        {centerLabel && (
+          <tspan
+            x={cx}
+            y={mode === "stacked" ? cy + 4 : cy + 24}
+            fill="var(--muted-foreground)"
+            font-size="13"
+            font-weight="400"
+          >
+            {centerLabel}
+          </tspan>
+        )}
+      </text>
+    )
+  }
+</svg>
+
+{showLegend && <ChartLegend config={config} series={legendKeys} />}
+{showTooltip && <ChartTooltip />}

--- a/apps/demo/src/components/starwind/chart/curves.ts
+++ b/apps/demo/src/components/starwind/chart/curves.ts
@@ -1,0 +1,148 @@
+// Shared curve-path builders for the cartesian line/area charts.
+//
+// These faithfully reproduce the d3-shape curves that Recharts uses, so an
+// Astro-rendered path matches shadcn's SVG geometry exactly:
+//   - "natural"  → d3 curveNatural   (natural cubic spline)
+//   - "monotone" → d3 curveMonotoneX (Fritsch–Carlson monotone cubic)
+//   - "linear"   → straight segments
+//   - "step"     → step-after
+//
+// LineChart and AreaChart both consumed byte-for-byte copies of this math; it
+// now lives here once. NOTE: LineChart.astro's client-side <script> keeps its
+// OWN copy of linePath/stepPath/monotonePath for the dense-data resize reflow —
+// a browser-runtime scope that can't import this module. If you change a curve
+// formula here, mirror it there (and vice versa) or the two will silently drift.
+// Everything operates on a plain {x, y} point. Segment
+// builders return path data WITHOUT a leading "M" (the area builder needs to
+// splice segments mid-path); `buildPath` adds the opening moveto for line use.
+
+export type Point = { x: number; y: number };
+
+export type CurveType = "linear" | "monotone" | "natural" | "step";
+
+// Straight line segments: "L…L…" (no leading M).
+function linearSegments(pts: Point[]): string {
+  return pts
+    .slice(1)
+    .map((p) => `L${p.x},${p.y}`)
+    .join(" ");
+}
+
+// Step-after: horizontal to the next x, then vertical to the next y.
+function stepSegments(pts: Point[]): string {
+  return pts
+    .slice(1)
+    .map((p) => `H${p.x} V${p.y}`)
+    .join(" ");
+}
+
+// d3-shape curveNatural: solve the tridiagonal system for a natural cubic
+// spline's bezier control points. Returns [firstControls, secondControls].
+function naturalControl(v: number[]): [number[], number[]] {
+  const m = v.length - 1;
+  const a: number[] = new Array(m);
+  const b: number[] = new Array(m);
+  const r: number[] = new Array(m);
+  a[0] = 0;
+  b[0] = 2;
+  r[0] = v[0] + 2 * v[1];
+  for (let i = 1; i < m - 1; i++) {
+    a[i] = 1;
+    b[i] = 4;
+    r[i] = 4 * v[i] + 2 * v[i + 1];
+  }
+  a[m - 1] = 2;
+  b[m - 1] = 7;
+  r[m - 1] = 8 * v[m - 1] + v[m];
+  for (let i = 1; i < m; i++) {
+    const t = a[i] / b[i - 1];
+    b[i] -= t;
+    r[i] -= t * r[i - 1];
+  }
+  a[m - 1] = r[m - 1] / b[m - 1];
+  for (let i = m - 2; i >= 0; i--) a[i] = (r[i] - a[i + 1]) / b[i];
+  b[m - 1] = (v[m] + a[m - 1]) / 2;
+  for (let i = 0; i < m - 1; i++) b[i] = 2 * v[i + 1] - a[i + 1];
+  return [a, b];
+}
+
+function naturalSegments(pts: Point[]): string {
+  if (pts.length < 2) return "";
+  const [ax, bx] = naturalControl(pts.map((p) => p.x));
+  const [ay, by] = naturalControl(pts.map((p) => p.y));
+  return pts
+    .slice(1)
+    .map(
+      (p, i) =>
+        `C${ax[i].toFixed(1)},${ay[i].toFixed(1)} ${bx[i].toFixed(1)},${by[i].toFixed(1)} ${p.x.toFixed(1)},${p.y.toFixed(1)}`,
+    )
+    .join(" ");
+}
+
+// d3-shape curveMonotoneX (Fritsch–Carlson), matching Recharts type="monotone".
+function monotoneSegments(pts: Point[]): string {
+  if (pts.length < 2) return "";
+  const n = pts.length;
+  const dxs = pts.slice(0, -1).map((p, i) => pts[i + 1].x - p.x);
+  const dys = pts.slice(0, -1).map((p, i) => pts[i + 1].y - p.y);
+  const tan: number[] = new Array(n).fill(0);
+  tan[0] = dxs[0] ? dys[0] / dxs[0] : 0;
+  tan[n - 1] = dxs[n - 2] ? dys[n - 2] / dxs[n - 2] : 0;
+  for (let i = 1; i < n - 1; i++) {
+    const s0 = dxs[i - 1] ? dys[i - 1] / dxs[i - 1] : 0;
+    const s1 = dxs[i] ? dys[i] / dxs[i] : 0;
+    tan[i] = s0 * s1 <= 0 ? 0 : (s0 + s1) / 2;
+  }
+  for (let i = 0; i < n - 1; i++) {
+    const s = dxs[i] ? dys[i] / dxs[i] : 0;
+    if (Math.abs(s) < 1e-10) {
+      tan[i] = tan[i + 1] = 0;
+      continue;
+    }
+    const a = tan[i] / s;
+    const b = tan[i + 1] / s;
+    const h = Math.sqrt(a * a + b * b);
+    if (h > 3) {
+      tan[i] = (3 / h) * a * s;
+      tan[i + 1] = (3 / h) * b * s;
+    }
+  }
+  return pts
+    .slice(1)
+    .map((p, i) => {
+      const dx = dxs[i];
+      const cp1x = (pts[i].x + dx / 3).toFixed(1);
+      const cp1y = (pts[i].y + (tan[i] * dx) / 3).toFixed(1);
+      const cp2x = (p.x - dx / 3).toFixed(1);
+      const cp2y = (p.y - (tan[i + 1] * dx) / 3).toFixed(1);
+      return `C${cp1x},${cp1y} ${cp2x},${cp2y} ${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+/** Path segments for `pts` in the given curve style, WITHOUT a leading moveto. */
+export function curveSegments(pts: Point[], curve: CurveType): string {
+  if (pts.length < 2) return "";
+  if (curve === "linear") return linearSegments(pts);
+  if (curve === "step") return stepSegments(pts);
+  if (curve === "natural") return naturalSegments(pts);
+  return monotoneSegments(pts);
+}
+
+/** A complete open path ("M…" + segments) for a line stroke. */
+export function buildPath(pts: Point[], curve: CurveType): string {
+  if (!pts.length) return "";
+  if (pts.length === 1) return `M${pts[0].x},${pts[0].y}`;
+  return `M${pts[0].x},${pts[0].y} ${curveSegments(pts, curve)}`;
+}
+
+/**
+ * A closed area path: the top curve forward, then the bottom curve reversed and
+ * closed. Seam is exact for monotone/linear (the same curve reversed).
+ */
+export function buildArea(topPts: Point[], bottomPts: Point[], curve: CurveType): string {
+  const topD = buildPath(topPts, curve);
+  if (!topD) return "";
+  const rev = [...bottomPts].reverse();
+  return `${topD} L${rev[0].x},${rev[0].y} ${curveSegments(rev, curve)} Z`;
+}

--- a/apps/demo/src/components/starwind/chart/curves.ts
+++ b/apps/demo/src/components/starwind/chart/curves.ts
@@ -68,6 +68,9 @@ function naturalControl(v: number[]): [number[], number[]] {
 
 function naturalSegments(pts: Point[]): string {
   if (pts.length < 2) return "";
+  // d3 curveNatural draws exactly two points as a straight segment; the
+  // tridiagonal solve below assumes at least three points.
+  if (pts.length === 2) return linearSegments(pts);
   const [ax, bx] = naturalControl(pts.map((p) => p.x));
   const [ay, by] = naturalControl(pts.map((p) => p.y));
   return pts

--- a/apps/demo/src/components/starwind/chart/index.ts
+++ b/apps/demo/src/components/starwind/chart/index.ts
@@ -1,0 +1,22 @@
+import BarChart from "./BarChart.astro";
+import Chart from "./Chart.astro";
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+import { chart, chartLegend, chartTooltip } from "./variants";
+
+const ChartVariants = {
+  chart,
+  chartTooltip,
+  chartLegend,
+};
+
+export type { ChartConfig };
+export { BarChart, Chart, ChartLegend, ChartTooltip, ChartVariants };
+
+export default {
+  Root: Chart,
+  Bar: BarChart,
+  Tooltip: ChartTooltip,
+  Legend: ChartLegend,
+};

--- a/apps/demo/src/components/starwind/chart/scale.ts
+++ b/apps/demo/src/components/starwind/chart/scale.ts
@@ -1,0 +1,89 @@
+// Shared axis-domain ("nice number") helpers for the cartesian charts.
+//
+// Recharts rounds a numeric axis' domain to human-friendly bounds even when the
+// axis is hidden, which is why shadcn's bars/areas leave headroom instead of
+// touching the plot edge at the raw data max. The three cartesian families each
+// need a SLIGHTLY DIFFERENT rounding and so keep their own entry point here —
+// they are intentionally NOT unified:
+//   - BarChart  → niceDomain    (full recharts-scale port; handles negatives)
+//   - LineChart → rechartsAutoMax
+//   - AreaChart → niceMax (with y-axis) / tightMax (default, tighter fit)
+// Co-locating them removes three divergent private copies without changing any
+// one chart's output.
+
+// --- BarChart: recharts-scale getNiceTickValues / calculateStep (tickCount=5),
+//     the only variant that must place a nice zero-crossing for negative data.
+export function niceStep(roughStep: number, correctionFactor: number): number {
+  if (roughStep <= 0) return 0;
+  const digitCount = Math.floor(Math.log10(Math.abs(roughStep))) + 1;
+  const digitValue = 10 ** digitCount;
+  const stepRatio = roughStep / digitValue;
+  const stepRatioScale = digitCount !== 1 ? 0.05 : 0.1;
+  return (Math.ceil(stepRatio / stepRatioScale) + correctionFactor) * stepRatioScale * digitValue;
+}
+
+export function niceDomain(
+  min: number,
+  max: number,
+  tickCount = 5,
+  correctionFactor = 0,
+): [number, number] {
+  if (min === max) return [Math.min(0, min), Math.max(10, max)];
+  const step = niceStep((max - min) / (tickCount - 1), correctionFactor);
+  const mid = (min + max) / 2;
+  const middle = min <= 0 && max >= 0 ? 0 : mid - (mid % step);
+  let belowCount = Math.ceil((middle - min) / step);
+  let upCount = Math.ceil((max - middle) / step);
+  const scaleCount = belowCount + upCount + 1;
+  if (scaleCount > tickCount) return niceDomain(min, max, tickCount, correctionFactor + 1);
+  if (scaleCount < tickCount) {
+    upCount = max > 0 ? upCount + (tickCount - scaleCount) : upCount;
+    belowCount = max > 0 ? belowCount : belowCount + (tickCount - scaleCount);
+  }
+  return [middle - belowCount * step, middle + upCount * step];
+}
+
+// --- LineChart: recharts auto-max for a non-negative domain (tickCount=5).
+export function rechartsAutoMax(v: number): number {
+  if (v <= 0) return 10;
+  const tickCount = 5;
+  const roughStep = v / (tickCount - 1);
+  const digitCount = Math.floor(Math.log10(Math.abs(roughStep))) + 1;
+  const digitValue = 10 ** digitCount;
+  const stepRatioScale = digitCount !== 1 ? 0.05 : 0.1;
+  const stepRatio = roughStep / digitValue;
+  const step = Math.ceil(stepRatio / stepRatioScale) * stepRatioScale * digitValue;
+  let upCount = Math.ceil(v / step);
+  const scaleCount = upCount + 1;
+  if (scaleCount < tickCount) upCount += tickCount - scaleCount;
+  return upCount * step;
+}
+
+// --- AreaChart: rounded max used when a y-axis is shown (5-step nice number).
+export function niceMax(v: number): number {
+  if (v <= 0) return 10;
+  const step0 = v / 5;
+  const base = 10 ** Math.floor(Math.log10(step0));
+  const error = step0 / base;
+  const step = (error >= 7.071 ? 10 : error >= 3.162 ? 5 : error >= 1.414 ? 2 : 1) * base;
+  return Math.ceil(v / step) * step;
+}
+
+// --- AreaChart: tighter max used by default (no y-axis) so the area fills more.
+export function tightMax(v: number): number {
+  if (v <= 0) return 10;
+  const step = 10 ** Math.max(0, Math.floor(Math.log10(v)) - 1);
+  return Math.ceil(v / step) * step;
+}
+
+/**
+ * X-axis label thinning — approximates Recharts' minTickGap for dense data.
+ * Returns the stride between labeled categories (1 = label every category).
+ * Identical logic previously lived inline in Bar/Line/Area.
+ */
+export function xLabelStep(dataLength: number, width: number): number {
+  const targetTicks = Math.max(4, Math.floor(width / 72));
+  return dataLength <= Math.max(8, targetTicks)
+    ? 1
+    : Math.max(1, Math.round(dataLength / targetTicks));
+}

--- a/apps/demo/src/components/starwind/chart/uid.ts
+++ b/apps/demo/src/components/starwind/chart/uid.ts
@@ -1,0 +1,8 @@
+// Monotonic id source for per-instance-unique SVG ids such as gradients and clip paths.
+// This must live in an imported module: a `let` in .astro frontmatter is emitted
+// inside the per-instance render function and resets to 0 every instance.
+let counter = 0;
+
+export function nextUid(prefix = "sw"): string {
+  return prefix + "-" + counter++;
+}

--- a/apps/demo/src/components/starwind/chart/variants.ts
+++ b/apps/demo/src/components/starwind/chart/variants.ts
@@ -1,0 +1,16 @@
+import { tv } from "tailwind-variants";
+
+// ChartConfig defined here (not in .astro frontmatter) to avoid esbuild parser issues with export type
+export type ChartConfig = Record<string, { label?: string; icon?: string; color?: string }>;
+
+export const chart = tv({
+  base: "starwind-chart relative flex aspect-video flex-col justify-center text-xs",
+});
+
+export const chartTooltip = tv({
+  base: "border-border bg-background pointer-events-none absolute z-50 hidden rounded-md border px-2.5 py-1.5 text-xs shadow-md",
+});
+
+export const chartLegend = tv({
+  base: "flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 pt-3",
+});

--- a/apps/demo/src/pages/charts/chart-demo-area.astro
+++ b/apps/demo/src/pages/charts/chart-demo-area.astro
@@ -1,0 +1,177 @@
+---
+import "@/styles/global.css";
+import { Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+import AreaChart from "@/components/starwind/chart/AreaChart.astro";
+
+// shadcn's canonical area chart sample data
+const monthlyData = [
+  { month: "Jan", desktop: 186, mobile: 80 },
+  { month: "Feb", desktop: 305, mobile: 200 },
+  { month: "Mar", desktop: 237, mobile: 120 },
+  { month: "Apr", desktop: 73, mobile: 190 },
+  { month: "May", desktop: 209, mobile: 130 },
+  { month: "Jun", desktop: 214, mobile: 140 },
+];
+
+const config: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+  mobile: { label: "Mobile", color: "var(--chart-2)" },
+};
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Area Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Area Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Area chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-8">
+      <!-- 1. Default: gradient + monotone (matches shadcn's primary area chart) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Default — gradient + monotone</h2>
+        <Chart config={config}>
+          <AreaChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Linear: no gradient, linear curve -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Linear — no gradient</h2>
+        <Chart config={config}>
+          <AreaChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            curve="linear"
+            gradient={false}
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. Stacked -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. Stacked</h2>
+        <Chart config={config}>
+          <AreaChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            stacked
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. Stacked + legend -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. Stacked + legend</h2>
+        <Chart config={config}>
+          <AreaChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            stacked
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. With dots -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. With dots</h2>
+        <Chart config={config}>
+          <AreaChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            showDots
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-8">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Default — gradient + monotone</h3>
+          <Chart config={config}>
+            <AreaChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Linear — no gradient</h3>
+          <Chart config={config}>
+            <AreaChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              curve="linear"
+              gradient={false}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Stacked + legend</h3>
+          <Chart config={config}>
+            <AreaChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              stacked
+              showLegend
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">With dots</h3>
+          <Chart config={config}>
+            <AreaChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              showDots
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/pages/charts/chart-demo-line.astro
+++ b/apps/demo/src/pages/charts/chart-demo-line.astro
@@ -1,0 +1,182 @@
+---
+import "@/styles/global.css";
+import { Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+import LineChart from "@/components/starwind/chart/LineChart.astro";
+
+// shadcn canonical line sample data
+const monthlyData = [
+  { month: "Jan", desktop: 186, mobile: 80 },
+  { month: "Feb", desktop: 305, mobile: 200 },
+  { month: "Mar", desktop: 237, mobile: 120 },
+  { month: "Apr", desktop: 73, mobile: 190 },
+  { month: "May", desktop: 209, mobile: 130 },
+  { month: "Jun", desktop: 214, mobile: 140 },
+];
+
+const config: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+  mobile: { label: "Mobile", color: "var(--chart-2)" },
+};
+
+const singleConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+};
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Line Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Line Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Line chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-8">
+      <!-- 1. Default single-series (monotone) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Single series — monotone (default)</h2>
+        <Chart config={singleConfig}>
+          <LineChart
+            data={monthlyData}
+            config={singleConfig}
+            categoryKey="month"
+            series={["desktop"]}
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Multiple series -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Multiple series — Desktop &amp; Mobile</h2>
+        <Chart config={config}>
+          <LineChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. No dots -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. No dots</h2>
+        <Chart config={config}>
+          <LineChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            showDots={false}
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. Stepped -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. Step curve</h2>
+        <Chart config={config}>
+          <LineChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            curve="step"
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. With value labels + Y-axis -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. Value labels + Y-axis</h2>
+        <Chart config={singleConfig}>
+          <LineChart
+            data={monthlyData}
+            config={singleConfig}
+            categoryKey="month"
+            series={["desktop"]}
+            showLabels
+            showYAxis
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-8">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Single series — monotone</h3>
+          <Chart config={singleConfig}>
+            <LineChart
+              data={monthlyData}
+              config={singleConfig}
+              categoryKey="month"
+              series={["desktop"]}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Multiple series</h3>
+          <Chart config={config}>
+            <LineChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              showLegend
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">No dots</h3>
+          <Chart config={config}>
+            <LineChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              showDots={false}
+              showLegend
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Step curve</h3>
+          <Chart config={config}>
+            <LineChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              curve="step"
+              showLegend
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/pages/charts/chart-demo-pie.astro
+++ b/apps/demo/src/pages/charts/chart-demo-pie.astro
@@ -1,0 +1,183 @@
+---
+import "@/styles/global.css";
+import { Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+import PieChart from "@/components/starwind/chart/PieChart.astro";
+
+// shadcn canonical browser dataset
+const browserData = [
+  { browser: "chrome", visitors: 275 },
+  { browser: "safari", visitors: 200 },
+  { browser: "firefox", visitors: 187 },
+  { browser: "edge", visitors: 173 },
+  { browser: "other", visitors: 90 },
+];
+
+const browserConfig: ChartConfig = {
+  chrome: { label: "Chrome", color: "var(--chart-1)" },
+  safari: { label: "Safari", color: "var(--chart-2)" },
+  firefox: { label: "Firefox", color: "var(--chart-3)" },
+  edge: { label: "Edge", color: "var(--chart-4)" },
+  other: { label: "Other", color: "var(--chart-5)" },
+};
+
+const total = browserData.reduce((s, d) => s + d.visitors, 0); // 925
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Pie Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Pie Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Pie / Donut chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+      <!-- 1. Simple pie -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Simple pie</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Donut -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Donut</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+            donut
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. Donut with center text (total) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. Donut with center text</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+            donut
+            centerText={String(total)}
+            centerLabel="Visitors"
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. Pie with value labels -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. Pie with labels</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+            showLabels
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. Pie with gap between slices -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. Pie with pad angle</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+            padAngle={3}
+          />
+        </Chart>
+      </section>
+
+      <!-- 6. Donut — no legend -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">6. Donut — no legend</h2>
+        <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+          <PieChart
+            data={browserData}
+            config={browserConfig}
+            nameKey="browser"
+            dataKey="visitors"
+            donut
+            showLegend={false}
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-3">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Simple pie</h3>
+          <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+            <PieChart
+              data={browserData}
+              config={browserConfig}
+              nameKey="browser"
+              dataKey="visitors"
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Donut with center text</h3>
+          <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+            <PieChart
+              data={browserData}
+              config={browserConfig}
+              nameKey="browser"
+              dataKey="visitors"
+              donut
+              centerText={String(total)}
+              centerLabel="Visitors"
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Pie with labels</h3>
+          <Chart config={browserConfig} class="mx-auto aspect-square max-w-[300px]">
+            <PieChart
+              data={browserData}
+              config={browserConfig}
+              nameKey="browser"
+              dataKey="visitors"
+              showLabels
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/pages/charts/chart-demo-radar.astro
+++ b/apps/demo/src/pages/charts/chart-demo-radar.astro
@@ -1,0 +1,163 @@
+---
+import "@/styles/global.css";
+import { Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+import RadarChart from "@/components/starwind/chart/RadarChart.astro";
+
+// shadcn radar sample data — Jan–Jun desktop/mobile
+const radarData = [
+  { month: "January", desktop: 186, mobile: 80 },
+  { month: "February", desktop: 305, mobile: 200 },
+  { month: "March", desktop: 237, mobile: 120 },
+  { month: "April", desktop: 173, mobile: 190 },
+  { month: "May", desktop: 209, mobile: 130 },
+  { month: "June", desktop: 214, mobile: 140 },
+];
+
+const config: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+  mobile: { label: "Mobile", color: "var(--chart-2)" },
+};
+
+const singleConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+};
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Radar Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Radar Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Radar chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-8">
+      <!-- 1. Default single series (filled polygon grid) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Single series — filled</h2>
+        <Chart config={singleConfig}>
+          <RadarChart
+            data={radarData}
+            config={singleConfig}
+            categoryKey="month"
+            series={["desktop"]}
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Multiple series -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Multiple series — Desktop &amp; Mobile</h2>
+        <Chart config={config}>
+          <RadarChart
+            data={radarData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. Circle grid -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. Circle grid</h2>
+        <Chart config={config}>
+          <RadarChart
+            data={radarData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            gridType="circle"
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. With dots -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. With dots</h2>
+        <Chart config={singleConfig}>
+          <RadarChart
+            data={radarData}
+            config={singleConfig}
+            categoryKey="month"
+            series={["desktop"]}
+            showDots={true}
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. With legend -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. With legend</h2>
+        <Chart config={config}>
+          <RadarChart
+            data={radarData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            showLegend={true}
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-8">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Single series</h3>
+          <Chart config={singleConfig}>
+            <RadarChart
+              data={radarData}
+              config={singleConfig}
+              categoryKey="month"
+              series={["desktop"]}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Multiple series</h3>
+          <Chart config={config}>
+            <RadarChart
+              data={radarData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Circle grid + legend</h3>
+          <Chart config={config}>
+            <RadarChart
+              data={radarData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              gridType="circle"
+              showLegend={true}
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/pages/charts/chart-demo-radial.astro
+++ b/apps/demo/src/pages/charts/chart-demo-radial.astro
@@ -1,0 +1,190 @@
+---
+import "@/styles/global.css";
+import { Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+import RadialChart from "@/components/starwind/chart/RadialChart.astro";
+
+// Browser data — shadcn radial sample
+const browserData = [
+  { browser: "chrome", visitors: 275 },
+  { browser: "safari", visitors: 200 },
+  { browser: "firefox", visitors: 187 },
+  { browser: "edge", visitors: 173 },
+  { browser: "other", visitors: 90 },
+];
+
+const browserConfig: ChartConfig = {
+  chrome: { label: "Chrome", color: "var(--chart-1)" },
+  safari: { label: "Safari", color: "var(--chart-2)" },
+  firefox: { label: "Firefox", color: "var(--chart-3)" },
+  edge: { label: "Edge", color: "var(--chart-4)" },
+  other: { label: "Other", color: "var(--chart-5)" },
+};
+
+// Single row for gauge
+const gaugeData = [{ browser: "chrome", visitors: 275 }];
+const gaugeConfig: ChartConfig = {
+  chrome: { label: "Chrome", color: "var(--chart-1)" },
+};
+
+// Stacked data — single row, two series
+const stackedData = [{ month: "january", desktop: 1260, mobile: 570 }];
+const stackedConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+  mobile: { label: "Mobile", color: "var(--chart-2)" },
+};
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Radial Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Radial Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Radial chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-8">
+      <!-- 1. Gauge (single arc, semicircle, center value) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Gauge — single arc with center value</h2>
+        <Chart config={gaugeConfig}>
+          <RadialChart
+            data={gaugeData}
+            config={gaugeConfig}
+            mode="gauge"
+            nameKey="browser"
+            dataKey="visitors"
+            startAngle={180}
+            endAngle={0}
+            centerLabel="Visitors"
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Bars (5 concentric arcs) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Bars — concentric arcs by browser</h2>
+        <Chart config={browserConfig}>
+          <RadialChart
+            data={browserData}
+            config={browserConfig}
+            mode="bars"
+            nameKey="browser"
+            dataKey="visitors"
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. Bars with value labels -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. Bars with value labels</h2>
+        <Chart config={browserConfig}>
+          <RadialChart
+            data={browserData}
+            config={browserConfig}
+            mode="bars"
+            nameKey="browser"
+            dataKey="visitors"
+            showLabels
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. Bars with legend -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. Bars with legend</h2>
+        <Chart config={browserConfig}>
+          <RadialChart
+            data={browserData}
+            config={browserConfig}
+            mode="bars"
+            nameKey="browser"
+            dataKey="visitors"
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. Stacked (two segments + center total) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. Stacked — desktop + mobile with center total</h2>
+        <Chart config={stackedConfig}>
+          <RadialChart
+            data={stackedData}
+            config={stackedConfig}
+            mode="stacked"
+            series={["desktop", "mobile"]}
+            categoryKey="month"
+            centerLabel="Visitors"
+            showLegend
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-8">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Gauge</h3>
+          <Chart config={gaugeConfig}>
+            <RadialChart
+              data={gaugeData}
+              config={gaugeConfig}
+              mode="gauge"
+              nameKey="browser"
+              dataKey="visitors"
+              startAngle={180}
+              endAngle={0}
+              centerLabel="Visitors"
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Bars</h3>
+          <Chart config={browserConfig}>
+            <RadialChart
+              data={browserData}
+              config={browserConfig}
+              mode="bars"
+              nameKey="browser"
+              dataKey="visitors"
+              showLegend
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Stacked</h3>
+          <Chart config={stackedConfig}>
+            <RadialChart
+              data={stackedData}
+              config={stackedConfig}
+              mode="stacked"
+              series={["desktop", "mobile"]}
+              categoryKey="month"
+              centerLabel="Visitors"
+              showLegend
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/pages/charts/chart-demo.astro
+++ b/apps/demo/src/pages/charts/chart-demo.astro
@@ -1,0 +1,181 @@
+---
+import "@/styles/global.css";
+import { BarChart, Chart } from "@/components/starwind/chart";
+import type { ChartConfig } from "@/components/starwind/chart";
+
+// Sample data for demo variants
+const monthlyData = [
+  { month: "Jan", desktop: 186, mobile: 80 },
+  { month: "Feb", desktop: 305, mobile: 200 },
+  { month: "Mar", desktop: 237, mobile: 120 },
+  { month: "Apr", desktop: 173, mobile: 190 },
+  { month: "May", desktop: 209, mobile: 130 },
+  { month: "Jun", desktop: 214, mobile: 140 },
+];
+
+const config: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+  mobile: { label: "Mobile", color: "var(--chart-2)" },
+};
+
+const singleConfig: ChartConfig = {
+  desktop: { label: "Desktop", color: "var(--chart-1)" },
+};
+
+const categoryData = [
+  { category: "Q1", revenue: 4200, expenses: 2800, profit: 1400 },
+  { category: "Q2", revenue: 5100, expenses: 3200, profit: 1900 },
+  { category: "Q3", revenue: 6300, expenses: 3600, profit: 2700 },
+  { category: "Q4", revenue: 7800, expenses: 4100, profit: 3700 },
+];
+
+const categoryConfig: ChartConfig = {
+  revenue: { label: "Revenue", color: "var(--chart-1)" },
+  expenses: { label: "Expenses", color: "var(--chart-2)" },
+  profit: { label: "Profit", color: "var(--chart-3)" },
+};
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Chart Demo — Starwind UI</title>
+    <!-- Theme init: eliminate FART -->
+    <script is:inline>
+      const t = localStorage.getItem("colorTheme");
+      if (t === "dark" || (!t && matchMedia("(prefers-color-scheme: dark)").matches)) {
+        document.documentElement.classList.add("dark");
+      }
+    </script>
+  </head>
+
+  <body class="bg-background text-foreground min-h-screen p-8">
+    <h1 class="mb-2 text-2xl font-semibold">Chart Demo</h1>
+    <p class="text-muted-foreground mb-10 text-sm">
+      Bar chart variants — Starwind UI (light + dark sections below)
+    </p>
+
+    <!-- Light mode section -->
+    <div class="mb-12 grid gap-8">
+      <!-- 1. Single series -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">1. Single series</h2>
+        <Chart config={singleConfig}>
+          <BarChart
+            data={monthlyData}
+            config={singleConfig}
+            categoryKey="month"
+            series={["desktop"]}
+          />
+        </Chart>
+      </section>
+
+      <!-- 2. Grouped (multiple series) -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">2. Grouped — Desktop &amp; Mobile</h2>
+        <Chart config={config}>
+          <BarChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 3. Stacked -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">3. Stacked</h2>
+        <Chart config={config}>
+          <BarChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            stacked
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 4. Horizontal -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">4. Horizontal</h2>
+        <Chart config={config}>
+          <BarChart
+            data={monthlyData}
+            config={config}
+            categoryKey="month"
+            series={["desktop", "mobile"]}
+            layout="horizontal"
+            showLegend
+          />
+        </Chart>
+      </section>
+
+      <!-- 5. Value labels + Y-axis + 3 series stacked -->
+      <section>
+        <h2 class="mb-3 text-sm font-medium">5. Value labels — 3-series grouped with Y-axis</h2>
+        <Chart config={categoryConfig}>
+          <BarChart
+            data={categoryData}
+            config={categoryConfig}
+            categoryKey="category"
+            series={["revenue", "expenses", "profit"]}
+            showYAxis
+            showLabels
+            showLegend
+          />
+        </Chart>
+      </section>
+    </div>
+
+    <!-- Dark mode mirror -->
+    <div class="dark rounded-xl bg-neutral-950 p-8">
+      <h2 class="mb-6 text-sm font-medium text-neutral-200">Dark mode</h2>
+      <div class="grid gap-8">
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Single series</h3>
+          <Chart config={singleConfig}>
+            <BarChart
+              data={monthlyData}
+              config={singleConfig}
+              categoryKey="month"
+              series={["desktop"]}
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Grouped</h3>
+          <Chart config={config}>
+            <BarChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              showLegend
+            />
+          </Chart>
+        </section>
+
+        <section>
+          <h3 class="mb-3 text-sm font-medium text-neutral-400">Stacked</h3>
+          <Chart config={config}>
+            <BarChart
+              data={monthlyData}
+              config={config}
+              categoryKey="month"
+              series={["desktop", "mobile"]}
+              stacked
+              showLegend
+            />
+          </Chart>
+        </section>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/demo/src/styles/global.css
+++ b/apps/demo/src/styles/global.css
@@ -72,6 +72,12 @@
   --color-input: var(--input);
   --color-outline: var(--outline);
 
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
   --radius-xs: calc(var(--radius) - 0.375rem);
   --radius-sm: calc(var(--radius) - 0.25rem);
   --radius-md: calc(var(--radius) - 0.125rem);
@@ -118,6 +124,11 @@
   --border: var(--color-neutral-200);
   --input: var(--color-neutral-200);
   --outline: var(--color-neutral-400);
+  --chart-1: var(--color-blue-600);
+  --chart-2: var(--color-sky-500);
+  --chart-3: var(--color-green-500);
+  --chart-4: var(--color-amber-500);
+  --chart-5: var(--color-rose-500);
   --radius: 0.625rem;
 
   /* sidebar variables */
@@ -159,6 +170,11 @@
   --border: --alpha(var(--color-neutral-50) / 10%);
   --input: --alpha(var(--color-neutral-50) / 15%);
   --outline: var(--color-neutral-500);
+  --chart-1: var(--color-blue-400);
+  --chart-2: var(--color-sky-400);
+  --chart-3: var(--color-green-400);
+  --chart-4: var(--color-amber-400);
+  --chart-5: var(--color-rose-400);
 
   /* sidebars variables */
   --sidebar-background: var(--color-neutral-900);

--- a/apps/demo/src/styles/starwind.css
+++ b/apps/demo/src/styles/starwind.css
@@ -55,6 +55,12 @@
   --color-input: var(--input);
   --color-outline: var(--outline);
 
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
   --radius-xs: calc(var(--radius) - 0.375rem);
   --radius-sm: calc(var(--radius) - 0.25rem);
   --radius-md: calc(var(--radius) - 0.125rem);
@@ -101,6 +107,11 @@
   --border: var(--color-neutral-200);
   --input: var(--color-neutral-200);
   --outline: var(--color-neutral-400);
+  --chart-1: var(--color-blue-600);
+  --chart-2: var(--color-sky-500);
+  --chart-3: var(--color-green-500);
+  --chart-4: var(--color-amber-500);
+  --chart-5: var(--color-rose-500);
   --radius: 0.625rem;
 
   /* sidebar variables */
@@ -142,6 +153,11 @@
   --border: --alpha(var(--color-neutral-50) / 10%);
   --input: --alpha(var(--color-neutral-50) / 15%);
   --outline: var(--color-neutral-500);
+  --chart-1: var(--color-blue-400);
+  --chart-2: var(--color-sky-400);
+  --chart-3: var(--color-green-400);
+  --chart-4: var(--color-amber-400);
+  --chart-5: var(--color-rose-400);
 
   /* sidebars variables */
   --sidebar-background: var(--color-neutral-900);

--- a/packages/core/src/components/chart/AreaChart.astro
+++ b/packages/core/src/components/chart/AreaChart.astro
@@ -1,0 +1,454 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { buildArea, buildPath, type Point } from "./curves";
+import { niceMax, tightMax, xLabelStep } from "./scale";
+import { nextUid } from "./uid";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  curve?: "linear" | "monotone" | "step" | "natural";
+  stacked?: boolean;
+  gradient?: boolean;
+  gradientOpacity?: number;
+  showDots?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  yTickCount?: number;
+  marginLeft?: number;
+  marginRight?: number;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  curve = "monotone",
+  stacked = false,
+  gradient = true,
+  gradientOpacity,
+  showDots = false,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLegend = false,
+  showTooltip = true,
+  yTickCount = 6,
+  marginLeft = 0,
+  marginRight,
+  width = 640,
+  height = 360,
+} = Astro.props;
+
+// Internal coordinate space — defaults to aspect-video; callers can override for wide containers
+const W = width;
+const H = height;
+
+// Domain maximum
+const domainVals = stacked
+  ? data.map((d) => series.reduce((sum, s) => sum + Number(d[s] ?? 0), 0))
+  : data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+const isWideChart = W > 800;
+const basePadX = isWideChart ? 8 : 26;
+// "Stacked expand" mode (data pre-normalised to sum ~100, e.g. Stacked Expanded):
+// oracle renders the bottom-most series at fillOpacity 0.1, the rest at 0.4.
+const expandStack = stacked && rawMax <= 100.0001;
+const padTop = expandStack ? (isWideChart ? 12 : 26) : 5;
+const padRight = basePadX + (marginRight ?? 0);
+const padBottom = showXAxis ? (showLegend ? (isWideChart ? 63 : 124) : isWideChart ? 63 : 64) : 10;
+const padLeft = (showYAxis ? (isWideChart ? 40 : 86) : basePadX) + marginLeft;
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+const domainMax = stacked
+  ? rawMax <= 100.0001
+    ? 100
+    : niceMax(rawMax)
+  : showYAxis
+    ? niceMax(rawMax)
+    : tightMax(rawMax);
+
+const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+const ticks = Array.from({ length: yTickCount }, (_, i) => (i * domainMax) / (yTickCount - 1));
+
+// X positions evenly across the plot width.
+const xOf = (i: number) =>
+  data.length <= 1 ? plotLeft + plotW / 2 : plotLeft + (i / (data.length - 1)) * plotW;
+
+// X-axis label thinning — approximates Recharts minTickGap for dense daily data.
+const labelStride = xLabelStep(data.length, W);
+
+// Cumulative sums per data point for stacking
+const cumSums: number[][] = data.map(() => new Array(series.length + 1).fill(0));
+if (stacked) {
+  for (let si = 0; si < series.length; si++) {
+    for (let di = 0; di < data.length; di++) {
+      cumSums[di][si + 1] = cumSums[di][si] + Number(data[di][series[si]] ?? 0);
+    }
+  }
+}
+
+type SeriesData = {
+  key: string;
+  areaPath: string;
+  linePath: string;
+  topPts: Point[];
+};
+
+const seriesData: SeriesData[] = series.map((key, si) => {
+  const topPts: Point[] = data.map((d, di) => ({
+    x: xOf(di),
+    y: stacked ? yOf(cumSums[di][si + 1]) : yOf(Number(d[key] ?? 0)),
+  }));
+  const bottomPts: Point[] = data.map((_d, di) => ({
+    x: xOf(di),
+    y: stacked ? yOf(cumSums[di][si]) : plotBottom,
+  }));
+  return {
+    key,
+    areaPath: buildArea(topPts, bottomPts, curve),
+    linePath: buildPath(topPts, curve),
+    topPts,
+  };
+});
+
+const hitBands = data.map((d, di) => {
+  const x = xOf(di);
+  const left = di === 0 ? plotLeft : (xOf(di - 1) + x) / 2;
+  const right = di === data.length - 1 ? plotRight : (x + xOf(di + 1)) / 2;
+  return {
+    x: left,
+    width: right - left,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(Number(d[key] ?? 0)),
+    })),
+    dots: seriesData.map(({ key, topPts }) => ({ key, point: topPts[di] })),
+  };
+});
+
+// Per-instance suffix so gradient ids don't collide with other AreaChart instances
+// on the same page — a shared id like "grad-desktop" is invalid HTML with >1 chart,
+// and some browsers fail to paint a url(#id) fill when the first same-id element
+// they resolve to sits in a hidden subtree (e.g. an inactive tab/panel elsewhere).
+const gid = nextUid("area-grad");
+
+const ariaLabel = `Area chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+const legendInset = isWideChart ? 5 : 12;
+const legendBottom = isWideChart ? 5 : 0;
+---
+
+<svg
+  data-area-chart
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="none"
+  overflow="visible"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <style>
+    [data-area-hit] [data-active-dot] {
+      opacity: 0;
+      pointer-events: none;
+    }
+    [data-area-hit]:hover [data-active-dot] {
+      opacity: 1;
+    }
+  </style>
+
+  <defs>
+    {
+      series.map((key) => (
+        <linearGradient id={`grad-${key}-${gid}`} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="5%" stop-color={`var(--color-${key})`} stop-opacity="0.8" />
+          <stop offset="95%" stop-color={`var(--color-${key})`} stop-opacity="0.1" />
+        </linearGradient>
+      ))
+    }
+  </defs>
+
+  <!-- Gridlines -->
+  {
+    showGrid &&
+      ticks.map((t) => (
+        <line
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels -->
+  {
+    showYAxis &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 30}
+          y={yOf(t) + 8}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels -->
+  {
+    showXAxis &&
+      data.map(
+        (d, i) =>
+          (data.length > 30 || i % labelStride === 0) && (
+            <text
+              data-area-x-label
+              data-index={i}
+              data-count={data.length}
+              x={xOf(i)}
+              y={plotBottom + 20}
+              dy="0.71em"
+              text-anchor="middle"
+              fill="var(--muted-foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {String(d[categoryKey])}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Area fills (back to front so later series render on top) -->
+  {
+    seriesData.map(({ key, areaPath }, i) => (
+      <path
+        d={areaPath}
+        fill={gradient ? `url(#grad-${key}-${gid})` : `var(--color-${key})`}
+        fill-opacity={gradient ? gradientOpacity : expandStack ? (i === 0 ? "0.1" : "0.4") : "0.4"}
+        stroke="none"
+      />
+    ))
+  }
+
+  <!-- Line strokes on top of fills -->
+  {
+    seriesData.map(({ key, linePath }) => (
+      <path
+        d={linePath}
+        fill="none"
+        stroke={`var(--color-${key})`}
+        stroke-width="1"
+        data-sw="1"
+        vector-effect="non-scaling-stroke"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    ))
+  }
+
+  <!-- Optional dots at each data point -->
+  {
+    showDots &&
+      seriesData.map(({ key, topPts }) =>
+        topPts.map((p) => (
+          <circle
+            cx={p.x}
+            cy={p.y}
+            r="6"
+            data-r="4"
+            fill={`var(--color-${key})`}
+            stroke="var(--background)"
+            stroke-width="2"
+            data-sw="2"
+          />
+        )),
+      )
+  }
+
+  <!-- Full-height hit bands — Recharts tooltip follows the nearest x-axis point. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <g data-area-hit>
+          <rect
+            x={band.x}
+            y={plotTop}
+            width={band.width}
+            height={plotH}
+            fill="transparent"
+            pointer-events="all"
+            data-series={band.items[0]?.series}
+            data-category={band.category}
+            data-items={JSON.stringify(band.items)}
+          />
+          {band.dots.map(({ key, point }) => (
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r="6"
+              data-r="4"
+              fill={`var(--color-${key})`}
+              stroke="var(--background)"
+              stroke-width="2"
+              data-sw="2"
+              data-active-dot
+            />
+          ))}
+        </g>
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div
+      style={`position:absolute;left:${legendInset}px;right:${legendInset}px;bottom:${legendBottom}px;`}
+    >
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  // Which x-axis labels to show for dense (daily) data, matched to shadcn's Recharts
+  // output: same first label + count + last-label position per breakpoint, spread
+  // EVENLY so nothing crowds the right edge. shadcn's last visible label sits ~1 band
+  // inset from the plot edge (Recharts right margin), so we end on total-2, not total-1.
+  const pickAreaLabelIndices = (total: number, width: number) => {
+    if (total <= 30) return null;
+    const [first, count] = width < 500 ? [14, 5] : width < 900 ? [4, 10] : [2, 15];
+    // shadcn's last visible label sits a fixed ~13px in from the plot edge (Recharts
+    // right margin). With mine's data spanning to the edge, that inset is ~1 band on
+    // desktop/tablet but ~3 on the much narrower mobile bands — so end further in there.
+    const last = total - (width < 500 ? 4 : 2);
+    const indices = new Set<number>();
+    for (let k = 0; k < count; k++) {
+      indices.add(Math.round(first + (k * (last - first)) / (count - 1)));
+    }
+    return indices;
+  };
+
+  const scaleAreaSvgMetrics = (svg: SVGSVGElement) => {
+    const vb = svg.viewBox?.baseVal;
+    if (!vb?.width || !vb?.height) return;
+    const box = svg.getBoundingClientRect();
+    if (!box.width || !box.height) return;
+
+    // preserveAspectRatio="none" on a fluid-width/fixed-height container lets
+    // sx and sy diverge (interactive card: sx≈0.36, sy≈1 at narrow widths).
+    // Counter-scale each text/dot about its own anchor with independent kx/ky
+    // so glyphs and dots render at their natural aspect instead of squished.
+    // For aspect-video cards sx===sy, so this collapses to the old uniform scale.
+    const sx = box.width / vb.width;
+    const sy = box.height / vb.height;
+    const kx = 1 / (sx || 1);
+    const ky = 1 / (sy || 1);
+
+    const anchorTransform = (ax: number, ay: number) =>
+      `translate(${(ax * (1 - kx)).toFixed(3)} ${(ay * (1 - ky)).toFixed(3)}) scale(${kx.toFixed(4)} ${ky.toFixed(4)})`;
+
+    svg.querySelectorAll<SVGTextElement>("[data-fs]").forEach((el) => {
+      const px = Number(el.getAttribute("data-fs")) || 12;
+      el.setAttribute("font-size", String(px));
+      const ax = Number(el.getAttribute("x")) || 0;
+      const ay = Number(el.getAttribute("y")) || 0;
+      el.setAttribute("transform", anchorTransform(ax, ay));
+    });
+
+    svg.querySelectorAll<SVGCircleElement>("[data-r]").forEach((el) => {
+      const px = Number(el.getAttribute("data-r")) || 4;
+      el.setAttribute("r", String(px));
+      const ax = Number(el.getAttribute("cx")) || 0;
+      const ay = Number(el.getAttribute("cy")) || 0;
+      el.setAttribute("transform", anchorTransform(ax, ay));
+    });
+
+    // Strokes (area/line paths) intentionally fill the width — just keep
+    // their on-screen thickness constant vertically. Dots carry data-r, so a
+    // counter-scale transform already cancels the viewport stretch and their
+    // stroke renders at natural size — they must NOT get the extra ky factor
+    // (that double-scales it and makes hover dots come out ~1.7× too heavy).
+    svg.querySelectorAll<SVGElement>("[data-sw]").forEach((el) => {
+      const px = Number(el.getAttribute("data-sw")) || 1;
+      // Transformed dots (data-r) and non-scaling-stroke line paths already
+      // render at a true screen px; only the width-filling gridlines still
+      // need the ky factor to hold their on-screen thickness.
+      const natural =
+        el.hasAttribute("data-r") || el.getAttribute("vector-effect") === "non-scaling-stroke";
+      el.setAttribute("stroke-width", natural ? String(px) : (px * ky).toFixed(2));
+    });
+    svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+  };
+
+  const updateAreaLabels = (svg: SVGSVGElement) => {
+    const labels = Array.from(svg.querySelectorAll<SVGTextElement>("[data-area-x-label]"));
+    if (!labels.length) return;
+    const total = Number(labels[0]?.dataset.count) || labels.length;
+    const chosen = pickAreaLabelIndices(
+      total,
+      svg.clientWidth || svg.getBoundingClientRect().width,
+    );
+    for (const label of labels) {
+      const index = Number(label.dataset.index);
+      label.style.display = !chosen || chosen.has(index) ? "" : "none";
+    }
+  };
+
+  const areaObserved = new WeakSet<SVGSVGElement>();
+  const areaResizeObserver = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const svg = entry.target as SVGSVGElement;
+      requestAnimationFrame(() => {
+        updateAreaLabels(svg);
+        scaleAreaSvgMetrics(svg);
+      });
+    }
+  });
+
+  const setupAreaCharts = () => {
+    document.querySelectorAll<SVGSVGElement>("svg[data-area-chart]").forEach((svg) => {
+      updateAreaLabels(svg);
+      scaleAreaSvgMetrics(svg);
+      requestAnimationFrame(() => {
+        updateAreaLabels(svg);
+        scaleAreaSvgMetrics(svg);
+      });
+      if (!areaObserved.has(svg)) {
+        areaObserved.add(svg);
+        areaResizeObserver.observe(svg);
+      }
+    });
+  };
+
+  setupAreaCharts();
+  document.addEventListener("astro:after-swap", setupAreaCharts);
+  document.addEventListener("starwind:init", setupAreaCharts);
+</script>

--- a/packages/core/src/components/chart/BarChart.astro
+++ b/packages/core/src/components/chart/BarChart.astro
@@ -1,0 +1,874 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { niceDomain, xLabelStep } from "./scale";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  layout?: "vertical" | "horizontal";
+  stacked?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLabels?: boolean;
+  showCategoryLabels?: boolean;
+  barRadius?: number;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  colorByCategory?: boolean;
+  activeIndex?: number;
+  labelInside?: boolean;
+  negativeColor?: string;
+  showCursor?: boolean;
+  hideTooltipLabel?: boolean;
+  hideTooltipIndicator?: boolean;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  layout = "vertical",
+  stacked = false,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLabels = false,
+  showCategoryLabels = false,
+  barRadius = 4,
+  showLegend = false,
+  showTooltip = true,
+  colorByCategory = false,
+  activeIndex,
+  labelInside = false,
+  negativeColor,
+  showCursor = false,
+  hideTooltipLabel = false,
+  hideTooltipIndicator = false,
+  width = 640,
+  height = 360,
+} = Astro.props;
+
+const isHorizontal = layout === "horizontal";
+const isDenseVertical = !isHorizontal && data.length > 30;
+
+// Internal coordinate space — driven by props so wide containers don't letterbox.
+const W = width;
+const H = height;
+
+// Padding (logical px) tuned to Recharts' plot box for the shadcn bar examples.
+// Negative/stacked+legend padTop/padBottom and horizontal padLeft/padRight were
+// re-derived from the oracle's real margin/CartesianGrid geometry — the old
+// values had been tuned to compensate for domainMax previously being raw
+// (un-nice-rounded); with the domain fix they left far too much dead margin.
+// Label overflow (month names, value labels) still fits: Recharts renders
+// these past the nominal margin via SVG overflow, and bars stop short of the
+// plot edge anyway once the domain is nice-rounded, leaving room for the
+// label offsets without needing extra padding to compensate.
+const padTop = isHorizontal
+  ? 3
+  : isDenseVertical
+    ? 37
+    : showCategoryLabels
+      ? 9
+      : showLabels
+        ? 55
+        : stacked && showLegend
+          ? 9
+          : 24;
+const padRight = isHorizontal ? (labelInside ? 29 : colorByCategory ? 8 : 0) : 12;
+const padBottom = isHorizontal
+  ? showXAxis
+    ? 28
+    : 3
+  : isDenseVertical
+    ? 30
+    : stacked && showLegend
+      ? 115
+      : showCategoryLabels
+        ? 9
+        : showLabels
+          ? 64
+          : showXAxis
+            ? 75
+            : 35;
+const padLeft = isHorizontal ? (labelInside ? 0 : colorByCategory ? 111 : 73) : showYAxis ? 50 : 12;
+
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+// Compute domain — auto-detect negatives
+const allVals = stacked
+  ? data.map((d) => series.reduce((sum, s) => sum + Number(d[s] ?? 0), 0))
+  : data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...allVals, 0);
+const rawMin = Math.min(...allVals, 0);
+
+// Faithful port of Recharts' default axis "nice" domain algorithm
+// (recharts-scale's getNiceTickValues/calculateStep, tickCount=5). Recharts
+// mutates a numeric axis' scale domain to this nice-rounded range EVEN WHEN
+// the axis is hidden — confirmed by reading generateCategoricalChart.js's
+// getTicksOfScale, which runs unconditionally per axis. That's the actual
+// root cause of shadcn's bars leaving headroom / stopping short of the plot
+// edges instead of touching them exactly at the raw data min/max.
+const [domainMin, domainMax] = niceDomain(rawMin, rawMax);
+const domainRange = domainMax - domainMin;
+
+// Unified scale helpers — backward-compatible when domainMin === 0
+const yOf = (v: number) => plotBottom - ((v - domainMin) / domainRange) * plotH;
+const xOf = (v: number) => plotLeft + (v / domainMax) * plotW;
+const baselineY = yOf(0); // = plotBottom when domainMin === 0
+
+// X-axis label thinning — approximates Recharts minTickGap for dense daily data.
+const labelStride = xLabelStep(data.length, W);
+
+// Grid ticks — Recharts' implicit-axis default: 5 evenly-spaced lines from
+// domainMin to domainMax (confirmed against oracle gridline y-positions).
+const tickCount = 5;
+const ticks = Array.from(
+  { length: tickCount },
+  (_, i) => domainMin + (i * domainRange) / (tickCount - 1),
+);
+
+// Shape helpers — used only for stacked segments
+function topRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, w / 2, h);
+  return (
+    `M${x},${y + h} L${x},${y + cr} Q${x},${y} ${x + cr},${y} ` +
+    `L${x + w - cr},${y} Q${x + w},${y} ${x + w},${y + cr} L${x + w},${y + h} Z`
+  );
+}
+
+// Rounds only the bottom two corners (for negative stacked bars growing downward)
+function bottomRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, w / 2, h);
+  return (
+    `M${x},${y} L${x + w},${y} L${x + w},${y + h - cr} ` +
+    `Q${x + w},${y + h} ${x + w - cr},${y + h} ` +
+    `L${x + cr},${y + h} Q${x},${y + h} ${x},${y + h - cr} L${x},${y} Z`
+  );
+}
+
+// Rounds only the right two corners (for horizontal stacked segments)
+function rightRoundRect(x: number, y: number, w: number, h: number, r: number): string {
+  if (h <= 0 || w <= 0) return "";
+  const cr = Math.min(r, h / 2, w);
+  return (
+    `M${x},${y} L${x + w - cr},${y} Q${x + w},${y} ${x + w},${y + cr} ` +
+    `L${x + w},${y + h - cr} Q${x + w},${y + h} ${x + w - cr},${y + h} L${x},${y + h} Z`
+  );
+}
+
+type BarItem = {
+  path: string;
+  // Non-stacked bars use a rect instead of a path (all-four-corner rounding via rx/ry).
+  rect?: { x: number; y: number; w: number; h: number; r: number };
+  fill: string;
+  labelText: string;
+  labelX: number;
+  labelY: number;
+  labelAnchor: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  dataIndex: number;
+  isActive: boolean;
+  catLabelText: string;
+  catLabelX: number;
+  catLabelY: number;
+  catLabelFill: string;
+  // Screen-space vertical offset (px) applied by the counter-scaler. Used for
+  // negative-bar month labels so the gap below the bar stays constant on screen
+  // instead of shrinking with the viewBox scale (which made labels touch bars).
+  catLabelDyPx?: number;
+  insideLabel?: { text: string; x: number; y: number };
+};
+
+const bars: BarItem[] = [];
+
+// Resolve fill for a single bar
+function resolveFill(key: string, val: number, category: string): string {
+  if (colorByCategory) return `var(--color-${category})`;
+  if (val < 0 && negativeColor) return negativeColor;
+  return `var(--color-${key})`;
+}
+
+if (!isHorizontal) {
+  const bandW = plotW / data.length;
+
+  if (stacked) {
+    const stackBarW = bandW * 0.75;
+    for (let di = 0; di < data.length; di++) {
+      const bandCenter = plotLeft + bandW * (di + 0.5);
+      const x = bandCenter - stackBarW / 2;
+      let currentBottom = baselineY;
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const h = (val / domainMax) * plotH;
+        const y = currentBottom - h;
+        const category = String(data[di][categoryKey]);
+        // Top segment: top corners rounded. Bottom segment: bottom corners rounded
+        // (matching shadcn radius={[0,0,4,4]} / radius={[4,4,0,0]}). Non-top
+        // segments extend 2px upward under the segment above to kill the
+        // antialiasing seam; bottomRoundRect inherits that trick via y-2/h+2.
+        const isTopSeg = si === series.length - 1;
+        const isBottomSeg = si === 0 && series.length > 1;
+        const segTop = y - 2;
+        const path = isTopSeg
+          ? topRoundRect(x, y, stackBarW, h, barRadius)
+          : isBottomSeg
+            ? bottomRoundRect(x, y - 2, stackBarW, h + 2, barRadius)
+            : `M${x},${y + h} L${x},${segTop} L${x + stackBarW},${segTop} L${x + stackBarW},${y + h} Z`;
+
+        bars.push({
+          path: path || "",
+          fill: resolveFill(key, val, category),
+          labelText: String(val),
+          labelX: x + stackBarW / 2,
+          labelY: y - 4,
+          labelAnchor: "middle",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: false,
+          catLabelText: category,
+          catLabelX: x + stackBarW / 2,
+          catLabelY: y - 8,
+          catLabelFill: "var(--foreground)",
+        });
+        currentBottom = y;
+      }
+    }
+  } else {
+    // Grouped vertical — Recharts uses ONE bar-width ratio regardless of
+    // whether LabelList is present; measured ~0.794 on the oracle (default
+    // and active bars agree to within 0.02%). Grouped pair fills ~0.9.
+    const groupFrac = series.length === 1 ? 0.79 : 0.9;
+    const groupW = bandW * groupFrac;
+    const barSlotW = groupW / series.length;
+    const actualBarW = series.length === 1 ? barSlotW : barSlotW * 0.92;
+    const barOffset = (barSlotW - actualBarW) / 2;
+
+    for (let di = 0; di < data.length; di++) {
+      const bandCenter = plotLeft + bandW * (di + 0.5);
+      const groupLeft = bandCenter - groupW / 2;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const x = groupLeft + si * barSlotW + barOffset;
+        const isNeg = val < 0;
+        const fill = resolveFill(key, val, category);
+
+        let rect: BarItem["rect"];
+        let labelY: number;
+        let catLabelY: number;
+        let catLabelDyPx: number | undefined;
+
+        if (isNeg) {
+          // Bar grows downward from baseline
+          const h = yOf(val) - baselineY;
+          const r = Math.min(barRadius, actualBarW / 2, h / 2);
+          rect = { x, y: baselineY, w: actualBarW, h, r };
+          labelY = baselineY - 4;
+          // Anchor at the bar's outer (bottom) edge; push the label down a
+          // constant 14px on screen (matches shadcn's LabelList gap). A viewBox
+          // offset would shrink under scaling and collapse the gap.
+          catLabelY = yOf(val);
+          catLabelDyPx = 14;
+        } else {
+          const barTop = yOf(val);
+          const h = baselineY - barTop;
+          const r = Math.min(barRadius, actualBarW / 2, h / 2);
+          rect = { x, y: barTop, w: actualBarW, h, r };
+          labelY = barTop - 8;
+          catLabelY = barTop - 6;
+        }
+
+        bars.push({
+          path: "",
+          rect,
+          fill,
+          labelText: String(val),
+          labelX: x + actualBarW / 2,
+          labelY,
+          labelAnchor: "middle",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: activeIndex !== undefined && di === activeIndex,
+          catLabelText: category,
+          catLabelX: x + actualBarW / 2,
+          catLabelY,
+          catLabelFill: fill,
+          catLabelDyPx,
+        });
+      }
+    }
+  }
+} else {
+  // Horizontal bars
+  const bandH = plotH / data.length;
+
+  if (stacked) {
+    const stackBarH = bandH * 0.6;
+    for (let di = 0; di < data.length; di++) {
+      const bandMidY = plotTop + bandH * (di + 0.5);
+      const y = bandMidY - stackBarH / 2;
+      let currentLeft = plotLeft;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const w = (val / domainMax) * plotW;
+        // Only the rightmost segment gets rounded corners. Non-rightmost
+        // segments extend ~0.75px right under the next so fills overlap and
+        // the antialiasing seam between colors disappears.
+        const isRightmost = si === series.length - 1;
+        const segRight = currentLeft + w + 0.75;
+        const path = isRightmost
+          ? rightRoundRect(currentLeft, y, w, stackBarH, barRadius)
+          : `M${currentLeft},${y} L${segRight},${y} L${segRight},${y + stackBarH} L${currentLeft},${y + stackBarH} Z`;
+
+        bars.push({
+          path: path || "",
+          fill: resolveFill(key, val, category),
+          labelText: String(val),
+          labelX: currentLeft + w + 4,
+          labelY: y + stackBarH / 2 + 4,
+          labelAnchor: "start",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: false,
+          catLabelText: category,
+          catLabelX: plotLeft + 8,
+          catLabelY: y + stackBarH / 2 + 4,
+          catLabelFill: "var(--foreground)",
+        });
+        currentLeft += w;
+      }
+    }
+  } else {
+    // Grouped horizontal — single bar ~0.7 of band; grouped pair fills ~0.8
+    const groupFrac = series.length === 1 ? 0.8 : 0.8;
+    const groupH = bandH * groupFrac;
+    const barSlotH = groupH / series.length;
+    const actualBarH = series.length === 1 ? barSlotH : barSlotH * 0.9;
+    const barOffset = (barSlotH - actualBarH) / 2;
+
+    for (let di = 0; di < data.length; di++) {
+      const bandMidY = plotTop + bandH * (di + 0.5);
+      const groupTop = bandMidY - groupH / 2;
+      const category = String(data[di][categoryKey]);
+
+      for (let si = 0; si < series.length; si++) {
+        const key = series[si];
+        const val = Number(data[di][key] ?? 0);
+        const w = xOf(val) - plotLeft;
+        const y = groupTop + si * barSlotH + barOffset;
+        // True bar center — text uses dominant-baseline="central" at render
+        // time instead of an alphabetic-baseline fudge offset (measured on
+        // the oracle: LabelList text centers within ~0.25px of bar center).
+        const midY = y + actualBarH / 2;
+        const fill = resolveFill(key, val, category);
+        const r = Math.min(barRadius, actualBarH / 2, w / 2);
+
+        bars.push({
+          path: "",
+          rect: { x: plotLeft, y, w, h: actualBarH, r },
+          fill,
+          labelText: String(val),
+          labelX: plotLeft + w + 6,
+          labelY: midY,
+          labelAnchor: "start",
+          seriesKey: key,
+          category,
+          value: String(val),
+          dataIndex: di,
+          isActive: activeIndex !== undefined && di === activeIndex,
+          catLabelText: category,
+          catLabelX: plotLeft + 8,
+          catLabelY: midY,
+          catLabelFill: fill,
+          // labelInside: category name inside bar (left) + value at right end
+          insideLabel: labelInside ? { text: category, x: plotLeft + 8, y: midY } : undefined,
+        });
+      }
+    }
+  }
+}
+
+const hitBands = data.map((d, di) => {
+  const category = String(d[categoryKey]);
+  const items = series.map((key) => ({
+    series: key,
+    label: config[key]?.label ?? key,
+    value: String(d[key] ?? 0),
+    // Resolved bar color CSS string — lets the tooltip swatch render even
+    // for series without a --color-<key> var (e.g. colorByCategory bars).
+    color: resolveFill(key, Number(d[key] ?? 0), category),
+  }));
+
+  if (isHorizontal) {
+    const bandH = plotH / data.length;
+    return {
+      index: di,
+      x: plotLeft,
+      y: plotTop + bandH * di,
+      width: plotW,
+      height: bandH,
+      category,
+      items,
+    };
+  }
+
+  const bandW = plotW / data.length;
+  return {
+    index: di,
+    x: plotLeft + bandW * di,
+    y: plotTop,
+    width: bandW,
+    height: plotH,
+    category,
+    items,
+  };
+});
+
+const ariaLabel = `Bar chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="xMidYMid meet"
+  overflow="visible"
+  data-bar-dense={isDenseVertical ? "true" : undefined}
+  data-bar-cursor={showCursor ? "true" : undefined}
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Gridlines -->
+  {
+    showGrid &&
+      !isHorizontal &&
+      ticks.map((t) => (
+        <line
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showGrid &&
+      isHorizontal &&
+      ticks.map((t) => (
+        <line
+          x1={xOf(t)}
+          x2={xOf(t)}
+          y1={plotTop}
+          y2={plotBottom}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels (vertical layout) -->
+  {
+    showYAxis &&
+      !isHorizontal &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 6}
+          y={yOf(t) + 4}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels (vertical layout) — thinned for dense datasets -->
+  {
+    showXAxis &&
+      !isHorizontal &&
+      data.map((d, i) => {
+        if (!isDenseVertical && i % labelStride !== 0) return null;
+        const bandW = plotW / data.length;
+        const cx = plotLeft + bandW * (i + 0.5);
+        return (
+          <text
+            x={cx}
+            y={plotBottom + 20}
+            dy="0.71em"
+            text-anchor="middle"
+            fill="var(--muted-foreground)"
+            font-size="12"
+            data-fs="12"
+            data-dense-x-label={isDenseVertical ? "true" : undefined}
+            data-index={isDenseVertical ? i : undefined}
+          >
+            {config[String(d[categoryKey])]?.label ?? String(d[categoryKey])}
+          </text>
+        );
+      })
+  }
+
+  <!-- Y-axis category labels (horizontal layout) — hidden when labelInside -->
+  {
+    !labelInside &&
+      isHorizontal &&
+      data.map((d, i) => {
+        const bandH = plotH / data.length;
+        const midY = plotTop + bandH * (i + 0.5);
+        const cat = String(d[categoryKey]);
+        return (
+          <text
+            x={plotLeft - 28}
+            y={midY + 4}
+            text-anchor="end"
+            fill="var(--muted-foreground)"
+            font-size="12"
+            data-fs="12"
+          >
+            {config[cat]?.label ?? cat}
+          </text>
+        );
+      })
+  }
+
+  <!-- X-axis value labels (horizontal layout) -->
+  {
+    showXAxis &&
+      isHorizontal &&
+      ticks.map((t) => (
+        <text
+          x={xOf(t)}
+          y={plotBottom + 16}
+          text-anchor="middle"
+          fill="var(--muted-foreground)"
+          font-size="11"
+          data-fs="11"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- Hover cursor band — shadcn only shows this on charts that don't set
+       cursor={false} (stacked, interactive). Hidden by default; toggled by
+       the script below on hover of the matching hit band. Rendered before
+       bars so bars paint on top of it, matching Recharts' z-order. -->
+  {
+    showCursor &&
+      hitBands.map((band) => (
+        <rect
+          x={band.x}
+          y={band.y}
+          width={band.width}
+          height={band.height}
+          fill="var(--muted)"
+          opacity="0"
+          pointer-events="none"
+          data-cursor-index={band.index}
+        />
+      ))
+  }
+
+  <!-- Bars — data-* attrs drive tooltip content.
+       Non-stacked bars use <rect rx/ry> for all-four-corner rounding (matches
+       Recharts radius={N}). Stacked segments keep <path> for per-corner control. -->
+  {
+    bars.map((b) =>
+      b.rect ? (
+        <rect
+          x={b.rect.x}
+          y={b.rect.y}
+          width={b.rect.w}
+          height={b.rect.h}
+          rx={b.rect.r}
+          ry={b.rect.r}
+          data-rxy={barRadius}
+          fill={b.fill}
+          fill-opacity={b.isActive ? 0.8 : 1}
+          stroke={b.isActive ? b.fill : "none"}
+          stroke-width={b.isActive ? 2 : 0}
+          data-sw={b.isActive ? "2" : undefined}
+          stroke-dasharray={b.isActive ? "4 4" : undefined}
+          stroke-dashoffset={b.isActive ? 4 : undefined}
+          data-series={b.seriesKey}
+          data-category={b.category}
+          data-value={b.value}
+          data-label={config[b.seriesKey]?.label ?? b.seriesKey}
+        />
+      ) : (
+        b.path && (
+          <path
+            d={b.path}
+            fill={b.fill}
+            fill-opacity={b.isActive ? 0.8 : 1}
+            stroke={b.isActive ? b.fill : "none"}
+            stroke-width={b.isActive ? 2 : 0}
+            data-sw={b.isActive ? "2" : undefined}
+            stroke-dasharray={b.isActive ? "4 4" : undefined}
+            stroke-dashoffset={b.isActive ? 4 : undefined}
+            data-series={b.seriesKey}
+            data-category={b.category}
+            data-value={b.value}
+            data-label={config[b.seriesKey]?.label ?? b.seriesKey}
+          />
+        )
+      ),
+    )
+  }
+
+  <!-- Optional per-bar value labels (above bar for vertical, right end for horizontal) -->
+  {
+    showLabels &&
+      !labelInside &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) && (
+            <text
+              x={b.labelX}
+              y={b.labelY}
+              text-anchor={b.labelAnchor}
+              fill="var(--foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {b.labelText}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Category key labels above/below bars (e.g. month names on the negative chart).
+       Each label is colored to match its bar and sits at the outer end of the bar. -->
+  {
+    showCategoryLabels &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) && (
+            <text
+              x={b.catLabelX}
+              y={b.catLabelY}
+              text-anchor={b.labelAnchor}
+              fill={b.catLabelFill}
+              font-size="12"
+              data-fs="12"
+              data-dy-px={b.catLabelDyPx}
+            >
+              {b.catLabelText}
+            </text>
+          ),
+      )
+  }
+
+  <!-- labelInside: category name inside bar (left) + value at right end -->
+  {
+    labelInside &&
+      bars.map(
+        (b) =>
+          (b.rect || b.path) &&
+          b.insideLabel && (
+            <>
+              <text
+                x={b.insideLabel.x}
+                y={b.insideLabel.y}
+                text-anchor="start"
+                dominant-baseline="central"
+                fill="var(--background)"
+                font-size="12"
+                font-weight="500"
+                data-fs="12"
+              >
+                {b.insideLabel.text}
+              </text>
+              <text
+                x={b.labelX}
+                y={b.labelY}
+                text-anchor="start"
+                dominant-baseline="central"
+                fill="var(--foreground)"
+                font-size="12"
+                font-weight="500"
+                data-fs="12"
+              >
+                {b.labelText}
+              </text>
+            </>
+          ),
+      )
+  }
+
+  <!-- Full-band hit targets — Recharts tooltip follows the nearest category, not just painted bars. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <rect
+          x={band.x}
+          y={band.y}
+          width={band.width}
+          height={band.height}
+          fill="transparent"
+          pointer-events="all"
+          data-index={band.index}
+          data-series={band.items[0]?.series}
+          data-category={band.category}
+          data-items={JSON.stringify(band.items)}
+          data-hide-label={hideTooltipLabel ? "1" : undefined}
+          data-hide-indicator={hideTooltipIndicator ? "1" : undefined}
+        />
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div class="pointer-events-none absolute inset-x-0 bottom-0">
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  const normalizeDenseBars = () => {
+    requestAnimationFrame(() => {
+      document.querySelectorAll<SVGSVGElement>('svg[data-bar-dense="true"]').forEach((svg) => {
+        const width = svg.clientWidth || svg.getBoundingClientRect().width;
+        const height = svg.clientHeight || svg.getBoundingClientRect().height;
+        if (!width || !height) return;
+
+        const left = 13;
+        const right = 13;
+        const top = 37;
+        const bottom = 30;
+        const plotWidth = width - left - right;
+        const plotHeight = height - top - bottom;
+        const plotBottom = top + plotHeight;
+        const bars = Array.from(
+          svg.querySelectorAll<SVGRectElement>("rect[data-value]:not([data-items])"),
+        );
+        if (!bars.length || plotWidth <= 0 || plotHeight <= 0) return;
+
+        svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+        const values = bars.map((bar) => Number(bar.dataset.value) || 0);
+        const max = Math.max(...values, 10);
+        const bandWidth = plotWidth / bars.length;
+        const barWidth = bandWidth * 0.78;
+
+        bars.forEach((bar, index) => {
+          const value = values[index] || 0;
+          const barHeight = (value / max) * plotHeight;
+          bar.setAttribute("x", String(left + bandWidth * index + (bandWidth - barWidth) / 2));
+          bar.setAttribute("y", String(plotBottom - barHeight));
+          bar.setAttribute("width", String(barWidth));
+          bar.setAttribute("height", String(barHeight));
+        });
+
+        const gridLines = Array.from(svg.querySelectorAll<SVGLineElement>("line[data-sw]"));
+        gridLines.forEach((line, index) => {
+          const ratio = gridLines.length > 1 ? index / (gridLines.length - 1) : 0;
+          const y = plotBottom - ratio * plotHeight;
+          line.setAttribute("x1", String(left));
+          line.setAttribute("x2", String(width - right));
+          line.setAttribute("y1", String(y));
+          line.setAttribute("y2", String(y));
+        });
+
+        Array.from(svg.querySelectorAll<SVGRectElement>("rect[data-items]")).forEach(
+          (hit, index) => {
+            hit.setAttribute("x", String(left + bandWidth * index));
+            hit.setAttribute("y", String(top));
+            hit.setAttribute("width", String(bandWidth));
+            hit.setAttribute("height", String(plotHeight));
+          },
+        );
+
+        const labels = Array.from(
+          svg.querySelectorAll<SVGTextElement>('text[data-dense-x-label="true"]'),
+        );
+        const first = width < 500 ? 11 : 2;
+        const step = width < 500 ? 20 : width < 900 ? 10 : 6;
+        labels.forEach((label, index) => {
+          const visible =
+            index === labels.length - 1 || (index >= first && (index - first) % step === 0);
+          label.style.display = visible ? "" : "none";
+          label.setAttribute("x", String(left + bandWidth * (index + 0.5)));
+          label.setAttribute("y", String(plotBottom + (width < 500 ? 12 : 20)));
+          label.setAttribute("font-size", "12");
+        });
+
+        svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+      });
+    });
+  };
+
+  // Hover cursor band (stacked/interactive) — self-contained here so it
+  // doesn't require changes to ChartTooltip.astro. Binds once per svg (guarded
+  // via dataset.cursorBound) since the interactive card toggles panels via
+  // `hidden` without recreating the DOM, so this can re-run harmlessly.
+  const setupBarCursor = () => {
+    document.querySelectorAll<SVGSVGElement>('svg[data-bar-cursor="true"]').forEach((svg) => {
+      if (svg.dataset.cursorBound === "true") return;
+      svg.dataset.cursorBound = "true";
+      const cursors = Array.from(svg.querySelectorAll<SVGRectElement>("rect[data-cursor-index]"));
+      svg.querySelectorAll<SVGRectElement>("rect[data-items]").forEach((hit) => {
+        const cursor = cursors.find((c) => c.dataset.cursorIndex === hit.dataset.index);
+        if (!cursor) return;
+        hit.addEventListener("mouseenter", () => {
+          for (const attr of ["x", "y", "width", "height"]) {
+            const v = hit.getAttribute(attr);
+            if (v !== null) cursor.setAttribute(attr, v);
+          }
+          cursor.setAttribute("opacity", "1");
+        });
+        hit.addEventListener("mouseleave", () => cursor.setAttribute("opacity", "0"));
+      });
+    });
+  };
+
+  normalizeDenseBars();
+  setupBarCursor();
+  window.addEventListener("resize", normalizeDenseBars);
+  document.addEventListener("astro:after-swap", normalizeDenseBars);
+  document.addEventListener("astro:after-swap", setupBarCursor);
+  document.addEventListener("starwind:init", normalizeDenseBars);
+  document.addEventListener("starwind:init", setupBarCursor);
+</script>

--- a/packages/core/src/components/chart/Chart.astro
+++ b/packages/core/src/components/chart/Chart.astro
@@ -1,0 +1,159 @@
+---
+import type { HTMLAttributes } from "astro/types";
+
+import type { ChartConfig } from "./variants";
+import { chart } from "./variants";
+
+type Props = HTMLAttributes<"div"> & {
+  config: ChartConfig;
+  id?: string;
+};
+
+// ponytail: module-level counter for stable SSR IDs; no Date/random = deterministic across renders
+let chartCounter = 0;
+
+const { config, id, class: className, ...rest } = Astro.props;
+const chartId = id ?? `starwind-chart-${chartCounter++}`;
+
+// Inject per-series color vars via inline style so SVG bars inherit them through CSS custom property cascade.
+// ponytail: inline style > [data-chart] <style is:inline set:html> — add the latter when light/dark theme
+// split per-series is needed (shadcn's themeObject config shape).
+const combinedStyle =
+  Object.entries(config)
+    .filter(([, cfg]) => cfg.color)
+    .map(([key, cfg]) => `--color-${key}: ${cfg.color}`)
+    .join("; ") || undefined;
+---
+
+<div
+  class={chart({ class: className })}
+  data-slot="chart"
+  data-chart={chartId}
+  style={combinedStyle}
+  {...rest}
+>
+  <slot />
+  {
+    /* Pre-paint counter-scale: runs synchronously during HTML parse (forcing a
+      layout read) so axis/value labels render at their final pixel size on the
+      FIRST paint instead of rendering tiny then jumping when the deferred module
+      script below runs. Uniform scale is exact for every chart except the two
+      anisotropic "interactive" area cards (factor≈1 there), which the module
+      scaler refines a frame later. ponytail: is:inline duplicates ~1KB/chart but
+      avoids a shared-global load-order dance; fine for a demo gallery. */
+  }
+  <script is:inline>
+    (function () {
+      var root = document.currentScript.parentElement;
+      var svgs = root.querySelectorAll("svg");
+      for (var i = 0; i < svgs.length; i++) {
+        var svg = svgs[i];
+        var vb = svg.viewBox && svg.viewBox.baseVal && svg.viewBox.baseVal.width;
+        if (!vb) continue;
+        // Prefer the container div's width — it resolves earlier than the SVG's
+        // own box mid-parse, so the pre-paint pass lands more often on the busy
+        // live page. Falls back to the SVG box; 0 → skip (module scaler + the
+        // hide-until-scaled CSS cover it a frame later).
+        var w = root.clientWidth || svg.clientWidth || svg.getBoundingClientRect().width;
+        if (!w) continue;
+        var f = vb / w;
+        svg.querySelectorAll("[data-fs]").forEach(function (t) {
+          t.setAttribute("font-size", ((Number(t.getAttribute("data-fs")) || 12) * f).toFixed(2));
+          var dy = t.getAttribute("data-dy-px");
+          if (dy !== null) t.setAttribute("dy", (Number(dy) * f).toFixed(2));
+        });
+        svg.querySelectorAll("[data-sw]").forEach(function (el) {
+          el.setAttribute(
+            "stroke-width",
+            ((Number(el.getAttribute("data-sw")) || 1) * f).toFixed(2),
+          );
+        });
+        svg.querySelectorAll("[data-r]").forEach(function (el) {
+          el.setAttribute("r", ((Number(el.getAttribute("data-r")) || 4) * f).toFixed(2));
+        });
+        svg.querySelectorAll("[data-rxy]").forEach(function (el) {
+          var v = ((Number(el.getAttribute("data-rxy")) || 0) * f).toFixed(2);
+          el.setAttribute("rx", v);
+          el.setAttribute("ry", v);
+        });
+        svg.setAttribute("data-scaled", ""); // reveal labels (hidden until now by CSS)
+      }
+    })();
+  </script>
+</div>
+
+<script>
+  // Keep axis/value labels a constant pixel size regardless of the chart's
+  // rendered width. Our SVGs use a fixed viewBox that scales to fit, so raw
+  // <text> would shrink/grow with the container (Recharts keeps it fixed).
+  // Counter-scale: font-size(userUnits) = targetPx * viewBoxWidth / clientWidth.
+  // Only glyph size changes; x/y positions stay anchored to data points.
+  const scaleSvgMetrics = (svg: SVGSVGElement) => {
+    const vb = svg.viewBox?.baseVal?.width;
+    if (!vb) return;
+    const w = svg.clientWidth || svg.getBoundingClientRect().width;
+    if (!w) return; // hidden panel (display:none) → skip until visible
+    const factor = vb / w;
+    svg.querySelectorAll<SVGTextElement>("[data-fs]").forEach((t) => {
+      const px = Number(t.getAttribute("data-fs")) || 12;
+      t.setAttribute("font-size", (px * factor).toFixed(2));
+      // Screen-constant vertical offset (px → viewBox units), e.g. negative-bar
+      // month labels that must keep a fixed gap below the bar at any width.
+      const dyPx = t.getAttribute("data-dy-px");
+      if (dyPx !== null) t.setAttribute("dy", (Number(dyPx) * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGElement>("[data-sw]").forEach((el) => {
+      const px = Number(el.getAttribute("data-sw")) || 1;
+      el.setAttribute("stroke-width", (px * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGCircleElement>("[data-r]").forEach((el) => {
+      const px = Number(el.getAttribute("data-r")) || 4;
+      el.setAttribute("r", (px * factor).toFixed(2));
+    });
+    svg.querySelectorAll<SVGRectElement>("[data-rxy]").forEach((el) => {
+      const px = Number(el.getAttribute("data-rxy")) || 0;
+      const value = (px * factor).toFixed(2);
+      el.setAttribute("rx", value);
+      el.setAttribute("ry", value);
+    });
+    svg.setAttribute("data-scaled", ""); // reveal labels (hidden until scaled by CSS)
+  };
+
+  const observed = new WeakSet<SVGSVGElement>();
+  const ro = new ResizeObserver((entries) => {
+    for (const e of entries) scaleSvgMetrics(e.target as SVGSVGElement);
+  });
+
+  const setupAxisScaling = () => {
+    document
+      .querySelectorAll<SVGSVGElement>('[data-slot="chart"] svg:not([data-area-chart])')
+      .forEach((svg) => {
+        scaleSvgMetrics(svg);
+        if (!observed.has(svg)) {
+          observed.add(svg);
+          ro.observe(svg);
+        }
+      });
+  };
+
+  setupAxisScaling();
+  document.addEventListener("astro:after-swap", setupAxisScaling);
+  document.addEventListener("starwind:init", setupAxisScaling);
+
+  // Safety net: never leave labels hidden. If any svg reached full load without
+  // a scaler running (e.g. an unforeseen path), reveal it — a flash beats
+  // permanently-invisible labels. Area/dense scalers set data-scaled themselves.
+  window.addEventListener("load", () => {
+    document
+      .querySelectorAll<SVGSVGElement>('[data-slot="chart"] svg:not([data-scaled])')
+      .forEach((svg) => {
+        // Only reveal svgs that are actually on-screen. A hidden-tab svg
+        // (width 0) can't be scaled yet; marking it data-scaled here would flash
+        // unscaled labels the moment its tab is opened. The ResizeObserver
+        // scales and reveals it when the panel becomes visible.
+        if (!(svg.clientWidth || svg.getBoundingClientRect().width)) return;
+        scaleSvgMetrics(svg);
+        svg.setAttribute("data-scaled", "");
+      });
+  });
+</script>

--- a/packages/core/src/components/chart/ChartLegend.astro
+++ b/packages/core/src/components/chart/ChartLegend.astro
@@ -1,0 +1,54 @@
+---
+import type { ChartConfig } from "./variants";
+import { chartLegend } from "./variants";
+
+type Props = {
+  config: ChartConfig;
+  series: string[];
+};
+
+const { config, series } = Astro.props;
+
+// Inline lucide icon paths for the variants whose legend uses icons instead of
+// colour swatches (area-icons, radar-icons). Keyed by the config `icon` name.
+const ICONS: Record<string, string> = {
+  "trending-up":
+    '<polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/>',
+  "trending-down":
+    '<polyline points="22 17 13.5 8.5 8.5 13.5 2 7"/><polyline points="16 17 22 17 22 11"/>',
+  "arrow-up-from-line": '<path d="m18 9-6-6-6 6"/><path d="M12 3v14"/><path d="M5 21h14"/>',
+  "arrow-down-from-line": '<path d="M19 3H5"/><path d="M12 21V7"/><path d="m6 15 6 6 6-6"/>',
+};
+---
+
+<div data-slot="chart-legend" class={chartLegend()}>
+  {
+    series.map((key) => {
+      const icon = config[key]?.icon;
+      return (
+        <div class="flex items-center gap-1.5">
+          {icon && ICONS[icon] ? (
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="text-muted-foreground h-3 w-3 shrink-0"
+              aria-hidden="true"
+              set:html={ICONS[icon]}
+            />
+          ) : (
+            <span
+              class="inline-block h-2 w-2 shrink-0 rounded-[2px]"
+              style={`background: var(--color-${key})`}
+            />
+          )}
+          <span>{config[key]?.label ?? key}</span>
+        </div>
+      );
+    })
+  }
+</div>

--- a/packages/core/src/components/chart/ChartTooltip.astro
+++ b/packages/core/src/components/chart/ChartTooltip.astro
@@ -8,6 +8,13 @@
 <script>
   type TooltipItem = { series: string; label: string; value: string; color?: string };
 
+  // Escape chart-derived text before it is spliced into innerHTML (XSS-safe with untrusted data).
+  const escapeHtml = (s: string) =>
+    String(s).replace(
+      /[&<>"']/g,
+      (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c]!,
+    );
+
   class ChartTooltipHandler {
     private chart: HTMLElement;
     private tooltip: HTMLElement;
@@ -87,13 +94,13 @@
             (item.color && item.color.trim()) || color || `var(--color-${item.series})`;
           const dot = hideIndicator
             ? ""
-            : `<span style="width:10px;height:10px;border-radius:2px;background:${swatch};flex-shrink:0"></span>`;
+            : `<span style="width:10px;height:10px;border-radius:2px;background:${escapeHtml(swatch)};flex-shrink:0"></span>`;
           return `
             <div style="display:flex;width:100%;align-items:center;gap:8px">
               ${dot}
               <div style="display:flex;flex:1;align-items:center;justify-content:space-between;line-height:1">
-                <span style="color:var(--muted-foreground)">${item.label}</span>
-                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${item.value}</span>
+                <span style="color:var(--muted-foreground)">${escapeHtml(item.label)}</span>
+                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${escapeHtml(item.value)}</span>
               </div>
             </div>
           `;
@@ -102,7 +109,7 @@
 
       this.content.innerHTML = `
         <div style="display:grid;gap:6px">
-          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${category}</div>`}
+          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${escapeHtml(category)}</div>`}
           ${rows}
         </div>
       `;

--- a/packages/core/src/components/chart/ChartTooltip.astro
+++ b/packages/core/src/components/chart/ChartTooltip.astro
@@ -1,0 +1,153 @@
+<div
+  data-slot="chart-tooltip"
+  class="border-border/50 bg-background pointer-events-none absolute z-50 hidden min-w-[8rem] items-start rounded-lg border px-2.5 py-1.5 text-xs shadow-xl"
+>
+  <div data-chart-tooltip-content></div>
+</div>
+
+<script>
+  type TooltipItem = { series: string; label: string; value: string; color?: string };
+
+  class ChartTooltipHandler {
+    private chart: HTMLElement;
+    private tooltip: HTMLElement;
+    private content: HTMLElement;
+
+    constructor(chart: HTMLElement) {
+      this.chart = chart;
+      this.tooltip = chart.querySelector('[data-slot="chart-tooltip"]')!;
+      this.content = this.tooltip.querySelector("[data-chart-tooltip-content]")!;
+      this.setup();
+    }
+
+    private setup(): void {
+      const svg = this.chart.querySelector("svg");
+      if (!svg || !this.tooltip || !this.content) return;
+
+      svg.addEventListener("mouseover", (e) => {
+        const target = (e.target as Element).closest(
+          "[data-series],[data-items]",
+        ) as HTMLElement | null;
+        if (!target) {
+          this.hide();
+          return;
+        }
+        this.show(target, e as MouseEvent);
+      });
+
+      svg.addEventListener("mousemove", (e) => {
+        if (!this.tooltip.classList.contains("hidden")) {
+          this.position(e as MouseEvent);
+        }
+      });
+
+      svg.addEventListener("mouseleave", () => this.hide());
+    }
+
+    private getItems(target: HTMLElement): TooltipItem[] {
+      if (target.dataset.items) {
+        try {
+          const parsed = JSON.parse(target.dataset.items);
+          if (Array.isArray(parsed)) {
+            return parsed
+              .map((item) => ({
+                series: String(item.series ?? ""),
+                label: String(item.label ?? item.series ?? ""),
+                value: String(item.value ?? ""),
+                color: String(item.color ?? ""),
+              }))
+              .filter((item) => item.series);
+          }
+        } catch {}
+      }
+
+      const series = target.dataset.series ?? "";
+      return [
+        {
+          series,
+          label: target.dataset.label ?? series,
+          value: target.dataset.value ?? "",
+          color: target.dataset.color ?? "",
+        },
+      ];
+    }
+
+    private show(target: HTMLElement, e: MouseEvent): void {
+      const category = target.dataset.category ?? "";
+      // Match shadcn's ChartTooltipContent hideLabel / hideIndicator flags.
+      const hideLabel = target.dataset.hideLabel === "1";
+      const hideIndicator = target.dataset.hideIndicator === "1";
+      const items = this.getItems(target);
+      const rows = items
+        .map((item) => {
+          const color = getComputedStyle(this.chart)
+            .getPropertyValue(`--color-${item.series}`)
+            .trim();
+          const swatch =
+            (item.color && item.color.trim()) || color || `var(--color-${item.series})`;
+          const dot = hideIndicator
+            ? ""
+            : `<span style="width:10px;height:10px;border-radius:2px;background:${swatch};flex-shrink:0"></span>`;
+          return `
+            <div style="display:flex;width:100%;align-items:center;gap:8px">
+              ${dot}
+              <div style="display:flex;flex:1;align-items:center;justify-content:space-between;line-height:1">
+                <span style="color:var(--muted-foreground)">${item.label}</span>
+                <span style="font-family:monospace;font-weight:500;font-variant-numeric:tabular-nums;color:var(--foreground)">${item.value}</span>
+              </div>
+            </div>
+          `;
+        })
+        .join("");
+
+      this.content.innerHTML = `
+        <div style="display:grid;gap:6px">
+          ${hideLabel ? "" : `<div style="font-weight:500;line-height:1">${category}</div>`}
+          ${rows}
+        </div>
+      `;
+
+      this.tooltip.classList.remove("hidden");
+      this.position(e);
+    }
+
+    private position(e: MouseEvent): void {
+      const chartRect = this.chart.getBoundingClientRect();
+      const tooltipW = this.tooltip.offsetWidth || 140;
+      const tooltipH = this.tooltip.offsetHeight || 60;
+      let x = e.clientX - chartRect.left + 8;
+      let y = e.clientY - chartRect.top - tooltipH - 8;
+
+      // Flip horizontally if would overflow right edge
+      if (x + tooltipW > chartRect.width) {
+        x = e.clientX - chartRect.left - tooltipW - 8;
+      }
+      // Clamp vertically
+      if (y + tooltipH > chartRect.height) {
+        y = e.clientY - chartRect.top - tooltipH - 8;
+      }
+      if (y < 0) y = 4;
+
+      this.tooltip.style.left = `${x}px`;
+      this.tooltip.style.top = `${y}px`;
+    }
+
+    private hide(): void {
+      this.tooltip.classList.add("hidden");
+    }
+  }
+
+  const tooltipInstances = new WeakMap<HTMLElement, ChartTooltipHandler>();
+
+  const setupChartTooltips = () => {
+    document.querySelectorAll<HTMLElement>('[data-slot="chart"]').forEach((chart) => {
+      if (chart.querySelector('[data-slot="chart-tooltip"]') && !tooltipInstances.has(chart)) {
+        tooltipInstances.set(chart, new ChartTooltipHandler(chart));
+      }
+    });
+  };
+
+  setupChartTooltips();
+  document.addEventListener("astro:after-swap", setupChartTooltips);
+  document.addEventListener("starwind:init", setupChartTooltips);
+</script>

--- a/packages/core/src/components/chart/LineChart.astro
+++ b/packages/core/src/components/chart/LineChart.astro
@@ -1,0 +1,483 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import { buildPath, type Point } from "./curves";
+import { rechartsAutoMax, xLabelStep } from "./scale";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  curve?: "linear" | "monotone" | "natural" | "step";
+  showDots?: boolean;
+  showGrid?: boolean;
+  showXAxis?: boolean;
+  showYAxis?: boolean;
+  showLabels?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  strokeWidth?: number;
+  /** Per-point dot color: name of a data field holding a CSS color string (e.g. "fill"). */
+  dotColorKey?: string;
+  /** "diamond" renders a git-commit-vertical style dot (vertical line + hollow circle). */
+  dotShape?: "circle" | "diamond";
+  /** Custom label key: data field whose value is looked up in config for the label text. */
+  labelKey?: string;
+  width?: number;
+  height?: number;
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  curve = "monotone",
+  showDots = true,
+  showGrid = true,
+  showXAxis = true,
+  showYAxis = false,
+  showLabels = false,
+  showLegend = false,
+  showTooltip = true,
+  strokeWidth = 2,
+  dotColorKey,
+  dotShape = "circle",
+  labelKey,
+  width = 297,
+  height = 167,
+} = Astro.props;
+
+// Internal coordinate space — defaults to Recharts' rendered aspect-video size.
+const W = width;
+const H = height;
+
+const padTop = showLabels ? (showXAxis ? 20 : 24) : showXAxis ? 0 : 24;
+const padRight = showXAxis ? 12 : 24;
+const padBottom = showXAxis ? 30 : 0;
+const padLeft = showYAxis ? 50 : showXAxis ? 12 : 24;
+
+const plotLeft = padLeft;
+const plotTop = padTop;
+const plotW = W - padLeft - padRight;
+const plotH = H - padTop - padBottom;
+const plotBottom = plotTop + plotH;
+const plotRight = plotLeft + plotW;
+
+const domainVals = data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+const domainMax = rechartsAutoMax(rawMax);
+
+// Points spread evenly across plot width; single-point case centers it
+const xOf = (i: number) =>
+  data.length > 1 ? plotLeft + (i / (data.length - 1)) * plotW : plotLeft + plotW / 2;
+const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+
+const tickCount = 5;
+const ticks = Array.from({ length: tickCount + 1 }, (_, i) => (i * domainMax) / tickCount);
+
+// Thin x-axis labels — approximates Recharts minTickGap for dense daily data.
+const isDenseXAxis = data.length > 20;
+const labelStride = xLabelStep(data.length, W);
+const xLabelStart = isDenseXAxis ? 2 : 0;
+const shouldShowXLabel = (i: number) =>
+  !isDenseXAxis ||
+  i === data.length - 1 ||
+  (i >= xLabelStart && i < data.length - labelStride && (i - xLabelStart) % labelStride === 0);
+
+type LinePoint = {
+  x: number;
+  y: number;
+  category: string;
+  value: string;
+  dotFill: string;
+  labelText: string;
+};
+type LineData = { key: string; pathD: string; points: LinePoint[] };
+
+const lines: LineData[] = series.map((key) => {
+  const pts: Point[] = data.map((d, i) => ({ x: xOf(i), y: yOf(Number(d[key] ?? 0)) }));
+  return {
+    key,
+    pathD: buildPath(pts, curve),
+    points: data.map((d, i) => ({
+      x: xOf(i),
+      y: yOf(Number(d[key] ?? 0)),
+      category: String(d[categoryKey]),
+      value: String(d[key] ?? 0),
+      dotFill: dotColorKey ? String(d[dotColorKey]) : `var(--color-${key})`,
+      labelText: labelKey
+        ? (config[String(d[labelKey])]?.label ?? String(d[labelKey]))
+        : String(d[key] ?? 0),
+    })),
+  };
+});
+
+const hitBands = data.map((d, di) => {
+  const x = xOf(di);
+  const left = di === 0 ? plotLeft : (xOf(di - 1) + x) / 2;
+  const right = di === data.length - 1 ? plotRight : (x + xOf(di + 1)) / 2;
+  return {
+    x: left,
+    width: right - left,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(d[key] ?? 0),
+    })),
+    dots: lines.map((line) => ({ key: line.key, point: line.points[di] })),
+  };
+});
+
+const ariaLabel = `Line chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+const denseValues = isDenseXAxis
+  ? JSON.stringify(data.map((d) => series.map((key) => Number(d[key] ?? 0))))
+  : undefined;
+---
+
+<svg
+  data-line-dense={isDenseXAxis ? "true" : undefined}
+  data-line-values={denseValues}
+  data-line-domain={isDenseXAxis ? domainMax : undefined}
+  data-line-curve={isDenseXAxis ? curve : undefined}
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  height="100%"
+  preserveAspectRatio="none"
+  overflow="visible"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <style>
+    [data-line-hit] [data-active-dot] {
+      opacity: 0;
+      pointer-events: none;
+    }
+    [data-line-hit]:hover [data-active-dot] {
+      opacity: 1;
+    }
+  </style>
+
+  <!-- Horizontal gridlines -->
+  {
+    showGrid &&
+      ticks.map((t, i) => (
+        <line
+          data-grid-line={i}
+          x1={plotLeft}
+          x2={plotRight}
+          y1={yOf(t)}
+          y2={yOf(t)}
+          stroke="var(--border)"
+          stroke-opacity="0.5"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+
+  <!-- Y-axis value labels -->
+  {
+    showYAxis &&
+      ticks.map((t) => (
+        <text
+          x={plotLeft - 6}
+          y={yOf(t) + 4}
+          text-anchor="end"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {t}
+        </text>
+      ))
+  }
+
+  <!-- X-axis category labels -->
+  {
+    showXAxis &&
+      data.map(
+        (d, i) =>
+          (isDenseXAxis || shouldShowXLabel(i)) && (
+            <text
+              data-x-label={i}
+              x={xOf(i)}
+              y={plotBottom + 14}
+              dy="0.71em"
+              text-anchor="middle"
+              fill="var(--muted-foreground)"
+              font-size="12"
+              data-fs="12"
+            >
+              {String(d[categoryKey])}
+            </text>
+          ),
+      )
+  }
+
+  <!-- Line paths — one per series -->
+  {
+    lines.map((line) => (
+      <path
+        data-line-path={line.key}
+        d={line.pathD}
+        fill="none"
+        stroke={`var(--color-${line.key})`}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth}
+        stroke-linejoin="round"
+        stroke-linecap="round"
+      />
+    ))
+  }
+
+  <!-- Visible dots (optional) -->
+  {
+    showDots &&
+      lines.map((line) =>
+        dotShape === "diamond"
+          ? line.points.map((pt) => (
+              <g>
+                <line
+                  x1={pt.x}
+                  y1={pt.y - 12}
+                  x2={pt.x}
+                  y2={pt.y + 12}
+                  stroke={`var(--color-${line.key})`}
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  data-sw="2"
+                />
+                <circle
+                  cx={pt.x}
+                  cy={pt.y}
+                  r="3"
+                  fill="var(--foreground)"
+                  stroke="var(--background)"
+                  stroke-width="2"
+                  data-r="3"
+                  data-sw="2"
+                />
+              </g>
+            ))
+          : line.points.map((pt) => (
+              <circle
+                cx={pt.x}
+                cy={pt.y}
+                r={dotColorKey ? "5" : "3"}
+                data-r={dotColorKey ? "5" : "3"}
+                fill={pt.dotFill}
+                stroke={pt.dotFill}
+                stroke-width={dotColorKey ? "1" : "2"}
+                data-sw={dotColorKey ? "1" : "2"}
+              />
+            )),
+      )
+  }
+
+  <!-- Full-height hit bands — Recharts tooltip follows the nearest x-axis point. -->
+  {
+    showTooltip &&
+      hitBands.map((band) => (
+        <g data-line-hit>
+          <rect
+            x={band.x}
+            y={plotTop}
+            width={band.width}
+            height={plotH}
+            fill="transparent"
+            pointer-events="all"
+            data-series={band.items[0]?.series}
+            data-category={band.category}
+            data-items={JSON.stringify(band.items)}
+          />
+          {band.dots.map(({ key, point }) => (
+            <circle
+              cx={point.x}
+              cy={point.y}
+              r="6"
+              data-r="6"
+              fill={`var(--color-${key})`}
+              stroke="var(--background)"
+              stroke-width="2"
+              data-sw="2"
+              data-active-dot
+            />
+          ))}
+        </g>
+      ))
+  }
+
+  <!-- Value/custom labels — pointer-events none so they don't block tooltip hit targets -->
+  {
+    showLabels &&
+      lines.map((line) =>
+        line.points.map((pt, i) => (
+          <text
+            x={pt.x}
+            y={pt.y - 10}
+            text-anchor={i === 0 ? "start" : i === line.points.length - 1 ? "end" : "middle"}
+            fill="var(--foreground)"
+            font-size="12"
+            font-weight="500"
+            pointer-events="none"
+            data-fs="12"
+          >
+            {pt.labelText}
+          </text>
+        )),
+      )
+  }
+</svg>
+
+{showLegend && <ChartLegend config={config} series={series} />}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  const installDenseLineReflow = () => {
+    const win = window as typeof window & { __starwindDenseLineReflow?: boolean };
+    if (win.__starwindDenseLineReflow) return;
+    win.__starwindDenseLineReflow = true;
+
+    const linePath = (pts: number[][]) =>
+      pts.length
+        ? `M${pts[0][0]},${pts[0][1]}` +
+          pts
+            .slice(1)
+            .map((p) => ` L${p[0]},${p[1]}`)
+            .join("")
+        : "";
+
+    const stepPath = (pts: number[][]) => {
+      if (!pts.length) return "";
+      let d = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 1; i < pts.length; i++) d += ` H${pts[i][0]} V${pts[i][1]}`;
+      return d;
+    };
+
+    const monotonePath = (pts: number[][]) => {
+      if (pts.length < 2) return pts.length === 1 ? `M${pts[0][0]},${pts[0][1]}` : "";
+      const n = pts.length;
+      const dxs = pts.slice(0, -1).map((p, i) => pts[i + 1][0] - p[0]);
+      const dys = pts.slice(0, -1).map((p, i) => pts[i + 1][1] - p[1]);
+      const tan = new Array(n).fill(0);
+      tan[0] = dxs[0] ? dys[0] / dxs[0] : 0;
+      tan[n - 1] = dxs[n - 2] ? dys[n - 2] / dxs[n - 2] : 0;
+      for (let i = 1; i < n - 1; i++) {
+        const s0 = dxs[i - 1] ? dys[i - 1] / dxs[i - 1] : 0;
+        const s1 = dxs[i] ? dys[i] / dxs[i] : 0;
+        tan[i] = s0 * s1 <= 0 ? 0 : (s0 + s1) / 2;
+      }
+      for (let i = 0; i < n - 1; i++) {
+        const s = dxs[i] ? dys[i] / dxs[i] : 0;
+        if (Math.abs(s) < 1e-10) {
+          tan[i] = tan[i + 1] = 0;
+          continue;
+        }
+        const a = tan[i] / s;
+        const b = tan[i + 1] / s;
+        const h = Math.sqrt(a * a + b * b);
+        if (h > 3) {
+          tan[i] = (3 / h) * a * s;
+          tan[i + 1] = (3 / h) * b * s;
+        }
+      }
+      let d = `M${pts[0][0]},${pts[0][1]}`;
+      for (let i = 0; i < n - 1; i++) {
+        const dx = dxs[i];
+        const cp1x = pts[i][0] + dx / 3;
+        const cp1y = pts[i][1] + (tan[i] * dx) / 3;
+        const cp2x = pts[i + 1][0] - dx / 3;
+        const cp2y = pts[i + 1][1] - (tan[i + 1] * dx) / 3;
+        d += ` C${cp1x.toFixed(1)},${cp1y.toFixed(1)} ${cp2x.toFixed(1)},${cp2y.toFixed(1)} ${pts[i + 1][0].toFixed(1)},${pts[i + 1][1].toFixed(1)}`;
+      }
+      return d;
+    };
+
+    const buildPath = (pts: number[][], curve: string) => {
+      if (curve === "linear") return linePath(pts);
+      if (curve === "step") return stepPath(pts);
+      return monotonePath(pts);
+    };
+
+    const labelPlan = (width: number, count: number) => {
+      if (width < 500) return { start: 11, step: 20, last: count - 1 };
+      if (width < 800) return { start: 2, step: 10, last: count - 1 };
+      return { start: 2, step: 6, last: count - 1 };
+    };
+
+    const reflow = (svg: SVGSVGElement) => {
+      const box = svg.getBoundingClientRect();
+      const width = box.width;
+      const height = box.height;
+      if (!width || !height) return;
+
+      const values = JSON.parse(svg.dataset.lineValues || "[]") as number[][];
+      const domainMax = Number(svg.dataset.lineDomain) || 1;
+      if (!values.length) return;
+
+      const padLeft = 12;
+      const padRight = 12;
+      const padTop = 0;
+      const padBottom = 30;
+      const plotW = width - padLeft - padRight;
+      const plotH = height - padTop - padBottom;
+      const plotBottom = padTop + plotH;
+      const xOf = (i: number) => padLeft + (i / (values.length - 1)) * plotW;
+      const yOf = (v: number) => plotBottom - (v / domainMax) * plotH;
+      const curve = svg.dataset.lineCurve || "monotone";
+
+      svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+      svg.querySelectorAll<SVGLineElement>("[data-grid-line]").forEach((line) => {
+        const i = Number(line.dataset.gridLine) || 0;
+        const y = yOf((i * domainMax) / 5);
+        line.setAttribute("x1", String(padLeft));
+        line.setAttribute("x2", String(width - padRight));
+        line.setAttribute("y1", String(y));
+        line.setAttribute("y2", String(y));
+      });
+
+      svg.querySelectorAll<SVGPathElement>("[data-line-path]").forEach((path, seriesIndex) => {
+        const pts = values.map((row, i) => [xOf(i), yOf(Number(row[seriesIndex] ?? 0))]);
+        path.setAttribute("d", buildPath(pts, curve));
+        path.setAttribute("stroke-width", "2");
+      });
+
+      const plan = labelPlan(width, values.length);
+      svg.querySelectorAll<SVGTextElement>("[data-x-label]").forEach((text) => {
+        const i = Number(text.dataset.xLabel);
+        const visible =
+          i === plan.last ||
+          (i >= plan.start && i < plan.last - plan.step / 2 && (i - plan.start) % plan.step === 0);
+        text.style.display = visible ? "" : "none";
+        text.setAttribute("x", String(xOf(i)));
+        text.setAttribute("y", String(plotBottom + 14));
+        text.setAttribute("font-size", "12");
+      });
+    };
+
+    const reflowAll = () => {
+      document.querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]').forEach(reflow);
+    };
+    const schedule = () => requestAnimationFrame(reflowAll);
+
+    const ro = new ResizeObserver(schedule);
+    document
+      .querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]')
+      .forEach((svg) => ro.observe(svg));
+    schedule();
+    document.addEventListener("starwind:init", schedule);
+    document.addEventListener("astro:after-swap", () => {
+      document
+        .querySelectorAll<SVGSVGElement>('svg[data-line-dense="true"]')
+        .forEach((svg) => ro.observe(svg));
+      schedule();
+    });
+  };
+
+  installDenseLineReflow();
+</script>

--- a/packages/core/src/components/chart/PieChart.astro
+++ b/packages/core/src/components/chart/PieChart.astro
@@ -149,12 +149,15 @@ function buildSlicesFor(
   // unchanged but slices land exactly where shadcn's do.
   let theta = 0; // Recharts angle (radians), CCW from 3 o'clock
   const halfPad = padRad / 2;
-  let idx = 0;
+  let dataIdx = 0;
 
   for (const d of sliceData) {
     const name = String(d[nameKey]);
     const val = Number(d[sliceDataKey] ?? 0);
-    if (val <= 0) continue;
+    if (val <= 0) {
+      dataIdx++;
+      continue;
+    }
     const pct = sliceTotal > 0 ? val / sliceTotal : 0;
     const sweep = pct * 2 * Math.PI;
     const thetaStart = theta + halfPad;
@@ -164,7 +167,7 @@ function buildSlicesFor(
     const midA = -(thetaStart + thetaEnd) / 2;
 
     // Active slice gets a 10px outer-radius bump (donut-active / interactive).
-    const sliceOuter = activIdx === idx ? oR + 10 : oR;
+    const sliceOuter = activIdx === dataIdx ? oR + 10 : oR;
 
     const labelR = sliceOuter + 16;
     const lx = fmt(cx + Math.cos(midA) * labelR);
@@ -198,7 +201,7 @@ function buildSlicesFor(
     });
 
     theta += sweep;
-    idx++;
+    dataIdx++;
   }
   return result;
 }

--- a/packages/core/src/components/chart/PieChart.astro
+++ b/packages/core/src/components/chart/PieChart.astro
@@ -1,0 +1,363 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  nameKey: string;
+  dataKey: string;
+  donut?: boolean;
+  innerRadiusRatio?: number;
+  showLabels?: boolean;
+  labelLine?: boolean;
+  /** What outside labels display: visitor count (default), config name, or percent. */
+  labelContent?: "value" | "name" | "percent";
+  /** Inside-slice labels (label-list variant). */
+  showInnerLabels?: boolean;
+  centerText?: string;
+  centerLabel?: string;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  padAngle?: number;
+  /** Stroke width on slice borders; set to 0 for separator-none. */
+  strokeWidth?: number;
+  /** If set, this slice index gets outerRadius + 10 (donut-active/interactive). */
+  activeIndex?: number;
+  /** Second ring data for stacked variant (outer ring). Requires dataKey2. */
+  data2?: Record<string, string | number>[];
+  dataKey2?: string;
+};
+
+const {
+  data,
+  config,
+  nameKey,
+  dataKey,
+  donut = false,
+  innerRadiusRatio = 0.6,
+  showLabels = false,
+  labelLine = false,
+  labelContent = "value",
+  showInnerLabels = false,
+  centerText,
+  centerLabel,
+  showLegend = true,
+  showTooltip = true,
+  padAngle = 0,
+  // No separator by default: shadcn's ChartContainer maps Recharts' default
+  // stroke='#fff' to stroke-transparent, so slices touch seamlessly.
+  strokeWidth = 0,
+  activeIndex,
+  data2,
+  dataKey2,
+} = Astro.props;
+
+// Square viewBox — use <Chart class="mx-auto aspect-square max-w-[300px]"> in the demo.
+const W = 260;
+const H = 260;
+const cx = W / 2;
+const cy = showLegend ? 108 : H / 2;
+// ~80% of the viewBox half (130) matches shadcn's plain pie proportion. Recharts
+// reserves vertical space for an in-chart legend, so the legend variant uses a
+// smaller radius inside the same square SVG.
+const outerR = showLegend ? 82.5 : 104;
+const innerR = donut ? outerR * innerRadiusRatio : 0;
+const padRad = (padAngle * Math.PI) / 180;
+
+// Round to 2 dp to keep SVG path strings tidy.
+function fmt(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+type Slice = {
+  path: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  labelX: number;
+  labelY: number;
+  labelLineStartX: number;
+  labelLineStartY: number;
+  labelLineEndX: number;
+  labelLineEndY: number;
+  labelAnchor: "start" | "middle" | "end";
+  percent: string;
+  innerLabelX: number;
+  innerLabelY: number;
+};
+
+// Builds an arc path. Outer arc CW, inner arc CCW (nonzero winding for donut holes).
+function buildArcPath(startA: number, endA: number, oR: number, iR: number): string {
+  const sweep = endA - startA;
+  const isFull = sweep >= 2 * Math.PI - 0.0001;
+
+  if (isFull) {
+    const ox1 = fmt(cx - oR),
+      ox2 = fmt(cx + oR),
+      oy = fmt(cy);
+    const outer = `M ${ox1} ${oy} A ${oR} ${oR} 0 1 1 ${ox2} ${oy} A ${oR} ${oR} 0 1 1 ${ox1} ${oy} Z`;
+    if (iR > 0) {
+      const ix1 = fmt(cx - iR),
+        ix2 = fmt(cx + iR);
+      const inner = `M ${ix1} ${oy} A ${iR} ${iR} 0 1 0 ${ix2} ${oy} A ${iR} ${iR} 0 1 0 ${ix1} ${oy} Z`;
+      return `${outer} ${inner}`;
+    }
+    return outer;
+  }
+
+  const largeArc = sweep > Math.PI ? 1 : 0;
+  const cos1 = Math.cos(startA),
+    sin1 = Math.sin(startA);
+  const cos2 = Math.cos(endA),
+    sin2 = Math.sin(endA);
+  const osx = fmt(cx + oR * cos1),
+    osy = fmt(cy + oR * sin1);
+  const oex = fmt(cx + oR * cos2),
+    oey = fmt(cy + oR * sin2);
+
+  if (iR > 0) {
+    const iex = fmt(cx + iR * cos2),
+      iey = fmt(cy + iR * sin2);
+    const isx = fmt(cx + iR * cos1),
+      isy = fmt(cy + iR * sin1);
+    return (
+      `M ${osx} ${osy} A ${oR} ${oR} 0 ${largeArc} 1 ${oex} ${oey} ` +
+      `L ${iex} ${iey} A ${iR} ${iR} 0 ${largeArc} 0 ${isx} ${isy} Z`
+    );
+  }
+
+  return `M ${fmt(cx)} ${fmt(cy)} L ${osx} ${osy} A ${oR} ${oR} 0 ${largeArc} 1 ${oex} ${oey} Z`;
+}
+
+function buildSlicesFor(
+  sliceData: Record<string, string | number>[],
+  sliceDataKey: string,
+  oR: number,
+  iR: number,
+  activIdx?: number,
+): Slice[] {
+  const sliceTotal = sliceData.reduce((s, d) => s + Number(d[sliceDataKey] ?? 0), 0);
+  const result: Slice[] = [];
+  // Recharts <Pie> defaults: startAngle=0 (3 o'clock) sweeping COUNTERclockwise
+  // (endAngle=360). Its polarToCartesian uses -angle, so a Recharts angle θ maps
+  // to SVG angle -θ (SVG y is down). We accumulate θ CCW from 0, then hand each
+  // slice's [θStart,θEnd] to buildArcPath as the equivalent positive-sweep SVG
+  // arc (-θEnd → -θStart) so the existing winding / largeArc logic is reused
+  // unchanged but slices land exactly where shadcn's do.
+  let theta = 0; // Recharts angle (radians), CCW from 3 o'clock
+  const halfPad = padRad / 2;
+  let idx = 0;
+
+  for (const d of sliceData) {
+    const name = String(d[nameKey]);
+    const val = Number(d[sliceDataKey] ?? 0);
+    if (val <= 0) continue;
+    const pct = sliceTotal > 0 ? val / sliceTotal : 0;
+    const sweep = pct * 2 * Math.PI;
+    const thetaStart = theta + halfPad;
+    const thetaEnd = theta + sweep - halfPad;
+    const startA = -thetaEnd;
+    const endA = -thetaStart;
+    const midA = -(thetaStart + thetaEnd) / 2;
+
+    // Active slice gets a 10px outer-radius bump (donut-active / interactive).
+    const sliceOuter = activIdx === idx ? oR + 10 : oR;
+
+    const labelR = sliceOuter + 16;
+    const lx = fmt(cx + Math.cos(midA) * labelR);
+    const ly = fmt(cy + Math.sin(midA) * labelR);
+    const cosM = Math.cos(midA);
+    const anchor: "start" | "middle" | "end" =
+      cosM > 0.1 ? "start" : cosM < -0.1 ? "end" : "middle";
+    const labelLineEndX = fmt(lx + (anchor === "start" ? -4 : anchor === "end" ? 4 : 0));
+
+    // Inner label at midpoint of the slice's radial depth (label-list variant).
+    const innerLabelR = iR > 0 ? (iR + sliceOuter) / 2 : sliceOuter * 0.6;
+    const ilx = fmt(cx + Math.cos(midA) * innerLabelR);
+    const ily = fmt(cy + Math.sin(midA) * innerLabelR);
+
+    result.push({
+      path: buildArcPath(startA, endA, sliceOuter, iR),
+      seriesKey: name,
+      category: name,
+      value: String(val),
+      label: config[name]?.label ?? name,
+      labelX: lx,
+      labelY: ly + 4,
+      labelLineStartX: fmt(cx + Math.cos(midA) * sliceOuter),
+      labelLineStartY: fmt(cy + Math.sin(midA) * sliceOuter),
+      labelLineEndX,
+      labelLineEndY: ly,
+      labelAnchor: anchor,
+      percent: `${Math.round(pct * 100)}%`,
+      innerLabelX: ilx,
+      innerLabelY: ily + 4,
+    });
+
+    theta += sweep;
+    idx++;
+  }
+  return result;
+}
+
+// ponytail: stacked uses fixed radii (60 inner, 70/90 outer) matching shadcn proportions.
+const isStacked = data2 !== undefined && dataKey2 !== undefined;
+const mainOuterR = isStacked ? 60 : outerR;
+const mainInnerR = isStacked ? 0 : innerR;
+
+const slices = buildSlicesFor(
+  data,
+  dataKey,
+  mainOuterR,
+  mainInnerR,
+  isStacked ? undefined : activeIndex,
+);
+const slices2 =
+  isStacked && data2 && dataKey2 ? buildSlicesFor(data2, dataKey2, 90, 70, undefined) : [];
+
+const seriesKeys = slices.map((s) => s.seriesKey);
+const ariaLabel = `Pie chart: ${seriesKeys.map((k) => `${config[k]?.label ?? k} ${slices.find((s) => s.seriesKey === k)?.value}`).join(", ")}`;
+
+function getLabelText(s: Slice): string {
+  if (labelContent === "name") return s.label;
+  if (labelContent === "percent") return s.percent;
+  return s.value;
+}
+
+const strokeAttr = strokeWidth > 0 ? "transparent" : "none";
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Main slices (or inner ring for stacked) — data-* attrs drive tooltip -->
+  {
+    slices.map((s) => (
+      <path
+        d={s.path}
+        fill={`var(--color-${s.seriesKey})`}
+        stroke={strokeAttr}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth > 0 ? strokeWidth : undefined}
+        data-series={s.seriesKey}
+        data-category={s.category}
+        data-value={s.value}
+        data-label={s.label}
+      />
+    ))
+  }
+
+  <!-- Outer ring (stacked variant) -->
+  {
+    slices2.map((s) => (
+      <path
+        d={s.path}
+        fill={`var(--color-${s.seriesKey})`}
+        stroke={strokeAttr}
+        stroke-width={strokeWidth}
+        data-sw={strokeWidth > 0 ? strokeWidth : undefined}
+        data-series={s.seriesKey}
+        data-category={s.category}
+        data-value={s.value}
+        data-label={s.label}
+      />
+    ))
+  }
+
+  <!-- Outside labels (label / label-custom variants) -->
+  {
+    showLabels &&
+      labelLine &&
+      slices.map((s) => (
+        <polyline
+          points={`${s.labelLineStartX},${s.labelLineStartY} ${s.labelLineEndX},${s.labelLineEndY}`}
+          fill="none"
+          stroke={`var(--color-${s.seriesKey})`}
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showLabels &&
+      slices.map((s) => (
+        <text
+          x={s.labelX}
+          y={s.labelY}
+          text-anchor={s.labelAnchor}
+          fill="var(--foreground)"
+          font-size="12"
+          font-weight="500"
+          data-fs="12"
+        >
+          {getLabelText(s)}
+        </text>
+      ))
+  }
+
+  <!-- Inside labels (label-list variant — browser name centred in each slice) -->
+  {
+    showInnerLabels &&
+      slices.map((s) => (
+        <text
+          x={s.innerLabelX}
+          y={s.innerLabelY}
+          text-anchor="middle"
+          fill="var(--background)"
+          font-size="12"
+          font-weight="500"
+          data-fs="12"
+        >
+          {s.label}
+        </text>
+      ))
+  }
+
+  <!-- Donut center text (donut-text / interactive variants) -->
+  {
+    donut && centerText && (
+      <g>
+        <text
+          x={cx}
+          y={cy}
+          text-anchor="middle"
+          dominant-baseline="middle"
+          font-size="12"
+          data-fs="12"
+        >
+          <tspan
+            x={cx}
+            y={centerLabel ? cy : cy + 8}
+            fill="var(--foreground)"
+            font-size="30"
+            font-weight="700"
+            data-fs="30"
+          >
+            {centerText}
+          </tspan>
+          {centerLabel && (
+            <tspan x={cx} y={cy + 24} fill="var(--muted-foreground)" font-size="12" data-fs="12">
+              {centerLabel}
+            </tspan>
+          )}
+        </text>
+      </g>
+    )
+  }
+</svg>
+
+{
+  showLegend && (
+    <div class="pointer-events-none absolute inset-x-0 bottom-0 [&_[data-slot=chart-legend]]:-translate-y-2 [&_[data-slot=chart-legend]>div]:basis-1/4 [&_[data-slot=chart-legend]>div]:justify-center">
+      <ChartLegend config={config} series={seriesKeys} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}

--- a/packages/core/src/components/chart/RadarChart.astro
+++ b/packages/core/src/components/chart/RadarChart.astro
@@ -1,0 +1,420 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  categoryKey: string;
+  series: string[];
+  gridType?: "polygon" | "circle";
+  gridLevels?: number;
+  showAxisLabels?: boolean;
+  fillOpacity?: number;
+  showDots?: boolean;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  /** Hide both grid rings and spokes (grid-none variant). */
+  showGrid?: boolean;
+  /** Hide radial spokes while keeping rings (lines-only, grid-custom, grid-circle-no-lines). */
+  showSpokes?: boolean;
+  /** Fill grid rings with the primary series color at 0.2 opacity, outermost-first for additive center effect (grid-fill, grid-circle-fill). */
+  gridFill?: boolean;
+  /** Explicit grid radii, matching Recharts PolarGrid polarRadius. */
+  polarRadius?: number[];
+  /** Show numeric value ticks along the axis between axis 0 and axis 1 (radius-axis variant). */
+  showRadiusAxis?: boolean;
+  /** Replace axis labels with value/value + month-name two-line labels (label-custom variant). */
+  showDataLabels?: boolean;
+  /** Per-series fill-opacity overrides. Index 0 = first series. Falls back to fillOpacity for unspecified indices. */
+  fillOpacities?: number[];
+};
+
+const {
+  data,
+  config,
+  categoryKey,
+  series,
+  gridType = "polygon",
+  gridLevels = 4,
+  showAxisLabels = true,
+  fillOpacity: fillOpacityProp,
+  fillOpacities,
+  showDots = true,
+  showLegend = false,
+  showTooltip = true,
+  showGrid = true,
+  showSpokes = true,
+  gridFill = false,
+  polarRadius,
+  showRadiusAxis = false,
+  showDataLabels = false,
+} = Astro.props;
+
+// Default opacity: single series looks richer at 0.6; overlapping polygons need less
+const fillOpacity = fillOpacityProp ?? (series.length > 1 ? 0.4 : 0.6);
+
+const W = 250;
+const H = 250;
+const cx = W / 2;
+const cy = H / 2;
+const maxR = showDataLabels ? 92 : 96;
+
+const N = data.length;
+
+// Compute domain max across all plotted values
+const domainVals = data.flatMap((d) => series.map((s) => Number(d[s] ?? 0)));
+const rawMax = Math.max(...domainVals, 0);
+
+// Recharts' PolarRadiusAxis defaults to domain [0, dataMax] when the axis is
+// hidden, so the largest value sits ON the outer ring (don't nice-round, or the
+// polygon shrinks). When the radius axis IS shown, Recharts nice-rounds the
+// domain so ticks are round (305 -> 320 = 4 × 80), and the polygon sits ~0.95.
+const domainMax = showRadiusAxis
+  ? Math.max(10, Math.ceil(rawMax / gridLevels / 10) * 10 * gridLevels)
+  : rawMax > 0
+    ? rawMax
+    : 10;
+
+// Polar → cartesian; axis 0 starts at top (-π/2), proceeds clockwise
+function polarToXY(r: number, axisIndex: number): [number, number] {
+  const angle = -Math.PI / 2 + axisIndex * ((2 * Math.PI) / N);
+  return [cx + r * Math.cos(angle), cy + r * Math.sin(angle)];
+}
+
+// Points string for a grid ring at a given radius
+function ringPoints(r: number): string {
+  return Array.from({ length: N }, (_, k) => polarToXY(r, k).join(",")).join(" ");
+}
+
+// Points string for a series polygon
+function seriesPoints(key: string): string {
+  return data
+    .map((d, k) => {
+      const r = (Number(d[key] ?? 0) / domainMax) * maxR;
+      return polarToXY(r, k).join(",");
+    })
+    .join(" ");
+}
+
+type Vertex = {
+  x: number;
+  y: number;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+};
+
+// Pre-compute all vertices for dots and tooltip hit areas
+const vertices: Vertex[] = series.flatMap((key) =>
+  data.map((d, k) => {
+    const val = Number(d[key] ?? 0);
+    const [x, y] = polarToXY((val / domainMax) * maxR, k);
+    return {
+      x,
+      y,
+      seriesKey: key,
+      category: String(d[categoryKey]),
+      value: String(val),
+      label: config[key]?.label ?? key,
+    };
+  }),
+);
+
+// Axis labels just outside the outer ring
+const labelR = maxR + 8;
+const axisLabels = data.map((d, k) => {
+  const [x, y] = polarToXY(labelR, k);
+  return {
+    x,
+    y,
+    anchor: x > cx + 1 ? "start" : x < cx - 1 ? "end" : "middle",
+    text: String(d[categoryKey]),
+    // seriesVals used by showDataLabels to render value/value above the month name
+    seriesVals: series.map((s) => String(d[s] ?? "")),
+  };
+});
+
+const hitWedges = data.map((d, k) => {
+  const [x1, y1] = polarToXY(labelR + 16, k - 0.5);
+  const [x2, y2] = polarToXY(labelR + 16, k + 0.5);
+  return {
+    points: `${cx},${cy} ${x1},${y1} ${x2},${y2}`,
+    category: String(d[categoryKey]),
+    items: series.map((key) => ({
+      series: key,
+      label: config[key]?.label ?? key,
+      value: String(d[key] ?? 0),
+    })),
+  };
+});
+
+// Radius axis: ticks placed between axis 0 and axis 1 (~30° from top, matching recharts angle=60)
+const radiusAxisAngle = -Math.PI / 2 + 0.5 * ((2 * Math.PI) / N);
+// gridLevels+1 ticks: 0 at center through domainMax at outer ring (matches recharts PolarRadiusAxis default)
+const radiusTicks = showRadiusAxis
+  ? Array.from({ length: gridLevels + 1 }, (_, i) => {
+      const r = (i / gridLevels) * maxR;
+      return {
+        x: cx + r * Math.cos(radiusAxisAngle),
+        y: cy + r * Math.sin(radiusAxisAngle),
+        tickValue: Math.round((i / gridLevels) * domainMax),
+      };
+    })
+  : ([] as { x: number; y: number; tickValue: number }[]);
+
+// gridFill: render outermost ring first so inner rings layer on top → additive center opacity
+const gridRadii =
+  polarRadius ?? Array.from({ length: gridLevels + 1 }, (_, i) => (i / gridLevels) * maxR);
+const visibleGridRadii = gridFill ? [...gridRadii].reverse() : gridRadii;
+
+const ariaLabel = `Radar chart of ${series.map((s) => config[s]?.label ?? s).join(", ")} by ${categoryKey}`;
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+  style="display:block"
+>
+  <!-- Concentric grid rings -->
+  {
+    showGrid &&
+      visibleGridRadii.map((r) => {
+        // gridFill: filled shapes, no stroke; normal: stroked outline, no fill
+        return gridType === "circle" ? (
+          <circle
+            cx={cx}
+            cy={cy}
+            r={r}
+            fill={gridFill ? `var(--color-${series[0]})` : "none"}
+            fill-opacity={gridFill ? 0.2 : undefined}
+            stroke={gridFill ? "none" : "var(--border)"}
+            stroke-width="1"
+            data-sw="1"
+          />
+        ) : (
+          <polygon
+            points={ringPoints(r)}
+            fill={gridFill ? `var(--color-${series[0]})` : "none"}
+            fill-opacity={gridFill ? 0.2 : undefined}
+            stroke={gridFill ? "none" : "var(--border)"}
+            stroke-width="1"
+            data-sw="1"
+          />
+        );
+      })
+  }
+
+  <!-- Radial spokes: center → outer ring tip -->
+  {
+    showGrid &&
+      showSpokes &&
+      data.map((_, k) => {
+        const [x, y] = polarToXY(maxR, k);
+        return (
+          <line x1={cx} y1={cy} x2={x} y2={y} stroke="var(--border)" stroke-width="1" data-sw="1" />
+        );
+      })
+  }
+
+  <!-- Series polygons — fill + stroke share the series color -->
+  {
+    series.map((key, i) => {
+      const opacity = fillOpacities?.[i] ?? fillOpacity;
+      return (
+        <polygon
+          points={seriesPoints(key)}
+          fill={`var(--color-${key})`}
+          fill-opacity={opacity}
+          stroke={opacity === 0 ? `var(--color-${key})` : "none"}
+          stroke-width="2"
+          data-sw={opacity === 0 ? "2" : undefined}
+          stroke-linejoin="round"
+        />
+      );
+    })
+  }
+
+  <!-- Optional vertex dots on top of polygons -->
+  {
+    showDots &&
+      vertices.map((v) => (
+        <circle cx={v.x} cy={v.y} r="4" data-r="4" fill={`var(--color-${v.seriesKey})`} />
+      ))
+  }
+
+  <!-- Hover dots: recharts' default activeDot (r=4, white 2px stroke) appears at the hovered
+       category's vertex per series, even when the permanent dot (showDots) is off. Skipped when
+       showDots is on — a permanent dot already sits there, so an identical one would just double-draw. -->
+  {
+    !showDots &&
+      vertices.map((v) => (
+        <circle
+          cx={v.x}
+          cy={v.y}
+          r="4"
+          data-r="4"
+          data-hover-dot="1"
+          data-category={v.category}
+          fill={`var(--color-${v.seriesKey})`}
+          stroke="#fff"
+          stroke-width="2"
+          data-sw="2"
+          pointer-events="none"
+          style="display:none"
+        />
+      ))
+  }
+
+  <!-- Transparent hit areas — carry data-* for the shared ChartTooltip -->
+  {
+    showTooltip &&
+      vertices.map((v) => (
+        <circle
+          cx={v.x}
+          cy={v.y}
+          r="10"
+          fill="transparent"
+          data-series={v.seriesKey}
+          data-category={v.category}
+          data-value={v.value}
+          data-label={v.label}
+        />
+      ))
+  }
+
+  <!-- Radius axis ticks (between axis 0 and axis 1, no axis line per recharts source) -->
+  {
+    radiusTicks.map(({ x, y, tickValue }) => (
+      <text
+        x={x}
+        y={y}
+        text-anchor="middle"
+        dominant-baseline="central"
+        fill="var(--foreground)"
+        font-size="12"
+        data-fs="12"
+      >
+        {tickValue}
+      </text>
+    ))
+  }
+
+  <!-- Custom value+month labels (label-custom variant: shows "val1/val2" + month name) -->
+  {
+    showDataLabels &&
+      axisLabels.map(({ x, y, anchor, seriesVals }) => (
+        <text
+          x={x}
+          y={y - 10}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="currentColor"
+          font-size="13"
+          font-weight="500"
+          data-fs="13"
+        >
+          {seriesVals.slice(0, 2).join("/")}
+        </text>
+      ))
+  }
+  {
+    showDataLabels &&
+      axisLabels.map(({ x, y, anchor, text }) => (
+        <text
+          x={x}
+          y={y + 8}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {text}
+        </text>
+      ))
+  }
+
+  <!-- Standard angular axis labels, rendered last so they sit above grid lines -->
+  {
+    !showDataLabels &&
+      showAxisLabels &&
+      axisLabels.map(({ x, y, anchor, text }) => (
+        <text
+          x={x}
+          y={y}
+          text-anchor={anchor}
+          dominant-baseline="central"
+          fill="var(--muted-foreground)"
+          font-size="12"
+          data-fs="12"
+        >
+          {text}
+        </text>
+      ))
+  }
+
+  <!-- Angular hit wedges — Recharts tooltip tracks the nearest polar category. -->
+  {
+    showTooltip &&
+      hitWedges.map((hit) => (
+        <polygon
+          points={hit.points}
+          fill="transparent"
+          pointer-events="all"
+          data-series={hit.items[0]?.series}
+          data-category={hit.category}
+          data-items={JSON.stringify(hit.items)}
+        />
+      ))
+  }
+</svg>
+
+{
+  showLegend && (
+    <div style="position:absolute;left:0;right:0;bottom:-10px;height:60px;padding-top:32px;display:flex;align-items:flex-start;justify-content:center">
+      <ChartLegend config={config} series={series} />
+    </div>
+  )
+}
+{showTooltip && <ChartTooltip />}
+
+<script>
+  // Reveal per-series [data-hover-dot] circles for the hovered category (recharts activeDot),
+  // reusing the same hit targets ([data-category] on hitWedges/vertex circles) as ChartTooltip.
+  const initialized = new WeakSet<SVGSVGElement>();
+  const setupRadarHoverDots = () => {
+    document.querySelectorAll<HTMLElement>('[data-slot="chart"]').forEach((chart) => {
+      const svg = chart.querySelector("svg");
+      if (!svg || initialized.has(svg)) return;
+      const dots = svg.querySelectorAll<SVGCircleElement>("[data-hover-dot]");
+      if (!dots.length) return;
+      initialized.add(svg);
+
+      const hideAll = () => dots.forEach((dot) => (dot.style.display = "none"));
+
+      svg.addEventListener("mouseover", (e) => {
+        const target = (e.target as Element).closest("[data-category]") as HTMLElement | null;
+        if (!target) {
+          hideAll();
+          return;
+        }
+        const category = target.dataset.category ?? "";
+        dots.forEach(
+          (dot) => (dot.style.display = dot.dataset.category === category ? "" : "none"),
+        );
+      });
+
+      svg.addEventListener("mouseleave", hideAll);
+    });
+  };
+
+  setupRadarHoverDots();
+  document.addEventListener("astro:after-swap", setupRadarHoverDots);
+  document.addEventListener("starwind:init", setupRadarHoverDots);
+</script>

--- a/packages/core/src/components/chart/RadialChart.astro
+++ b/packages/core/src/components/chart/RadialChart.astro
@@ -1,0 +1,645 @@
+---
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+
+type Props = {
+  data: Record<string, string | number>[];
+  config: ChartConfig;
+  mode?: "bars" | "stacked" | "gauge";
+  // bars / gauge: one arc per data row
+  nameKey?: string;
+  dataKey?: string;
+  // stacked: one arc band, segments end-to-end
+  series?: string[];
+  categoryKey?: string;
+  // geometry
+  startAngle?: number;
+  endAngle?: number;
+  innerRadiusRatio?: number;
+  /** Explicit outer radius in SVG units (matches shadcn outerRadius prop). */
+  outerRadius?: number;
+  /** Explicit inner radius in SVG units (matches shadcn innerRadius prop). */
+  innerRadius?: number;
+  /** Override ring-background radii [outer, inner] (matches shadcn PolarGrid polarRadius). */
+  polarRadius?: [number, number];
+  barGap?: number;
+  maxValue?: number;
+  // display
+  showLabels?: boolean;
+  /** "value" = numeric value at arc tip; "name" = capitalized series name inside arc start. */
+  labelMode?: "value" | "name";
+  centerText?: string;
+  centerLabel?: string;
+  showLegend?: boolean;
+  showTooltip?: boolean;
+  cornerRadius?: number;
+  /** Hide the muted background track behind each arc (set false for grid variant). */
+  showTrack?: boolean;
+  /** Draw concentric circle grid lines at each arc radius (grid variant). */
+  showGrid?: boolean;
+  /** Draw a muted-filled outer ring + background-filled inner circle behind the arc (text / shape variants). */
+  ringBackground?: boolean;
+};
+
+const {
+  data,
+  config,
+  mode = "bars",
+  nameKey = "name",
+  dataKey = "value",
+  series = [],
+  categoryKey,
+  startAngle = 0,
+  endAngle = 360,
+  innerRadiusRatio = 0.3,
+  outerRadius: outerRadiusProp,
+  innerRadius: innerRadiusProp,
+  polarRadius: polarRadiusProp,
+  barGap = 2,
+  maxValue,
+  showLabels = false,
+  labelMode = "value",
+  centerText,
+  centerLabel,
+  showLegend = false,
+  showTooltip = true,
+  cornerRadius = 0,
+  showTrack = true,
+  showGrid = false,
+  ringBackground = false,
+} = Astro.props;
+
+// Recharts radial examples render into the 250px chart box with 1 SVG unit = 1px.
+const W = 250;
+const H = 250;
+const cx = W / 2;
+const cy = H / 2;
+const outerR = outerRadiusProp ?? 108;
+const innerR =
+  innerRadiusProp !== undefined ? innerRadiusProp : outerR * Math.max(innerRadiusRatio, 0.1);
+// Whether explicit radii were given (affects gauge strokeW and stack geometry)
+const hasExplicitRadii = outerRadiusProp !== undefined && innerRadiusProp !== undefined;
+// Angle direction: Recharts endAngle > startAngle → CCW on screen (SVG sweep-flag 0)
+const isCCW = endAngle > startAngle;
+const sf: 0 | 1 = isCCW ? 0 : 1; // SVG sweep-flag: 1=CW, 0=CCW
+const totalSweep = Math.abs(startAngle - endAngle);
+// Ring background support (text / shape variants): outer fill = muted, inner fill = background.
+// polarRadiusProp overrides; otherwise use outerR / innerR (or fallback outerR-24 for gauge).
+const ringBgOuterR = polarRadiusProp ? polarRadiusProp[0] : outerR;
+const ringBgInnerR = polarRadiusProp
+  ? polarRadiusProp[1]
+  : innerRadiusProp !== undefined
+    ? innerR
+    : outerR - 24;
+
+// Format to 2dp, drop trailing zeros — keeps SVG path strings compact
+function f(n: number): string {
+  return Number(n.toFixed(2)).toString();
+}
+
+// Recharts angle convention: 90 = top, clockwise = decreasing angle.
+// Maps to SVG coordinates where y increases downward.
+// x = cx + r·cos(θ), y = cy − r·sin(θ)  (standard math, y-flipped for SVG screen)
+function polarToXY(r: number, angleDeg: number): [number, number] {
+  const rad = (angleDeg * Math.PI) / 180;
+  return [cx + r * Math.cos(rad), cy - r * Math.sin(rad)];
+}
+
+// Stroked arc path from sa → ea.
+// sweepFlag: 1 = CW on screen (sa > ea), 0 = CCW on screen (sa < ea).
+// Handles the degenerate ≥360° case by splitting into two semicircles.
+// large-arc-flag: 1 when sweep > 180° (must take the major arc), else 0.
+function arcD(r: number, sa: number, ea: number, sweepFlag: 0 | 1 = 1): string {
+  const sweep = Math.abs(sa - ea);
+  if (sweep <= 0) return "";
+  if (sweep >= 360) {
+    // Full circle: single-arc from/to the same point is degenerate in SVG —
+    // split into two semicircles joined end-to-end.
+    const [x1, y1] = polarToXY(r, sa);
+    const [x2, y2] = polarToXY(r, sweepFlag === 1 ? sa - 180 : sa + 180);
+    return (
+      `M${f(x1)},${f(y1)} A${r},${r},0,1,${sweepFlag},${f(x2)},${f(y2)}` +
+      ` A${r},${r},0,1,${sweepFlag},${f(x1)},${f(y1)}`
+    );
+  }
+  const [x1, y1] = polarToXY(r, sa);
+  const [x2, y2] = polarToXY(r, ea);
+  const large = sweep > 180 ? 1 : 0;
+  return `M${f(x1)},${f(y1)} A${r},${r},0,${large},${sweepFlag},${f(x2)},${f(y2)}`;
+}
+
+function sectorD(inner: number, outer: number, sa: number, ea: number): string {
+  if (Math.abs(ea - sa) >= 360) {
+    const dir = ea >= sa ? 1 : -1;
+    const mid = sa + dir * 180;
+    const outerSweep: 0 | 1 = dir > 0 ? 0 : 1;
+    const innerSweep: 0 | 1 = dir > 0 ? 1 : 0;
+    const [osx, osy] = polarToXY(outer, sa);
+    const [omx, omy] = polarToXY(outer, mid);
+    const [isx, isy] = polarToXY(inner, sa);
+    const [imx, imy] = polarToXY(inner, mid);
+    return (
+      `M${f(osx)},${f(osy)} A${outer},${outer},0,1,${outerSweep},${f(omx)},${f(omy)}` +
+      ` A${outer},${outer},0,1,${outerSweep},${f(osx)},${f(osy)}` +
+      ` L${f(isx)},${f(isy)} A${inner},${inner},0,1,${innerSweep},${f(imx)},${f(imy)}` +
+      ` A${inner},${inner},0,1,${innerSweep},${f(isx)},${f(isy)} Z`
+    );
+  }
+
+  const signedSweep = Math.sign(ea - sa || 1) * Math.min(Math.abs(ea - sa), 359.999);
+  const end = sa + signedSweep;
+  const [osx, osy] = polarToXY(outer, sa);
+  const [oex, oey] = polarToXY(outer, end);
+  const [isx, isy] = polarToXY(inner, sa);
+  const [iex, iey] = polarToXY(inner, end);
+  const large = Math.abs(signedSweep) > 180 ? 1 : 0;
+  const outerSweep = sa > end ? 1 : 0;
+  const innerSweep = sa <= end ? 1 : 0;
+  return `M${f(osx)},${f(osy)} A${outer},${outer},0,${large},${outerSweep},${f(oex)},${f(oey)} L${f(iex)},${f(iey)} A${inner},${inner},0,${large},${innerSweep},${f(isx)},${f(isy)} Z`;
+}
+
+function niceMax(v: number): number {
+  if (v <= 0) return 10;
+  const exp = Math.floor(Math.log10(v));
+  const step = Math.pow(10, exp);
+  return Math.ceil(v / step) * step;
+}
+
+// ── bars / gauge ─────────────────────────────────────────────────────────────
+// Each data row becomes one concentric arc (outermost = index 0).
+type ArcItem = {
+  midR: number;
+  strokeW: number;
+  trackD: string;
+  valueD: string;
+  color: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  valueAngle: number;
+  filled: boolean;
+};
+
+const arcs: ArcItem[] = [];
+const legendKeys: string[] = [];
+const gridRadii: number[] = [];
+const gridSpokeAngles: number[] = [];
+
+if (mode === "bars" || mode === "gauge") {
+  const N = data.length;
+  if (N > 0) {
+    const rawVals = data.map((d) => Number(d[dataKey] ?? 0));
+    const maxVal = maxValue ?? (Math.max(...rawVals, 0) || 10);
+    const isGauge = mode === "gauge";
+    const gaugeW = hasExplicitRadii ? Math.max(4, Math.min(12, (outerR - innerR) * 0.4)) : 24;
+    const slotW = isGauge ? gaugeW : (outerR - innerR) / N;
+    const strokeW = isGauge ? gaugeW : Math.max(Math.floor(slotW * 0.8), 2);
+    const usesStroke = isGauge && cornerRadius > 0;
+
+    if (showGrid && !isGauge) {
+      for (let i = 0; i < N; i++) gridRadii.push(innerR + i * slotW);
+      const step = maxVal > 200 ? 20 : Math.max(1, Math.ceil(maxVal / 12));
+      for (let v = 0; v < maxVal; v += step) {
+        const spokeSweep = (v / maxVal) * totalSweep;
+        gridSpokeAngles.push(isCCW ? startAngle + spokeSweep : startAngle - spokeSweep);
+      }
+    }
+
+    for (let i = 0; i < N; i++) {
+      const row = data[i];
+      const val = Number(row[dataKey] ?? 0);
+      const key = String(row[nameKey] ?? i);
+      const midR = isGauge
+        ? hasExplicitRadii
+          ? innerR
+          : outerR - strokeW / 2
+        : innerR - slotW / 2 + slotW * 0.1 + strokeW / 2 + i * slotW;
+      const innerEdge = Math.max(midR - strokeW / 2, 0);
+      const outerEdge = midR + strokeW / 2;
+      const valueSweep = maxVal > 0 ? (val / maxVal) * totalSweep : 0;
+      // CCW: angle increases from startAngle; CW: angle decreases
+      const valueEnd = isCCW ? startAngle + valueSweep : startAngle - valueSweep;
+
+      arcs.push({
+        midR,
+        strokeW,
+        trackD: usesStroke
+          ? arcD(midR, startAngle, endAngle, sf)
+          : sectorD(innerEdge, outerEdge, startAngle, endAngle),
+        valueD: usesStroke
+          ? arcD(midR, startAngle, valueEnd, sf)
+          : sectorD(innerEdge, outerEdge, startAngle, valueEnd),
+        color: `var(--color-${key})`,
+        seriesKey: key,
+        category: String(row[nameKey] ?? key),
+        value: String(val),
+        label: config[key]?.label ?? key,
+        valueAngle: valueEnd,
+        filled: !usesStroke,
+      });
+      legendKeys.push(key);
+    }
+  }
+}
+
+// ── stacked ───────────────────────────────────────────────────────────────────
+// Single arc band; multiple series fill it end-to-end like a pie-on-a-ring.
+type StackedSeg = {
+  d: string;
+  trackD: string;
+  midR: number;
+  strokeW: number;
+  color: string;
+  seriesKey: string;
+  category: string;
+  value: string;
+  label: string;
+  linecap: "round" | "butt";
+};
+
+const stackedSegs: StackedSeg[] = [];
+let stackedTotal = 0;
+
+if (mode === "stacked" && data.length > 0 && series.length > 0) {
+  const row = data[0];
+  const strokeW = hasExplicitRadii
+    ? Math.max(4, Math.min(12, (outerR - innerR) * 0.4))
+    : Math.max(outerR - outerR * 0.72, 2);
+  const midR = hasExplicitRadii ? innerR : outerR - strokeW / 2;
+  const stackLinecap = cornerRadius > 0 ? "round" : "butt";
+  const cat = categoryKey ? String(row[categoryKey] ?? "") : "";
+  const vals = series.map((s) => Number(row[s] ?? 0));
+  stackedTotal = vals.reduce((a, b) => a + b, 0);
+  const maxVal = maxValue ?? (stackedTotal || 10);
+  const trackD = arcD(midR, startAngle, endAngle, sf);
+  let currentA = startAngle;
+
+  for (let i = 0; i < series.length; i++) {
+    const key = series[i];
+    const val = vals[i];
+    const segSweep = maxVal > 0 ? (val / maxVal) * totalSweep : 0;
+    const segEnd = isCCW ? currentA + segSweep : currentA - segSweep;
+    const innerEdge = Math.max(midR - strokeW / 2, 0);
+    const outerEdge = midR + strokeW / 2;
+
+    stackedSegs.push({
+      d: sectorD(innerEdge, outerEdge, currentA, segEnd),
+      trackD: i === 0 ? trackD : "", // draw full track once, behind all segments
+      midR,
+      strokeW,
+      color: `var(--color-${key})`,
+      seriesKey: key,
+      category: cat,
+      value: String(val),
+      label: config[key]?.label ?? key,
+      linecap: stackLinecap,
+    });
+    currentA = segEnd;
+    legendKeys.push(key);
+  }
+}
+
+// Label just outside the arc end (radially outward by half stroke + margin)
+function labelXY(midR: number, strokeW: number, angle: number): [number, number] {
+  return polarToXY(midR + strokeW / 2 + 10, angle);
+}
+
+// Unique per-instance id prefix for the insideStart label textPaths (multiple radial
+// charts can share a page, so path ids must not collide).
+const gid = Math.random().toString(36).slice(2, 9);
+// shadcn's insideStart LabelList rides a circular textPath at the bar's own mid-radius,
+// starting 5deg into the sweep from startAngle (Recharts' Label default `offset`).
+const nameLabelStart = startAngle + (isCCW ? 1 : -1) * 5;
+const nameLabelEnd = nameLabelStart + (isCCW ? 1 : -1) * 359;
+
+// Center value: explicit prop, or auto-inferred for gauge (single row) / stacked total
+const autoCenter =
+  centerText ??
+  (mode === "gauge" && data.length === 1
+    ? Number(data[0][dataKey] ?? 0).toLocaleString("en-US")
+    : mode === "stacked" && stackedTotal > 0
+      ? stackedTotal.toLocaleString("en-US")
+      : undefined);
+
+const ariaLabel =
+  mode === "stacked"
+    ? `Radial stacked chart: ${series.map((s) => config[s]?.label ?? s).join(", ")}`
+    : `Radial ${mode} chart: ${data.map((d) => String(d[nameKey] ?? "")).join(", ")}`;
+
+// ponytail: stroke-linecap="round" gives cap shape for free; no manual cap path math needed
+const linecap = cornerRadius > 0 ? "round" : "butt";
+---
+
+<svg
+  viewBox={`0 0 ${W} ${H}`}
+  width="100%"
+  preserveAspectRatio="xMidYMid meet"
+  role="img"
+  aria-label={ariaLabel}
+>
+  <!-- Ring background: muted outer disk + background inner disk → visible ring (text / shape variants) -->
+  {ringBackground && <circle cx={cx} cy={cy} r={ringBgOuterR} fill="var(--muted)" />}
+  {ringBackground && <circle cx={cx} cy={cy} r={ringBgInnerR} fill="var(--background)" />}
+
+  <!-- Concentric grid circles at each arc radius (grid variant) -->
+  {
+    showGrid &&
+      gridRadii.map((r) => (
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke="var(--border)"
+          stroke-width="1"
+          data-sw="1"
+        />
+      ))
+  }
+  {
+    showGrid &&
+      gridSpokeAngles.map((angle) => {
+        const [x1, y1] = polarToXY(innerR, angle);
+        const [x2, y2] = polarToXY(outerR, angle);
+        return (
+          <line
+            x1={x1}
+            y1={y1}
+            x2={x2}
+            y2={y2}
+            stroke="var(--border)"
+            stroke-width="1"
+            data-sw="1"
+          />
+        );
+      })
+  }
+
+  <!-- Fallback hover surface for empty radial space; exact arc paths render later and win on top. -->
+  {
+    showTooltip && arcs.length > 0 && (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={outerR + 16}
+        fill="transparent"
+        pointer-events="all"
+        data-series={arcs[0]?.seriesKey}
+        data-category={arcs[0]?.category}
+        data-items={JSON.stringify(
+          arcs.map((arc) => ({
+            series: arc.seriesKey,
+            label: arc.label,
+            value: arc.value,
+          })),
+        )}
+      />
+    )
+  }
+  {
+    showTooltip && arcs.length === 0 && stackedSegs.length > 0 && (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={outerR + 16}
+        fill="transparent"
+        pointer-events="all"
+        data-series={stackedSegs[0]?.seriesKey}
+        data-category={stackedSegs[0]?.category}
+        data-items={JSON.stringify(
+          stackedSegs.map((seg) => ({
+            series: seg.seriesKey,
+            label: seg.label,
+            value: seg.value,
+          })),
+        )}
+      />
+    )
+  }
+
+  <!-- Background tracks (bars / gauge) -->
+  {
+    showTrack &&
+      arcs.map(
+        (arc) =>
+          arc.trackD &&
+          (arc.filled ? (
+            <path d={arc.trackD} fill="var(--muted)" stroke="none" />
+          ) : (
+            <path
+              d={arc.trackD}
+              fill="none"
+              stroke="var(--muted)"
+              stroke-width={arc.strokeW}
+              stroke-linecap={linecap}
+            />
+          )),
+      )
+  }
+
+  <!-- Background track (stacked — drawn once, behind all segments) -->
+  {
+    showTrack &&
+      stackedSegs.map(
+        (seg) =>
+          seg.trackD && (
+            <path
+              d={seg.trackD}
+              fill="none"
+              stroke="var(--muted)"
+              stroke-width={seg.strokeW}
+              stroke-linecap="butt"
+            />
+          ),
+      )
+  }
+
+  <!-- Value arcs (bars / gauge) — data-* attrs drive the shared tooltip -->
+  {
+    arcs.map(
+      (arc) =>
+        arc.valueD &&
+        (arc.filled ? (
+          <path
+            d={arc.valueD}
+            fill={arc.color}
+            stroke="none"
+            data-series={arc.seriesKey}
+            data-category={arc.category}
+            data-value={arc.value}
+            data-label={arc.label}
+          />
+        ) : (
+          <path
+            d={arc.valueD}
+            fill="none"
+            stroke={arc.color}
+            stroke-width={arc.strokeW}
+            stroke-linecap={linecap}
+            data-series={arc.seriesKey}
+            data-category={arc.category}
+            data-value={arc.value}
+            data-label={arc.label}
+          />
+        )),
+    )
+  }
+
+  <!-- Value arcs (stacked) -->
+  {
+    stackedSegs.map(
+      (seg) =>
+        seg.d && (
+          <path
+            d={seg.d}
+            fill={seg.color}
+            stroke="transparent"
+            stroke-width={cornerRadius > 0 ? "2" : "0"}
+            stroke-linecap={seg.linecap}
+            data-series={seg.seriesKey}
+            data-category={seg.category}
+            data-value={seg.value}
+            data-label={seg.label}
+          />
+        ),
+    )
+  }
+
+  <!-- Invisible full-ring hit paths for tooltip parity with Recharts. -->
+  {
+    showTooltip &&
+      arcs.map(
+        (arc) =>
+          arc.trackD &&
+          (arc.filled ? (
+            <path
+              d={arc.trackD}
+              fill="transparent"
+              stroke="none"
+              pointer-events="all"
+              data-series={arc.seriesKey}
+              data-category={arc.category}
+              data-value={arc.value}
+              data-label={arc.label}
+            />
+          ) : (
+            <path
+              d={arc.trackD}
+              fill="none"
+              stroke="transparent"
+              stroke-width={arc.strokeW + 6}
+              stroke-linecap={linecap}
+              pointer-events="stroke"
+              data-series={arc.seriesKey}
+              data-category={arc.category}
+              data-value={arc.value}
+              data-label={arc.label}
+            />
+          )),
+      )
+  }
+  {
+    showTooltip &&
+      stackedSegs.map(
+        (seg) =>
+          seg.trackD && (
+            <path
+              d={seg.trackD}
+              fill="none"
+              stroke="transparent"
+              stroke-width={seg.strokeW + 6}
+              stroke-linecap="butt"
+              pointer-events="stroke"
+              data-series={stackedSegs[0]?.seriesKey}
+              data-category={seg.category}
+              data-items={JSON.stringify(
+                stackedSegs.map((item) => ({
+                  series: item.seriesKey,
+                  label: item.label,
+                  value: item.value,
+                })),
+              )}
+            />
+          ),
+      )
+  }
+
+  <!-- Per-arc value labels at arc end (optional) -->
+  {
+    showLabels &&
+      arcs.map((arc, i) => {
+        if (labelMode === "name") {
+          // Capitalized series name riding the arc's own ring, starting just inside
+          // its sweep (shadcn insideStart — a curved textPath, not a fixed point).
+          const pathId = `radial-label-${gid}-${i}`;
+          return (
+            <text
+              fill="#fff"
+              font-size="11"
+              data-fs="11"
+              dominant-baseline="central"
+              style="text-transform: capitalize; mix-blend-mode: luminosity;"
+            >
+              <defs>
+                <path id={pathId} d={arcD(arc.midR, nameLabelStart, nameLabelEnd, sf)} />
+              </defs>
+              <textPath xlink:href={`#${pathId}`}>{arc.label}</textPath>
+            </text>
+          );
+        }
+        const [lx, ly] = labelXY(arc.midR, arc.strokeW, arc.valueAngle);
+        return (
+          <text
+            x={lx}
+            y={ly}
+            text-anchor="middle"
+            dominant-baseline="middle"
+            fill="var(--foreground)"
+            font-size="11"
+            font-weight="500"
+            data-fs="11"
+          >
+            {arc.value}
+          </text>
+        );
+      })
+  }
+
+  <!-- Center value (gauge single-value or stacked total) -->
+  {
+    autoCenter && (
+      <text
+        x={cx}
+        y={mode === "stacked" ? cy - 16 : cy}
+        text-anchor="middle"
+        dominant-baseline="middle"
+        fill="var(--foreground)"
+      >
+        <tspan
+          x={cx}
+          y={mode === "stacked" ? cy - 16 : cy}
+          font-size={mode === "stacked" ? "24" : "36"}
+          font-weight="700"
+        >
+          {autoCenter}
+        </tspan>
+        {centerLabel && (
+          <tspan
+            x={cx}
+            y={mode === "stacked" ? cy + 4 : cy + 24}
+            fill="var(--muted-foreground)"
+            font-size="13"
+            font-weight="400"
+          >
+            {centerLabel}
+          </tspan>
+        )}
+      </text>
+    )
+  }
+</svg>
+
+{showLegend && <ChartLegend config={config} series={legendKeys} />}
+{showTooltip && <ChartTooltip />}

--- a/packages/core/src/components/chart/curves.ts
+++ b/packages/core/src/components/chart/curves.ts
@@ -1,0 +1,148 @@
+// Shared curve-path builders for the cartesian line/area charts.
+//
+// These faithfully reproduce the d3-shape curves that Recharts uses, so an
+// Astro-rendered path matches shadcn's SVG geometry exactly:
+//   - "natural"  → d3 curveNatural   (natural cubic spline)
+//   - "monotone" → d3 curveMonotoneX (Fritsch–Carlson monotone cubic)
+//   - "linear"   → straight segments
+//   - "step"     → step-after
+//
+// LineChart and AreaChart both consumed byte-for-byte copies of this math; it
+// now lives here once. NOTE: LineChart.astro's client-side <script> keeps its
+// OWN copy of linePath/stepPath/monotonePath for the dense-data resize reflow —
+// a browser-runtime scope that can't import this module. If you change a curve
+// formula here, mirror it there (and vice versa) or the two will silently drift.
+// Everything operates on a plain {x, y} point. Segment
+// builders return path data WITHOUT a leading "M" (the area builder needs to
+// splice segments mid-path); `buildPath` adds the opening moveto for line use.
+
+export type Point = { x: number; y: number };
+
+export type CurveType = "linear" | "monotone" | "natural" | "step";
+
+// Straight line segments: "L…L…" (no leading M).
+function linearSegments(pts: Point[]): string {
+  return pts
+    .slice(1)
+    .map((p) => `L${p.x},${p.y}`)
+    .join(" ");
+}
+
+// Step-after: horizontal to the next x, then vertical to the next y.
+function stepSegments(pts: Point[]): string {
+  return pts
+    .slice(1)
+    .map((p) => `H${p.x} V${p.y}`)
+    .join(" ");
+}
+
+// d3-shape curveNatural: solve the tridiagonal system for a natural cubic
+// spline's bezier control points. Returns [firstControls, secondControls].
+function naturalControl(v: number[]): [number[], number[]] {
+  const m = v.length - 1;
+  const a: number[] = new Array(m);
+  const b: number[] = new Array(m);
+  const r: number[] = new Array(m);
+  a[0] = 0;
+  b[0] = 2;
+  r[0] = v[0] + 2 * v[1];
+  for (let i = 1; i < m - 1; i++) {
+    a[i] = 1;
+    b[i] = 4;
+    r[i] = 4 * v[i] + 2 * v[i + 1];
+  }
+  a[m - 1] = 2;
+  b[m - 1] = 7;
+  r[m - 1] = 8 * v[m - 1] + v[m];
+  for (let i = 1; i < m; i++) {
+    const t = a[i] / b[i - 1];
+    b[i] -= t;
+    r[i] -= t * r[i - 1];
+  }
+  a[m - 1] = r[m - 1] / b[m - 1];
+  for (let i = m - 2; i >= 0; i--) a[i] = (r[i] - a[i + 1]) / b[i];
+  b[m - 1] = (v[m] + a[m - 1]) / 2;
+  for (let i = 0; i < m - 1; i++) b[i] = 2 * v[i + 1] - a[i + 1];
+  return [a, b];
+}
+
+function naturalSegments(pts: Point[]): string {
+  if (pts.length < 2) return "";
+  const [ax, bx] = naturalControl(pts.map((p) => p.x));
+  const [ay, by] = naturalControl(pts.map((p) => p.y));
+  return pts
+    .slice(1)
+    .map(
+      (p, i) =>
+        `C${ax[i].toFixed(1)},${ay[i].toFixed(1)} ${bx[i].toFixed(1)},${by[i].toFixed(1)} ${p.x.toFixed(1)},${p.y.toFixed(1)}`,
+    )
+    .join(" ");
+}
+
+// d3-shape curveMonotoneX (Fritsch–Carlson), matching Recharts type="monotone".
+function monotoneSegments(pts: Point[]): string {
+  if (pts.length < 2) return "";
+  const n = pts.length;
+  const dxs = pts.slice(0, -1).map((p, i) => pts[i + 1].x - p.x);
+  const dys = pts.slice(0, -1).map((p, i) => pts[i + 1].y - p.y);
+  const tan: number[] = new Array(n).fill(0);
+  tan[0] = dxs[0] ? dys[0] / dxs[0] : 0;
+  tan[n - 1] = dxs[n - 2] ? dys[n - 2] / dxs[n - 2] : 0;
+  for (let i = 1; i < n - 1; i++) {
+    const s0 = dxs[i - 1] ? dys[i - 1] / dxs[i - 1] : 0;
+    const s1 = dxs[i] ? dys[i] / dxs[i] : 0;
+    tan[i] = s0 * s1 <= 0 ? 0 : (s0 + s1) / 2;
+  }
+  for (let i = 0; i < n - 1; i++) {
+    const s = dxs[i] ? dys[i] / dxs[i] : 0;
+    if (Math.abs(s) < 1e-10) {
+      tan[i] = tan[i + 1] = 0;
+      continue;
+    }
+    const a = tan[i] / s;
+    const b = tan[i + 1] / s;
+    const h = Math.sqrt(a * a + b * b);
+    if (h > 3) {
+      tan[i] = (3 / h) * a * s;
+      tan[i + 1] = (3 / h) * b * s;
+    }
+  }
+  return pts
+    .slice(1)
+    .map((p, i) => {
+      const dx = dxs[i];
+      const cp1x = (pts[i].x + dx / 3).toFixed(1);
+      const cp1y = (pts[i].y + (tan[i] * dx) / 3).toFixed(1);
+      const cp2x = (p.x - dx / 3).toFixed(1);
+      const cp2y = (p.y - (tan[i + 1] * dx) / 3).toFixed(1);
+      return `C${cp1x},${cp1y} ${cp2x},${cp2y} ${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+/** Path segments for `pts` in the given curve style, WITHOUT a leading moveto. */
+export function curveSegments(pts: Point[], curve: CurveType): string {
+  if (pts.length < 2) return "";
+  if (curve === "linear") return linearSegments(pts);
+  if (curve === "step") return stepSegments(pts);
+  if (curve === "natural") return naturalSegments(pts);
+  return monotoneSegments(pts);
+}
+
+/** A complete open path ("M…" + segments) for a line stroke. */
+export function buildPath(pts: Point[], curve: CurveType): string {
+  if (!pts.length) return "";
+  if (pts.length === 1) return `M${pts[0].x},${pts[0].y}`;
+  return `M${pts[0].x},${pts[0].y} ${curveSegments(pts, curve)}`;
+}
+
+/**
+ * A closed area path: the top curve forward, then the bottom curve reversed and
+ * closed. Seam is exact for monotone/linear (the same curve reversed).
+ */
+export function buildArea(topPts: Point[], bottomPts: Point[], curve: CurveType): string {
+  const topD = buildPath(topPts, curve);
+  if (!topD) return "";
+  const rev = [...bottomPts].reverse();
+  return `${topD} L${rev[0].x},${rev[0].y} ${curveSegments(rev, curve)} Z`;
+}

--- a/packages/core/src/components/chart/curves.ts
+++ b/packages/core/src/components/chart/curves.ts
@@ -68,6 +68,9 @@ function naturalControl(v: number[]): [number[], number[]] {
 
 function naturalSegments(pts: Point[]): string {
   if (pts.length < 2) return "";
+  // d3 curveNatural draws exactly two points as a straight segment; the
+  // tridiagonal solve below assumes at least three points.
+  if (pts.length === 2) return linearSegments(pts);
   const [ax, bx] = naturalControl(pts.map((p) => p.x));
   const [ay, by] = naturalControl(pts.map((p) => p.y));
   return pts

--- a/packages/core/src/components/chart/index.ts
+++ b/packages/core/src/components/chart/index.ts
@@ -1,0 +1,22 @@
+import BarChart from "./BarChart.astro";
+import Chart from "./Chart.astro";
+import ChartLegend from "./ChartLegend.astro";
+import ChartTooltip from "./ChartTooltip.astro";
+import type { ChartConfig } from "./variants";
+import { chart, chartLegend, chartTooltip } from "./variants";
+
+const ChartVariants = {
+  chart,
+  chartTooltip,
+  chartLegend,
+};
+
+export type { ChartConfig };
+export { BarChart, Chart, ChartLegend, ChartTooltip, ChartVariants };
+
+export default {
+  Root: Chart,
+  Bar: BarChart,
+  Tooltip: ChartTooltip,
+  Legend: ChartLegend,
+};

--- a/packages/core/src/components/chart/scale.ts
+++ b/packages/core/src/components/chart/scale.ts
@@ -1,0 +1,89 @@
+// Shared axis-domain ("nice number") helpers for the cartesian charts.
+//
+// Recharts rounds a numeric axis' domain to human-friendly bounds even when the
+// axis is hidden, which is why shadcn's bars/areas leave headroom instead of
+// touching the plot edge at the raw data max. The three cartesian families each
+// need a SLIGHTLY DIFFERENT rounding and so keep their own entry point here —
+// they are intentionally NOT unified:
+//   - BarChart  → niceDomain    (full recharts-scale port; handles negatives)
+//   - LineChart → rechartsAutoMax
+//   - AreaChart → niceMax (with y-axis) / tightMax (default, tighter fit)
+// Co-locating them removes three divergent private copies without changing any
+// one chart's output.
+
+// --- BarChart: recharts-scale getNiceTickValues / calculateStep (tickCount=5),
+//     the only variant that must place a nice zero-crossing for negative data.
+export function niceStep(roughStep: number, correctionFactor: number): number {
+  if (roughStep <= 0) return 0;
+  const digitCount = Math.floor(Math.log10(Math.abs(roughStep))) + 1;
+  const digitValue = 10 ** digitCount;
+  const stepRatio = roughStep / digitValue;
+  const stepRatioScale = digitCount !== 1 ? 0.05 : 0.1;
+  return (Math.ceil(stepRatio / stepRatioScale) + correctionFactor) * stepRatioScale * digitValue;
+}
+
+export function niceDomain(
+  min: number,
+  max: number,
+  tickCount = 5,
+  correctionFactor = 0,
+): [number, number] {
+  if (min === max) return [Math.min(0, min), Math.max(10, max)];
+  const step = niceStep((max - min) / (tickCount - 1), correctionFactor);
+  const mid = (min + max) / 2;
+  const middle = min <= 0 && max >= 0 ? 0 : mid - (mid % step);
+  let belowCount = Math.ceil((middle - min) / step);
+  let upCount = Math.ceil((max - middle) / step);
+  const scaleCount = belowCount + upCount + 1;
+  if (scaleCount > tickCount) return niceDomain(min, max, tickCount, correctionFactor + 1);
+  if (scaleCount < tickCount) {
+    upCount = max > 0 ? upCount + (tickCount - scaleCount) : upCount;
+    belowCount = max > 0 ? belowCount : belowCount + (tickCount - scaleCount);
+  }
+  return [middle - belowCount * step, middle + upCount * step];
+}
+
+// --- LineChart: recharts auto-max for a non-negative domain (tickCount=5).
+export function rechartsAutoMax(v: number): number {
+  if (v <= 0) return 10;
+  const tickCount = 5;
+  const roughStep = v / (tickCount - 1);
+  const digitCount = Math.floor(Math.log10(Math.abs(roughStep))) + 1;
+  const digitValue = 10 ** digitCount;
+  const stepRatioScale = digitCount !== 1 ? 0.05 : 0.1;
+  const stepRatio = roughStep / digitValue;
+  const step = Math.ceil(stepRatio / stepRatioScale) * stepRatioScale * digitValue;
+  let upCount = Math.ceil(v / step);
+  const scaleCount = upCount + 1;
+  if (scaleCount < tickCount) upCount += tickCount - scaleCount;
+  return upCount * step;
+}
+
+// --- AreaChart: rounded max used when a y-axis is shown (5-step nice number).
+export function niceMax(v: number): number {
+  if (v <= 0) return 10;
+  const step0 = v / 5;
+  const base = 10 ** Math.floor(Math.log10(step0));
+  const error = step0 / base;
+  const step = (error >= 7.071 ? 10 : error >= 3.162 ? 5 : error >= 1.414 ? 2 : 1) * base;
+  return Math.ceil(v / step) * step;
+}
+
+// --- AreaChart: tighter max used by default (no y-axis) so the area fills more.
+export function tightMax(v: number): number {
+  if (v <= 0) return 10;
+  const step = 10 ** Math.max(0, Math.floor(Math.log10(v)) - 1);
+  return Math.ceil(v / step) * step;
+}
+
+/**
+ * X-axis label thinning — approximates Recharts' minTickGap for dense data.
+ * Returns the stride between labeled categories (1 = label every category).
+ * Identical logic previously lived inline in Bar/Line/Area.
+ */
+export function xLabelStep(dataLength: number, width: number): number {
+  const targetTicks = Math.max(4, Math.floor(width / 72));
+  return dataLength <= Math.max(8, targetTicks)
+    ? 1
+    : Math.max(1, Math.round(dataLength / targetTicks));
+}

--- a/packages/core/src/components/chart/uid.ts
+++ b/packages/core/src/components/chart/uid.ts
@@ -1,0 +1,8 @@
+// Monotonic id source for per-instance-unique SVG ids such as gradients and clip paths.
+// This must live in an imported module: a `let` in .astro frontmatter is emitted
+// inside the per-instance render function and resets to 0 every instance.
+let counter = 0;
+
+export function nextUid(prefix = "sw"): string {
+  return prefix + "-" + counter++;
+}

--- a/packages/core/src/components/chart/variants.ts
+++ b/packages/core/src/components/chart/variants.ts
@@ -1,0 +1,16 @@
+import { tv } from "tailwind-variants";
+
+// ChartConfig defined here (not in .astro frontmatter) to avoid esbuild parser issues with export type
+export type ChartConfig = Record<string, { label?: string; icon?: string; color?: string }>;
+
+export const chart = tv({
+  base: "starwind-chart relative flex aspect-video flex-col justify-center text-xs",
+});
+
+export const chartTooltip = tv({
+  base: "border-border bg-background pointer-events-none absolute z-50 hidden rounded-md border px-2.5 py-1.5 text-xs shadow-md",
+});
+
+export const chartLegend = tv({
+  base: "flex flex-wrap items-center justify-center gap-x-4 gap-y-1.5 pt-3",
+});

--- a/packages/core/src/registry.json
+++ b/packages/core/src/registry.json
@@ -27,6 +27,7 @@
       "version": "1.0.3",
       "dependencies": ["@starwind-ui/core/button@^2.1.0", "embla-carousel@^8.6.0"]
     },
+    { "name": "chart", "type": "component", "version": "1.0.0", "dependencies": [] },
     { "name": "checkbox", "type": "component", "version": "1.4.3", "dependencies": [] },
     { "name": "collapsible", "type": "component", "version": "1.0.2", "dependencies": [] },
     {


### PR DESCRIPTION
## `feat(components): add chart component`

A **dependency-free** Astro/SVG port of shadcn's chart system, themed with
Starwind's own design tokens. No React, no Recharts, no runtime dependency — every
chart is inline SVG computed in Astro frontmatter, with a small vanilla-JS pattern
for hover tooltips/legends.

> Opened as a **draft**, and mindful that #25 was closed `NOT_PLANNED`. Sharing a
> complete, zero-dependency implementation in case it changes the calculus — happy
> to discuss, iterate, or close.

### Why charts fit Starwind

Charts are one of the highest-value things a component kit can offer a **content
site** — docs, dashboards, marketing pages, changelogs, reports. Today reaching for
data-viz in an Astro project means pulling in React + Recharts (or similar) and
shipping a client runtime. This component keeps Starwind's core promise — copy-in
Astro components, no runtime dependency — while covering the full shadcn chart
catalog, so content authors get charts that match the rest of their Starwind UI and
ship as static SVG.

### What's included

- **`Chart`** container — injects per-instance `--color-<key>` from a `ChartConfig`
  (mirrors shadcn's `ChartContainer`/`ChartConfig` model), and counter-scales SVG
  text so labels stay a constant pixel size across widths.
- **Shared `ChartTooltip` + `ChartLegend`** (hover, driven by `data-*` on each mark).
- **`--chart-1..5` design tokens** (light + dark) added to the demo theme.
- **Seven families:** `BarChart` (single/grouped/stacked/horizontal/labelled),
  `LineChart` (linear/monotone/step, dots, labels), `AreaChart`
  (gradient/linear/stacked), `PieChart` (pie/donut/center-text/labels/pad-angle),
  `RadarChart` (polygon/circle grid, multiple series), `RadialChart`
  (gauge/bars/stacked), plus Tooltip examples.
- Bar/Line/Area share pure-TS `curves`, `scale`, and `uid` helpers.
- Six demo pages under `apps/demo/src/pages/charts/`, a `registry.json` entry, and a
  changeset.

### Conventions & accessibility

- Follows the repo component conventions: `HTMLAttributes` typing,
  `tailwind-variants`, `data-slot` hooks, vanilla JS in `.astro` scripts,
  re-init on `astro:after-swap` / `starwind:init`, `WeakMap` instance tracking.
- `role="img"` + `aria-label` on every chart.

### Verification

- `pnpm demo:build` and `pnpm core:build` pass (Astro 5.11).
- `prettier --check`, `biome check`, and `eslint` all clean on the new files.
- Built pages render real SVG geometry with the `--chart-*` token chain resolving
  in both themes.

### Usage

```astro
---
import { Chart, BarChart } from "@/components/starwind/chart";
import type { ChartConfig } from "@/components/starwind/chart";
const data = [{ month: "Jan", desktop: 186, mobile: 80 } /* … */];
const config: ChartConfig = {
  desktop: { label: "Desktop", color: "var(--chart-1)" },
  mobile: { label: "Mobile", color: "var(--chart-2)" },
};
---
<Chart config={config}>
  <BarChart data={data} config={config} categoryKey="month" series={["desktop", "mobile"]} showLegend />
</Chart>
```

### Notes for maintainers

- Design attribution: this ports shadcn's chart system; shadcn is already credited in
  `ATTRIBUTION.md` and the port is disclosed in the changeset.
- Follow-ups if of interest: `ChartConfig` per-series `{light,dark}` theme object,
  and clickable legend-to-toggle-series. Foundation supports both.

Refs #25.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete chart suite (bar, line, area, pie/donut, radar, radial) with configurable legends and interactive tooltips.
  * Introduced consistent chart scaling so labels, markers, and strokes stay readable across resizes.
  * Added a set of demo pages showcasing light/dark variants and multiple chart configurations.
  * Added chart color theming via shared design tokens.
* **Bug Fixes**
  * Improved dense chart label/dot handling and reflow behavior to reduce overlap.
  * Enhanced tooltip positioning and hover targeting for more reliable, accessible interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->