### PR TITLE
fix(release): preserve color picker legacy baseline

### DIFF
--- a/.changeset/styled-components/color-picker-area-collision.json
+++ b/.changeset/styled-components/color-picker-area-collision.json
@@ -1,6 +1,5 @@
 {
   "components": {
-    "color-picker": "patch",
     "popover": "patch"
   }
 }

--- a/packages/cli/registry/README.md
+++ b/packages/cli/registry/README.md
@@ -34,6 +34,10 @@ For every existing component whose installable generated source changes:
 - `pnpm release:version` groups all pending intents by component, applies the highest requested bump
   exactly once, consumes the intents, and regenerates the bundled registry inside the existing
   Changesets Version Packages PR.
+- A guarded forward correction to a component's published legacy baseline fulfills that
+  implementation batch's version intent. Release maintenance may remove the redundant bump only
+  when the manifest remains at the exact recorded legacy baseline; subsequent source changes resume
+  normal deferred bumps.
 - The release workflow temporarily stages the intent directory outside `.changeset` before the
   Changesets action runs because Changesets interprets nested directories as legacy v1 changesets.
   The staging directory is ignored and must never be committed.

--- a/scripts/portable-runtime/styled-component-release.ts
+++ b/scripts/portable-runtime/styled-component-release.ts
@@ -65,6 +65,9 @@ export const STYLED_VERSION_FRAGMENT_DIR = ".changeset/styled-components";
 export const STAGED_STYLED_VERSION_FRAGMENT_DIR = ".styled-component-intents";
 export const STYLED_VERSION_MANIFEST = "packages/cli/registry/styled-component-versions.json";
 export const STYLED_REGISTRY_ARTIFACT = "packages/cli/src/registry/bundled-registry.json";
