### PR TITLE
fix(release): regenerate registries during versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,5 +43,7 @@ jobs:
       - name: Create Release Pull Request
         # changesets/action@v1.8.0
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
+        with:
+          version: pnpm release:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "check": "pnpm lint:check && pnpm typecheck && pnpm format:check",
     "verify": "pnpm check && pnpm test:all && pnpm test:homes && pnpm runtime:generate:test && pnpm runtime:generate:typecheck && pnpm runtime:docs:metadata:check && pnpm build && pnpm audit --prod --audit-level high",
     "version": "changeset version",
+    "release:version": "changeset version && pnpm runtime:registry:generate",
     "local:release": "pnpm build && changeset version && changeset publish",
     "release:prepare": "pnpm runtime:generate:all && pnpm runtime:registry:generate && pnpm runtime:build && pnpm --filter=@starwind-ui/astro typecheck && pnpm react:build && pnpm cli:build",
     "release:gate": "pnpm verify && pnpm demo:smoke && pnpm react-demo:smoke && pnpm runtime:size:check",

--- a/packages/cli/tests/commands/init.test.ts
+++ b/packages/cli/tests/commands/init.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PATHS } from "../../src/utils/constants.js";
@@ -55,6 +57,12 @@ import * as tsconfig from "../../src/utils/tsconfig.js";
 import * as viteConfig from "../../src/utils/vite-config.js";
 import { init } from "../../src/commands/init.js";
 import { migrate } from "../../src/commands/migrate.js";
+
+const runtimePackage = JSON.parse(
+  readFileSync(new URL("../../../runtime/package.json", import.meta.url), "utf8"),
+) as { version: string };
+const CURRENT_ASTRO_SPEC = `@starwind-ui/astro@${runtimePackage.version}`;
+const CURRENT_REACT_SPEC = `@starwind-ui/react@${runtimePackage.version}`;
 
 const mockTasks = vi.mocked(clackPrompts.tasks);
 const mockGroup = vi.mocked(clackPrompts.group);
@@ -164,10 +172,7 @@ describe("init command", () => {
     expect(mockSetupReactViteConfig).toHaveBeenCalled();
     expect(mockSetupReactCssImport).toHaveBeenCalledWith(PATHS.LOCAL_CSS_FILE);
     expect(mockSetupTsConfig).toHaveBeenCalledWith("react");
-    expect(mockInstallDependencies).toHaveBeenCalledWith(
-      ["@starwind-ui/react@0.1.0-beta.1"],
-      "pnpm",
-    );
+    expect(mockInstallDependencies).toHaveBeenCalledWith([CURRENT_REACT_SPEC], "pnpm");
   });
 
   it("configures Pro authorization during fresh init without shadcn components config", async () => {
@@ -235,10 +240,7 @@ describe("init command", () => {
       }),
       { appendComponents: false },
     );
-    expect(mockInstallDependencies).toHaveBeenCalledWith(
-      ["@starwind-ui/react@0.1.0-beta.1"],
-      "pnpm",
-    );
+    expect(mockInstallDependencies).toHaveBeenCalledWith([CURRENT_REACT_SPEC], "pnpm");
 
     vi.clearAllMocks();
     mockDefaultProject();
@@ -251,10 +253,7 @@ describe("init command", () => {
       }),
       { appendComponents: false },
     );
