### PR TITLE
fix(release): resolve custom changelog formatter

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": "./.changeset/changelog.mjs",
+  "changelog": "./changelog.mjs",
   "commit": true,
   "fixed": [["@starwind-ui/runtime", "@starwind-ui/astro", "@starwind-ui/react"]],
   "linked": [],


### PR DESCRIPTION
## Summary

- resolve the custom changelog formatter relative to the Changesets config directory
- unblock the Version Packages workflow on Linux

## Verification

- focused release/sync tests: 37 passed
- full private pnpm build
- real pnpm changeset version completed on a fresh release branch
- guarded public sync reports zero drift

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog configuration to ensure release notes are generated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->