### PR TITLE
test(release): add published beta acceptance

### DIFF
--- a/.github/workflows/published-beta-acceptance.yml
+++ b/.github/workflows/published-beta-acceptance.yml
@@ -1,0 +1,58 @@
+name: Published Beta Acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact published Starwind CLI beta version (for example, 3.0.0-beta.1)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: published-beta-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  acceptance:
+    name: Astro and React published-package acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout Repo
+        # checkout@6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Install pnpm
+        # pnpm/action-setup@v6.0.8
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+        with:
+          cache: true
+
+      - name: Setup Node.js 24
+        # actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter=react-demo exec playwright install --with-deps chromium
+
+      - name: Test Published Beta
+        run: pnpm test:published-beta -- --version "${{ inputs.version }}" --artifacts .artifacts/published-beta
+
+      - name: Upload Acceptance Diagnostics
+        if: always()
+        # upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: published-beta-${{ inputs.version }}
+          path: .artifacts/published-beta
+          if-no-files-found: ignore
+          retention-days: 7

--- a/docs/portable-runtime/beta-release.md
+++ b/docs/portable-runtime/beta-release.md
@@ -69,6 +69,18 @@ the Astro/React dependencies on Runtime. Then install `starwind@beta` in disposa
 projects, add `button`, `dialog`, and `context-menu`, build both projects, and exercise Dialog and
 Context Menu behavior in a browser.
 
+Run the persistent published-package acceptance harness with the exact CLI version:
+
+```bash
+pnpm test:published-beta -- --version 3.0.0-beta.1
+```
+
+The harness creates disposable Astro and React projects, installs the exact published CLI, verifies
+the installed adapter and Runtime beta versions, builds both projects, and checks Dialog and Context
+Menu behavior in Chromium. It removes temporary projects after the run. The public repository also
+exposes the same check as the manually dispatched **Published Beta Acceptance** workflow, with logs,
+screenshots on browser failure, and a package-version summary uploaded as workflow diagnostics.
+
 ## Partial publish recovery
 
 If publishing fails, stop and query all four exact versions on npm. Continue only when the packages

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:coverage": "vitest run --coverage",
     "test:coverage:all": "pnpm test:coverage && pnpm runtime:test:coverage",
     "test:homes": "node scripts/check-test-homes.mjs",
+    "test:published-beta": "node scripts/published-beta-acceptance.mjs",
     "cli:dev": "pnpm --filter=starwind dev",
     "cli:build": "pnpm --filter=starwind build",
     "cli:start": "pnpm --filter=starwind start:dev",

