### PR TITLE
test(release): avoid pinning primitive versions

### DIFF
--- a/scripts/portable-runtime/tests/generate-layered-docs-metadata.test.ts
+++ b/scripts/portable-runtime/tests/generate-layered-docs-metadata.test.ts
@@ -397,9 +397,9 @@ describe("generateLayeredDocsMetadata", () => {
       metadata.primitives.map((primitive) => [primitive.id, primitive.registryVersion]),
     );
 
-    expect(versions.accordion).toBe("0.1.2");
-    expect(versions.select).toBe("0.1.2");
-    expect(Object.keys(versions)).toHaveLength(runtimeAdapterContracts.length);
+    expect(Object.keys(versions).sort()).toEqual(
+      runtimeAdapterContracts.map((contract) => contract.component).sort(),
+    );
 
     const { accordion: _missing, ...missingAccordion } = versions;
     expect(() => buildLayeredDocsMetadata({ primitiveVersions: missingAccordion })).toThrow(


### PR DESCRIPTION
## Summary

- remove concrete Accordion and Select version assertions from layered docs metadata tests
- assert the durable inventory contract: released Primitive IDs exactly match Runtime adapter contract IDs
- retain missing, unknown, and invalid SemVer rejection coverage

## Verification

- focused layered docs metadata suite: 48 tests passed
- guarded private-to-public sync: exactly 1 modification, no additions or deletions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated validation for the released Primitive version inventory.
  * Ensured generated metadata includes exactly the expected set of component identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->