### PR TITLE
fix(release): make changelogs deterministic

### DIFF
--- a/.changeset/changelog.mjs
+++ b/.changeset/changelog.mjs
@@ -1,0 +1,25 @@
+function formatSummary(summary) {
+  const [firstLine, ...remainingLines] = summary
+    .split("\n")
+    .map((line) => line.trimEnd());
+
+  const continuation = remainingLines.map((line) => `  ${line}`).join("\n");
+  return continuation ? `- ${firstLine}\n${continuation}` : `- ${firstLine}`;
+}
+
+export async function getReleaseLine(changeset) {
+  return formatSummary(changeset.summary);
+}
+
+export async function getDependencyReleaseLine(_changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) return "";
+
+  return [
+    "- Updated dependencies",
+    ...dependenciesUpdated.map(
+      (dependency) => `  - ${dependency.name}@${dependency.newVersion}`,
+    ),
+  ].join("\n");
+}
+
+export default { getDependencyReleaseLine, getReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": "./.changeset/changelog.mjs",
   "commit": true,
   "fixed": [["@starwind-ui/runtime", "@starwind-ui/astro", "@starwind-ui/react"]],
   "linked": [],


### PR DESCRIPTION
## Summary

- render Changesets changelogs without repository-specific commit IDs
- preserve release summaries and dependency update entries
- keep private and public Version Packages outputs exactly reconcilable across separate Git histories

## Verification

- private focused release/sync tests: 37 passed
- private pnpm build
- guarded public sync drift check
- public frozen install
- public pnpm verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changelog**
  * Improved release note formatting with clearer bullet lists and indented multi-line summaries.
  * Added dependency update entries showing each dependency’s new version when applicable.
  * Configured releases to use the project’s customized changelog format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->