--- a/scripts/published-beta-acceptance.mjs
+++ b/scripts/published-beta-acceptance.mjs
@@ -1,0 +1,539 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
+const HOST = "127.0.0.1";
+
+const BETA_VERSION_PATTERN = /^\d+\.\d+\.\d+-beta\.\d+$/;
+
+const ASTRO_FIXTURE = `---
+import "../styles/starwind.css";
+import { Button } from "../components/starwind/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../components/starwind/dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "../components/starwind/context-menu";
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Starwind published beta acceptance</title>
+  </head>
+  <body>
+    <main class="mx-auto flex min-h-screen max-w-xl flex-col gap-10 p-10">
+      <h1 class="text-2xl font-semibold">Starwind Astro published beta acceptance</h1>
+      <Dialog id="acceptance-dialog">
+        <DialogTrigger asChild>
+          <Button id="dialog-trigger" type="button">Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent id="dialog-content">
+          <DialogHeader>
+            <DialogTitle>Published package dialog</DialogTitle>
+            <DialogDescription>Runtime-backed dialog acceptance test.</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+      <ContextMenu id="acceptance-context-menu">
+        <ContextMenuTrigger
+          id="context-trigger"
+          class="border-input bg-card flex min-h-40 items-center justify-center rounded-md border border-dashed p-6"
+        >
+          Right-click this area
+        </ContextMenuTrigger>
+        <ContextMenuContent id="context-content">
+          <ContextMenuItem id="context-item">Accept action</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </main>
+  </body>
+</html>
+`;
+
+const REACT_FIXTURE = `import { Button } from "./components/starwind/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "./components/starwind/dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "./components/starwind/context-menu";
+
+function App() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-xl flex-col gap-10 p-10">
+      <h1 className="text-2xl font-semibold">Starwind React published beta acceptance</h1>
+      <Dialog id="acceptance-dialog">
+        <DialogTrigger asChild>
+          <Button id="dialog-trigger" type="button">Open dialog</Button>
+        </DialogTrigger>
+        <DialogContent id="dialog-content">
+          <DialogHeader>
+            <DialogTitle>Published package dialog</DialogTitle>
+            <DialogDescription>Runtime-backed dialog acceptance test.</DialogDescription>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+      <ContextMenu id="acceptance-context-menu">
+        <ContextMenuTrigger
+          id="context-trigger"
+          className="border-input bg-card flex min-h-40 items-center justify-center rounded-md border border-dashed p-6"
+        >
+          Right-click this area
+        </ContextMenuTrigger>
+        <ContextMenuContent id="context-content">
+          <ContextMenuItem id="context-item">Accept action</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    </main>
+  );
+}
+
+export default App;
+`;
+
+export function parseArgs(argv) {
+  let artifacts;
+  let keepTemp = false;
+  let version;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+
+    if (argument === "--") {
+      continue;
+    } else if (argument === "--version") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Expected a value after --version.");
+      version = value;
+      index += 1;
+    } else if (argument.startsWith("--version=")) {
+      version = argument.slice("--version=".length);
+    } else if (argument === "--artifacts") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error("Expected a path after --artifacts.");
+      artifacts = value;
+      index += 1;
+    } else if (argument.startsWith("--artifacts=")) {
+      artifacts = argument.slice("--artifacts=".length);
+    } else if (argument === "--keep-temp") {
+      keepTemp = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (!version) throw new Error("Pass --version <version>.");
+  if (!BETA_VERSION_PATTERN.test(version)) {
+    throw new Error(`Expected an exact numbered beta version, received: ${version}`);
+  }
+  return { artifacts, keepTemp, version };
+}
+
+export function createAcceptancePlan({ root, version }) {
+  const cliSpecifier = `starwind@${version}`;
+  const components = ["button", "dialog", "context-menu"];
+  const createProject = (framework, scaffoldArgs, { install = false } = {}) => {
+    const directory = path.join(root, framework);
+
+    return {
+      add: {
+        args: ["dlx", cliSpecifier, "add", ...components, "--yes"],
+        cwd: directory,
+      },
+      build: { args: ["build"], cwd: directory },
+      directory,
+      framework,
+      init: {
+        args: ["dlx", cliSpecifier, "init", "--defaults", `--${framework}`],
+        cwd: directory,
+      },
+      ...(install ? { install: { args: ["install"], cwd: directory } } : {}),
+      scaffold: { args: scaffoldArgs, cwd: root },
+      version: { args: ["dlx", cliSpecifier, "--version"], cwd: directory },
+    };
+  };
+
+  return {
+    cliSpecifier,
+    projects: [
+      createProject("astro", [
+        "create",
+        "astro@latest",
+        "astro",
+        "--template",
+        "minimal",
+        "--install",
+        "--no-git",
+        "--yes",
+      ]),
+      createProject(
+        "react",
+        ["create", "vite@latest", "react", "--template", "react-ts", "--no-interactive"],
+        { install: true },
+      ),
+    ],
+    root,
+    version,
+  };
+}
+
+export function getFixtureFiles(framework) {
+  if (framework === "astro") {
+    return [{ content: ASTRO_FIXTURE, path: "src/pages/index.astro" }];
+  }
+  if (framework === "react") {
+    return [{ content: REACT_FIXTURE, path: "src/App.tsx" }];
+  }
+
+  throw new Error(`Unsupported acceptance framework: ${framework}`);
+}
+
+function getPnpmCommand() {
+  return process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+}
+
+function quoteWindowsCommandArg(argument) {
+  if (/^[A-Za-z0-9._:/=@+-]+$/.test(argument)) return argument;
+  if (/["&<>|^%!\r\n]/.test(argument)) {
+    throw new Error(`Cannot safely pass argument to cmd.exe: ${argument}`);
+  }
+  return `"${argument}"`;
+}
+
+function createSpawn(command, args) {
+  if (process.platform === "win32" && command.endsWith(".cmd")) {
+    return {
+      args: ["/d", "/s", "/c", [command, ...args].map(quoteWindowsCommandArg).join(" ")],
+      command: "cmd.exe",
+    };
+  }
+
+  return { args, command };
+}
+
+async function runCommand({ args, cwd }, { capture = false } = {}) {
+  const command = getPnpmCommand();
+  const spawned = createSpawn(command, args);
+  console.log(`[acceptance] ${path.basename(cwd)}: ${command} ${args.join(" ")}`);
+
+  return await new Promise((resolve, reject) => {
+    let stderr = "";
+    let stdout = "";
+    const child = spawn(spawned.command, spawned.args, {
+      cwd,
+      env: { ...process.env, ASTRO_TELEMETRY_DISABLED: "1" },
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+
+    if (capture) {
+      child.stdout.on("data", (chunk) => {
+        stdout += chunk.toString();
+      });
+      child.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+    }
+
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve({ stderr, stdout });
+        return;
+      }
+
+      reject(
+        new Error(
+          `${command} ${args.join(" ")} failed in ${cwd} with exit code ${code}.${stderr ? `\n${stderr}` : ""}`,
+        ),
+      );
+    });
+  });
+}
+
+async function writeFixtures(project) {
+  for (const file of getFixtureFiles(project.framework)) {
+    const target = path.join(project.directory, file.path);
+    await mkdir(path.dirname(target), { recursive: true });
+    await writeFile(target, file.content, "utf8");
+  }
+}
+
+async function validateInstalledAdapter(project) {
+  const projectManifest = JSON.parse(
+    await readFile(path.join(project.directory, "package.json"), "utf8"),
+  );
+  const packageName = `@starwind-ui/${project.framework}`;
+  const declaredVersion = projectManifest.dependencies?.[packageName];
+
+  assert.equal(typeof declaredVersion, "string", `${packageName} must be a project dependency`);
+  assert.doesNotMatch(
+    declaredVersion,
+    /^(?:workspace|file|link):/,
+    `${packageName} must come from npm`,
+  );
+
+  const adapterManifest = JSON.parse(
+    await readFile(
+      path.join(
+        project.directory,
+        "node_modules",
+        "@starwind-ui",
+        project.framework,
+        "package.json",
+      ),
+      "utf8",
+    ),
+  );
+  assert.equal(
+    adapterManifest.version,
+    declaredVersion,
+    `${packageName} must install its exact version`,
+  );
+  assert.match(
+    adapterManifest.version,
+    BETA_VERSION_PATTERN,
+    `${packageName} must be a numbered beta`,
+  );
+  assert.match(
+    adapterManifest.dependencies?.["@starwind-ui/runtime"] ?? "",
+    BETA_VERSION_PATTERN,
+    `${packageName} must depend on an exact Runtime beta`,
+  );
+
+  return {
+    adapter: `${packageName}@${adapterManifest.version}`,
+    runtime: `@starwind-ui/runtime@${adapterManifest.dependencies["@starwind-ui/runtime"]}`,
+  };
+}
+
+async function getFreePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : undefined;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}
+
+function resolvePreviewBin(project) {
+  const projectRequire = createRequire(path.join(project.directory, "package.json"));
+  const packageName = project.framework === "astro" ? "astro" : "vite";
+  const packageJsonPath = projectRequire.resolve(`${packageName}/package.json`);
+  return path.join(
+    path.dirname(packageJsonPath),
+    project.framework === "astro" ? "bin/astro.mjs" : "bin/vite.js",
+  );
+}
+
+function startPreview(project, port) {
+  const child = spawn(
+    process.execPath,
+    [resolvePreviewBin(project), "preview", "--host", HOST, "--port", String(port)],
+    {
+      cwd: project.directory,
+      env: { ...process.env, ASTRO_TELEMETRY_DISABLED: "1" },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let output = "";
+  child.stdout.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk.toString();
+  });
+
+  return { child, getOutput: () => output };
+}
+
+async function waitForPreview(url, preview) {
+  const deadline = Date.now() + 45_000;
+
+  while (Date.now() < deadline) {
+    if (preview.child.exitCode !== null) {
+      throw new Error(`Preview exited before it became ready.\n${preview.getOutput()}`);
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The preview socket is not ready yet.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Timed out waiting for ${url}.\n${preview.getOutput()}`);
+}
+
+async function stopPreview(preview) {
+  if (preview.child.exitCode !== null) return;
+  preview.child.kill();
+  await Promise.race([
+    new Promise((resolve) => preview.child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 3_000)),
+  ]);
+}
+
+async function verifyBrowserProject({ artifacts, browser, project }) {
+  const port = await getFreePort();
+  const url = `http://${HOST}:${port}/`;
+  const preview = startPreview(project, port);
+  const page = await browser.newPage({ viewport: { height: 900, width: 1280 } });
+  const browserErrors = [];
+
+  page.on("console", (message) => {
+    if (message.type() === "error") browserErrors.push(`console error: ${message.text()}`);
+  });
+  page.on("pageerror", (error) => browserErrors.push(`page error: ${error.message}`));
+  page.on("requestfailed", (request) => {
+    const failure = request.failure()?.errorText ?? "unknown failure";
+    if (failure !== "net::ERR_ABORTED") {
+      browserErrors.push(`request failed: ${request.url()} ${failure}`);
+    }
+  });
+
+  try {
+    await waitForPreview(url, preview);
+    await page.goto(url, { waitUntil: "networkidle" });
+    await page
+      .getByRole("heading", { name: new RegExp(`${project.framework} published beta`, "i") })
+      .waitFor();
+
+    const dialogTrigger = page.getByRole("button", { name: "Open dialog" });
+    await dialogTrigger.click();
+    const dialog = page.getByRole("dialog", { name: "Published package dialog" });
+    await dialog.waitFor({ state: "visible" });
+    await dialog.press("Escape");
+    await dialog.waitFor({ state: "hidden" });
+    assert.equal(
+      await page.evaluate(() => document.activeElement?.id),
+      "dialog-trigger",
+      `${project.framework} Dialog must restore focus after Escape`,
+    );
+
+    await page.locator("#context-trigger").click({ button: "right" });
+    const menuItem = page.getByRole("menuitem", { name: "Accept action" });
+    await menuItem.waitFor({ state: "visible" });
+    await menuItem.click();
+    await menuItem.waitFor({ state: "hidden" });
+
+    assert.deepEqual(browserErrors, [], `${project.framework} browser errors`);
+    console.log(`[acceptance] ${project.framework} browser behavior passed at ${url}`);
+  } catch (error) {
+    await page.screenshot({
+      fullPage: true,
+      path: path.join(artifacts, `${project.framework}-failure.png`),
+    });
+    throw error;
+  } finally {
+    await writeFile(
+      path.join(artifacts, `${project.framework}-preview.log`),
+      preview.getOutput(),
+      "utf8",
+    );
+    await page.close();
+    await stopPreview(preview);
+  }
+}
+
+export async function runPublishedBetaAcceptance(options) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "starwind-published-beta-"));
+  const artifacts = options.artifacts
+    ? path.resolve(options.artifacts)
+    : await mkdtemp(path.join(os.tmpdir(), "starwind-published-beta-artifacts-"));
+  const plan = createAcceptancePlan({ root, version: options.version });
+  const packageVersions = [];
+  let browser;
+
+  await mkdir(artifacts, { recursive: true });
+  console.log(`[acceptance] temporary projects: ${root}`);
+  console.log(`[acceptance] diagnostic artifacts: ${artifacts}`);
+
+  try {
+    for (const project of plan.projects) {
+      await runCommand(project.scaffold);
+      if (project.install) await runCommand(project.install);
+      const versionResult = await runCommand(project.version, { capture: true });
+      assert.equal(
+        versionResult.stdout.trim(),
+        options.version,
+        `Published CLI version must equal ${options.version}`,
+      );
+      await runCommand(project.init);
+      await runCommand(project.add);
+      await writeFixtures(project);
+      packageVersions.push({
+        framework: project.framework,
+        ...(await validateInstalledAdapter(project)),
+      });
+      await runCommand(project.build);
+    }
+
+    const reactDemoRequire = createRequire(path.join(REPO_ROOT, "apps/react-demo/package.json"));
+    const { chromium } = reactDemoRequire("playwright");
+    browser = await chromium.launch({ headless: true });
+
+    for (const project of plan.projects) {
+      await verifyBrowserProject({ artifacts, browser, project });
+    }
+
+    await writeFile(
+      path.join(artifacts, "summary.json"),
+      `${JSON.stringify({ cli: `starwind@${options.version}`, packages: packageVersions }, null, 2)}\n`,
+      "utf8",
+    );
+    console.log(`[acceptance] published beta ${options.version} passed in Astro and React`);
+  } finally {
+    await browser?.close();
+    if (options.keepTemp) console.log(`[acceptance] preserved temporary projects: ${root}`);
+    else await rm(root, { force: true, recursive: true });
+  }
+
+  return { artifacts, packageVersions };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  await runPublishedBetaAcceptance(options);
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/published-beta-acceptance.test.ts
+++ b/scripts/tests/published-beta-acceptance.test.ts
@@ -1,0 +1,111 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { createAcceptancePlan, getFixtureFiles, parseArgs } from "../published-beta-acceptance.mjs";
+
+describe("published beta acceptance", () => {
+  it("requires an exact numbered beta CLI version", () => {
+    expect(parseArgs(["--version", "3.0.0-beta.1"])).toEqual({
+      artifacts: undefined,
+      keepTemp: false,
+      version: "3.0.0-beta.1",
+    });
+    expect(parseArgs(["--", "--version", "3.0.0-beta.1"])).toEqual({
+      artifacts: undefined,
+      keepTemp: false,
+      version: "3.0.0-beta.1",
+    });
+
+    expect(() => parseArgs(["--version", "beta"])).toThrow(/exact numbered beta version/i);
+    expect(() => parseArgs([])).toThrow(/--version/);
+    expect(() => parseArgs(["--version", "3.0.0-beta.1", "--artifacts"])).toThrow(
+      /path after --artifacts/i,
+    );
+  });
+
+  it("plans fresh Astro and React projects against the exact CLI version", () => {
+    const root = path.resolve("published-beta-test-root");
+    const plan = createAcceptancePlan({ root, version: "3.0.0-beta.1" });
+
+    expect(plan.projects.map((project) => project.framework)).toEqual(["astro", "react"]);
+    expect(plan.projects.map((project) => project.directory)).toEqual([
+      path.join(root, "astro"),
+      path.join(root, "react"),
+    ]);
+    expect(plan.projects[0].scaffold.args).toEqual([
+      "create",
+      "astro@latest",
+      "astro",
+      "--template",
+      "minimal",
+      "--install",
+      "--no-git",
+      "--yes",
+    ]);
+    expect(plan.projects[1].scaffold.args).toEqual([
+      "create",
+      "vite@latest",
+      "react",
+      "--template",
+      "react-ts",
+      "--no-interactive",
+    ]);
+    expect(plan.projects[0].install).toBeUndefined();
+    expect(plan.projects[1].install).toEqual({ args: ["install"], cwd: path.join(root, "react") });
+
+    for (const project of plan.projects) {
+      expect(project.version.args).toEqual(["dlx", "starwind@3.0.0-beta.1", "--version"]);
+      expect(project.init.args).toEqual([
+        "dlx",
+        "starwind@3.0.0-beta.1",
+        "init",
+        "--defaults",
+        `--${project.framework}`,
+      ]);
+      expect(project.add.args).toEqual([
+        "dlx",
+        "starwind@3.0.0-beta.1",
+        "add",
+        "button",
+        "dialog",
+        "context-menu",
+        "--yes",
+      ]);
+    }
+  });
+
+  it("provides browser-observable Dialog and Context Menu fixtures for both frameworks", () => {
+    const astro = getFixtureFiles("astro");
+    const react = getFixtureFiles("react");
+
+    expect(astro.map((file) => file.path)).toEqual(["src/pages/index.astro"]);
+    expect(react.map((file) => file.path)).toEqual(["src/App.tsx"]);
+
+    for (const fixture of [astro[0].content, react[0].content]) {
+      expect(fixture).toContain('id="dialog-trigger"');
+      expect(fixture).toContain('id="dialog-content"');
+      expect(fixture).toContain('id="context-trigger"');
+      expect(fixture).toContain('id="context-item"');
+      expect(fixture).toContain("Published package dialog");
+      expect(fixture).toContain("Accept action");
+    }
+  });
+
+  it("is exposed as an explicit root command and manual post-publish workflow", async () => {
+    const rootPackage = JSON.parse(await readFile("package.json", "utf8"));
+    const workflow = await readFile(".github/workflows/published-beta-acceptance.yml", "utf8");
+    const releaseGuide = await readFile("docs/portable-runtime/beta-release.md", "utf8");
+
+    expect(rootPackage.scripts["test:published-beta"]).toBe(
+      "node scripts/published-beta-acceptance.mjs",
+    );
+    expect(workflow).toContain("workflow_dispatch:");
+    expect(workflow).toContain("version:");
+    expect(workflow).toContain("pnpm test:published-beta -- --version");
+    expect(workflow).toContain("playwright install --with-deps chromium");
+    expect(workflow).not.toContain("pull_request:");
+    expect(workflow).not.toContain("push:");
+    expect(releaseGuide).toContain("pnpm test:published-beta -- --version 3.0.0-beta.1");
+  });
+});