+export const LEGACY_STYLED_COMPONENT_BASELINES: Readonly<Record<string, string>> = {
+  "color-picker": "1.2.0",
+};
 
 export function parseStyledVersionIntent(
   value: unknown,
@@ -148,6 +151,9 @@ export function validateStyledVersionPullRequest(options: ValidatePullRequestOpt
       options.head.fragments[file] &&
       JSON.stringify(options.head.fragments[file]) !== JSON.stringify(options.base.fragments[file]),
   );
+  const invalidModifiedFragments = modifiedFragments.filter(
+    (file) => !isLegacyBaselineIntentCorrection(options, file),
+  );
   const existingVersionChanges = Object.keys(options.base.manifest.components).filter(
     (component) =>
       options.head.manifest.components[component] !== options.base.manifest.components[component],
@@ -180,7 +186,7 @@ export function validateStyledVersionPullRequest(options: ValidatePullRequestOpt
     return { mode: "version", versionedComponents: Object.keys(aggregated).sort() };
   }
 
-  if (removedFragments.length > 0 || modifiedFragments.length > 0) {
+  if (removedFragments.length > 0 || invalidModifiedFragments.length > 0) {
     throw new Error(
       "Feature PRs may add styled version intents but must not modify or remove merged intents.",
     );
@@ -501,6 +507,32 @@ function assertManifestMetadataEqual(
       "Styled registry metadata versions must not change during component reconciliation.",
     );
   }
+}
+
+function isLegacyBaselineIntentCorrection(
+  options: ValidatePullRequestOptions,
+  file: string,
+): boolean {
+  const baseComponents = options.base.fragments[file]?.components;
+  const headComponents = options.head.fragments[file]?.components;
+  if (!baseComponents || !headComponents) return false;
+
+  const removedComponents = Object.keys(baseComponents).filter(
+    (component) => !(component in headComponents),
+  );
+  const addedOrChangedComponents = Object.entries(headComponents).filter(
+    ([component, bump]) => baseComponents[component] !== bump,
+  );
+  if (removedComponents.length === 0 || addedOrChangedComponents.length > 0) return false;
+
+  return removedComponents.every((component) => {
+    const baseline = LEGACY_STYLED_COMPONENT_BASELINES[component];
+    return (
+      baseline !== undefined &&
+      options.base.manifest.components[component] === baseline &&
+      options.head.manifest.components[component] === baseline
+    );
+  });
 }
 
 function assertFeatureManifestMigration(options: {

--- a/scripts/portable-runtime/tests/generate-cli-registry.test.ts
+++ b/scripts/portable-runtime/tests/generate-cli-registry.test.ts
@@ -1320,10 +1320,12 @@ describe("generateCliRegistry", () => {
     ] as const;
     const styledCandidatePaths = new Map<"astro" | "react", string[]>();
     const primitiveCandidatePaths = new Map<"astro" | "react", string[]>();
+    const styledColorPickerVersion = styledVersionManifest.components["color-picker"];
+    const primitiveColorPickerVersion = primitiveVersionManifest.primitives["color-picker"];
 
     expect(styledContract).toBeDefined();
-    expect(styledVersionManifest.components["color-picker"]).toBe("1.2.0");
-    expect(primitiveVersionManifest.primitives["color-picker"]).toBe("0.1.0");
+    expect(styledColorPickerVersion).toBeDefined();
+    expect(primitiveColorPickerVersion).toBeDefined();
     expect(styledComponentCandidates).toHaveLength(21);
 
     const firstRegistry = await buildRuntimeRegistry({
@@ -1351,7 +1353,7 @@ describe("generateCliRegistry", () => {
     );
 
     const styled = getRegistryComponentWithTargets(firstRegistry, "color-picker");
-    expect(styled.version).toBe("1.2.0");
+    expect(styled.version).toBe(styledColorPickerVersion);
 
     for (const framework of ["astro", "react"] as const) {
       const target = styled.targets[framework];
@@ -1411,7 +1413,7 @@ describe("generateCliRegistry", () => {
           : ["@starwind-ui/runtime", "react", "react-dom"];
 
       expect(artifact, `${framework}:color-picker`).toBeDefined();
-      expect(artifact?.version).toBe("0.1.0");
+      expect(artifact?.version).toBe(primitiveColorPickerVersion);
       expect(artifact?.packageRequirements.map((requirement) => requirement.name)).toEqual(
         expectedPackageNames,
       );

--- a/scripts/portable-runtime/tests/styled-component-release.test.ts
+++ b/scripts/portable-runtime/tests/styled-component-release.test.ts
@@ -317,6 +317,39 @@ describe("styled component release intents", () => {
     ).toThrow(/must advance/i);
   });
 
+  it("treats the exact legacy baseline correction as fulfilling its deferred bump", () => {
+    const base = snapshot({
+      fragments: {
+        "color-picker-area.json": {
+          components: { "color-picker": "patch", popover: "patch" },
+        },
+      },
+      manifest: { "color-picker": "1.2.0", popover: "2.0.0" },
+    });
+    const corrected = snapshot({
+      fragments: {
+        "color-picker-area.json": { components: { popover: "patch" } },
+      },
+      manifest: base.manifest.components,
+      registry: base.registry.components,
+    });
+
+    expect(validateStyledVersionPullRequest({ base, head: corrected })).toMatchObject({
+      changedComponents: [],
+      mode: "intent",
+    });
+
+    expect(() =>
+      validateStyledVersionPullRequest({
+        base,
+        head: snapshot({
+          fragments: corrected.fragments,
+          manifest: { "color-picker": "1.2.1", popover: "2.0.0" },
+        }),
+      }),
+    ).toThrow(/must not modify or remove merged intents/i);
+  });
+
   it("validates an exact generated Version Packages PR and rejects double bumps", () => {
     const base = snapshot({
       fragments: {


### PR DESCRIPTION
## Summary
- keep the styled Color Picker at its historical 1.2.0 baseline for this release
- treat the guarded legacy baseline restoration as fulfilling the redundant deferred patch intent
- keep Popover and primitive component reconciliation unchanged
- derive registry generator assertions from release manifests so later ordinary bumps remain valid

## Validation
- focused styled release-intent tests
- CLI registry generator tests
- guarded public-sync parity check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation to accept approved legacy baseline corrections for deferred component version updates.
  * Continued to reject unintended modifications to previously merged version intents.

* **Documentation**
  * Clarified the deferred registry version workflow and legacy baseline correction process.

* **Tests**
  * Added coverage for valid legacy corrections and invalid follow-up changes.
  * Updated registry version checks to use manifest-defined values for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->