### PR TITLE
test(release): derive styled bump expectation

### DIFF
--- a/scripts/portable-runtime/tests/styled-component-release.test.ts
+++ b/scripts/portable-runtime/tests/styled-component-release.test.ts
@@ -341,6 +341,9 @@ describe("styled component release intents", () => {
     const currentManifestPath = path.resolve(
       "packages/cli/registry/styled-component-versions.json",
     );
+    const currentManifest = JSON.parse(await readFile(currentManifestPath, "utf8")) as {
+      components: Record<string, string>;
+    };
     await mkdir(fragmentRoot, { recursive: true });
     await mkdir(path.dirname(manifestPath), { recursive: true });
     await writeFile(manifestPath, await readFile(currentManifestPath, "utf8"));
@@ -357,7 +360,9 @@ describe("styled component release intents", () => {
     });
     const accordion = registry.components.find((component) => component.name === "accordion")!;
 
-    expect(accordion.version).toBe("2.0.2");
+    expect(accordion.version).toBe(
+      applyStyledVersionIntents(currentManifest.components, { accordion: "patch" }).accordion,
+    );
     expect(Object.keys(accordion.targets ?? {}).sort()).toEqual(["astro", "react"]);
     expect(
       Object.values(accordion.targets ?? {}).flatMap((target) =>


### PR DESCRIPTION
Makes the styled release registry test derive its expected patch version from the current manifest instead of hardcoding one release state. Validation: full private build; focused sync/release tests; frozen public install; full public pnpm verify; guarded sync check with zero drift. Release impact: none; no Changeset or package version change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated release validation to use the current component version manifest when checking generated registry artifacts.
  * Prevented test failures caused by outdated hard-coded version expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->