### PR DESCRIPTION
## What changed

- add `pnpm test:published-beta -- --version <exact-beta>`
- scaffold disposable Astro and React projects from current official templates
- run the exact published CLI through version, init, add, and production-build checks
- verify installed Astro/React adapters and Runtime come from exact numbered npm betas
- browser-test Dialog open/Escape/focus restoration and Context Menu open/item dismissal
- add a manual **Published Beta Acceptance** workflow with diagnostic artifact uploads
- document the post-publish command

## Why

The beta.1 consumer validation was previously a real but disposable manual run. This makes that release gate repeatable for future betas without adding it to ordinary pre-publish CI, where the target npm version does not exist yet.

## Validation

- TDD command, plan, fixture, and workflow tests: 4 passing
- focused release/sync tests: 26 passing privately, 20 passing in the synced public checkout
- test-home check passes
- Biome and Prettier checks pass
- guarded public sync check reports zero drift
- live `starwind@3.0.0-beta.1` run passed in fresh Astro and React projects, including both builds and browser behavior
- temporary projects were removed; diagnostic logs and version summary were produced
- Changesets reports no pending release; this does not create beta.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated acceptance test for published beta releases across Astro and React projects.
  * Added browser-based checks for builds, component interactions, accessibility behavior, and runtime errors.
  * Added support for selecting an exact beta version and saving test artifacts, logs, screenshots, and summaries.
  * Added a manually triggered workflow for running published beta acceptance tests.

* **Documentation**
  * Documented the beta acceptance process and command in the release guide.

* **Tests**
  * Added coverage for command validation, project setup plans, fixtures, workflow configuration, and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->