-    expect(mockInstallDependencies).toHaveBeenCalledWith(
-      ["@starwind-ui/astro@0.1.0-beta.1"],
-      "pnpm",
-    );
+    expect(mockInstallDependencies).toHaveBeenCalledWith([CURRENT_ASTRO_SPEC], "pnpm");
   });
 
   it("recommends migrate for legacy configs before writing runtime setup", async () => {

--- a/packages/cli/tests/commands/primitives.integration.test.ts
+++ b/packages/cli/tests/commands/primitives.integration.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -42,7 +43,10 @@ import * as packageManager from "../../src/utils/package-manager.js";
 const mockInstallDependencies = vi.mocked(packageManager.installDependencies);
 const mockConfirm = vi.mocked(clackPrompts.confirm);
 const mockLog = vi.mocked(clackPrompts.log);
-const CURRENT_BETA_RUNTIME_SPEC = "@starwind-ui/runtime@^0.1.0-beta.1";
+const runtimePackage = JSON.parse(
+  readFileSync(new URL("../../../runtime/package.json", import.meta.url), "utf8"),
+) as { version: string };
+const CURRENT_BETA_RUNTIME_SPEC = `@starwind-ui/runtime@^${runtimePackage.version}`;
 
 describe.sequential("primitives add integration", () => {
   let tempDir = "";

--- a/packages/cli/tests/utils/registry.test.ts
+++ b/packages/cli/tests/utils/registry.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -12,7 +13,10 @@ import {
   type StarwindRegistry,
 } from "../../src/utils/registry.js";
 
-const CURRENT_BETA_PACKAGE_RANGE = "^0.1.0-beta.1";
+const runtimePackage = JSON.parse(
+  readFileSync(new URL("../../../runtime/package.json", import.meta.url), "utf8"),
+) as { version: string };
+const CURRENT_BETA_PACKAGE_RANGE = `^${runtimePackage.version}`;
 
 const validRegistry: StarwindRegistry = {
   $schema: "https://starwind.dev/registry-schema.v2.json",

--- a/scripts/portable-runtime/tests/generate-cli-registry.test.ts
+++ b/scripts/portable-runtime/tests/generate-cli-registry.test.ts
@@ -29,7 +29,10 @@ import {
 } from "../generate-cli-registry.js";
 import { getPrimitiveFrameworkAdapterTarget } from "../renderers/framework-adapters/index.js";
 
-const CURRENT_BETA_PACKAGE_RANGE = "^0.1.0-beta.1";
+const runtimePackage = JSON.parse(
+  await readFile(new URL("../../../packages/runtime/package.json", import.meta.url), "utf8"),
+) as { version: string };
+const CURRENT_BETA_PACKAGE_RANGE = `^${runtimePackage.version}`;
 
 describe("generateCliRegistry", () => {
   let tempRoot: string;

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -25,7 +25,6 @@ type PackageJson = {
 
 type PackageRequirement = { name: string; range: string };
 
-const CURRENT_RUNTIME_RANGE = "^0.1.0-beta.1";
 const STARWIND_RUNTIME_DEPENDENCIES = new Set([
   "@starwind-ui/runtime",
   "@starwind-ui/astro",
@@ -59,6 +58,9 @@ describe("release package tooling", () => {
 
   it("exposes generic release commands and beta compatibility aliases", async () => {
     const root = await readJson<PackageJson>("package.json");
+    expect(root.scripts?.["release:version"]).toBe(
+      "changeset version && pnpm runtime:registry:generate",
+    );
     expect(root.scripts?.["publish:release:dry-run"]).toContain(
       "node scripts/release-packages.mjs --dry-run",
     );
@@ -212,6 +214,10 @@ describe("release package tooling", () => {
   });
 
   it("keeps generated Runtime package requirements publishable", async () => {
+    const runtimePackage = await readJson<Required<Pick<PackageJson, "version">>>(
+      "packages/runtime/package.json",
+    );
+    const currentRuntimeRange = `^${runtimePackage.version}`;
     const values = [
       await readJson<unknown>("packages/cli/src/registry/bundled-registry.json"),
       await readJson<unknown>("packages/cli/src/registry/primitive-vendoring-artifacts.json"),
@@ -222,7 +228,7 @@ describe("release package tooling", () => {
       expect(requirement.range).not.toContain("workspace:");
       expect(requirement.range).not.toBe("*");
       if (STARWIND_RUNTIME_DEPENDENCIES.has(requirement.name)) {
-        expect(requirement.range).toBe(CURRENT_RUNTIME_RANGE);
+        expect(requirement.range).toBe(currentRuntimeRange);
       }
     }
   });

--- a/scripts/tests/root-verification-scripts.test.ts
+++ b/scripts/tests/root-verification-scripts.test.ts
@@ -64,5 +64,6 @@ describe("root verification scripts", () => {
 
     expect(releaseWorkflow).toContain("uses: ./.github/workflows/verify.yml");
     expect(releaseWorkflow).toMatch(/release:\s+name: Release\s+needs: verify/);
+    expect(releaseWorkflow).toContain("version: pnpm release:version");
   });
 });


### PR DESCRIPTION
## Summary

- run CLI registry generation as part of the Changesets version command
- include generated package ranges in every Version Packages PR
- derive current adapter versions in release and CLI tests instead of pinning the prior beta

## Verification

- private full pnpm verify
- private focused release/registry tests: 82 passed
- guarded public sync: 8 modified files, zero drift
- public focused release/registry tests: 76 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the release process by automatically generating runtime registry artifacts during versioning.

* **Tests**
  * Updated release and package validation checks to use the current runtime version dynamically.
  * Added verification that the release workflow uses the enhanced versioning command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->