### PR TITLE
test(vue): allow ignored prerelease metadata

### DIFF
--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -781,8 +781,17 @@ describe("Vue non-shipping public-contract gate", () => {
     expect(changesetConfig.ignore).toEqual(approvedChangesetIgnore);
     expect(changesetConfig.fixed.flat().filter(containsBoundaryAwareVue)).toEqual([]);
     expect(findChangesetConfigVueViolations(changesetConfig)).toEqual([]);
+    const prereleaseState = JSON.parse(
+      readFileSync(join(process.cwd(), ".changeset/pre.json"), "utf8"),
+    ) as {
+      changesets: string[];
+      initialVersions: Record<string, string>;
+    };
+    expect(prereleaseState.initialVersions["vue-demo"]).toBe("0.0.0");
+    expect(prereleaseState.initialVersions["@starwind-ui/vue"]).toBe("0.0.0");
+    expect(prereleaseState.changesets.filter(containsBoundaryAwareVue)).toEqual([]);
     for (const file of listFiles(join(process.cwd(), ".changeset")).filter(
-      (candidate) => candidate !== "config.json",
+      (candidate) => candidate !== "config.json" && candidate !== "pre.json",
     )) {
       expect(
         containsBoundaryAwareVue(readFileSync(join(process.cwd(), ".changeset", file), "utf8")),


### PR DESCRIPTION
## Summary
- treat Changesets prerelease state as metadata rather than a user Changeset
- assert quarantined Vue workspaces remain recorded only at 0.0.0
- continue rejecting Vue references in actual Changeset files and IDs

## Verification
- pnpm build (private)
- pnpm verify (public)
- Vue non-shipping contract gate: 11/11 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended validation to ensure Vue prerelease metadata remains configured correctly.
  * Added checks confirming unsupported Vue changesets are excluded from prerelease metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->