### PR TITLE
fix(release): keep publish handoff fast

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "release:gate": "pnpm verify && pnpm demo:smoke && pnpm react-demo:smoke && pnpm runtime:size:check",
     "release:artifacts": "pnpm runtime:build && pnpm react:build && pnpm cli:build",
     "publish:release:dry-run": "pnpm release:prepare && pnpm release:gate && pnpm release:artifacts && node scripts/release-packages.mjs --dry-run",
-    "publish:release": "pnpm release:prepare && pnpm release:gate && pnpm release:artifacts && node scripts/release-packages.mjs --publish",
+    "publish:release": "node scripts/release-packages.mjs --publish",
     "release:beta:prepare": "pnpm release:prepare",
     "release:beta:gate": "pnpm release:gate",
     "release:beta:artifacts": "pnpm release:artifacts",

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -64,9 +64,7 @@ describe("release package tooling", () => {
     expect(root.scripts?.["publish:release:dry-run"]).toContain(
       "node scripts/release-packages.mjs --dry-run",
     );
-    expect(root.scripts?.["publish:release"]).toContain(
-      "node scripts/release-packages.mjs --publish",
-    );
+    expect(root.scripts?.["publish:release"]).toBe("node scripts/release-packages.mjs --publish");
     expect(root.scripts?.["publish:beta:dry-run"]).toBe("pnpm publish:release:dry-run");
     expect(root.scripts?.["publish:beta"]).toBe("pnpm publish:release");
     expect(root.scripts?.["release:gate"]).toContain("pnpm verify");


### PR DESCRIPTION
## Summary

- keep full verification, smoke, size, and build gates in the agent-owned dry-run
- make the user-owned publish command invoke only the guarded package publisher
- prevent future reintroduction with a focused script-contract test

## Verification

- regression test failed against the old command expansion
- private release/acceptance suites: 20 passed
- guarded public sync: 2 modified files, zero drift
- public release/acceptance suites: 14 passed
- all beta.2 npm coordinates remain unpublished