### PR TITLE
test(release): harden beta gate expectations

### DIFF
--- a/scripts/portable-runtime/tests/generate-layered-docs-metadata.test.ts
+++ b/scripts/portable-runtime/tests/generate-layered-docs-metadata.test.ts
@@ -397,7 +397,7 @@ describe("generateLayeredDocsMetadata", () => {
       metadata.primitives.map((primitive) => [primitive.id, primitive.registryVersion]),
     );
 
-    expect(versions.accordion).toBe("0.1.1");
+    expect(versions.accordion).toBe("0.1.2");
     expect(versions.select).toBe("0.1.2");
     expect(Object.keys(versions)).toHaveLength(runtimeAdapterContracts.length);
 

--- a/scripts/portable-runtime/tests/specialized-adapter-spec.test.ts
+++ b/scripts/portable-runtime/tests/specialized-adapter-spec.test.ts
@@ -1167,7 +1167,7 @@ describe("SpecializedAdapterSpec", () => {
       expect(adapterSource).not.toMatch(/\bconst select\s*=/);
       expect(adapterSource).not.toMatch(/\bselect\./);
     }
-  }, 60_000);
+  }, 120_000);
 
   it("rejects Select writer specs when adapter-facing facts drift from the writer assumptions", async () => {
     const spec = buildSelectSpecializedAdapterSpec(selectRuntimeAdapterContract);


### PR DESCRIPTION
## Summary

- update the released Accordion inventory expectation to the reconciled 0.1.2 registry version
- raise the existing Select generator test timeout for the full concurrent release suite

## Verification

- focused Vitest: 209 tests passed
- guarded private-to-public sync: exactly 2 modifications, no additions or deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the expected released Accordion version in the metadata validation test.
  * Increased the timeout for a specialized adapter test to reduce failures during longer-running checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->