### PR TITLE
fix(deps): require patched fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   ajv@>=6.0.0 <7.0.0: 6.12.6
-  fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   postcss@<=8.5.17: ^8.5.18
   sharp@<0.35.0: ^0.35.0
@@ -2834,8 +2834,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6608,7 +6608,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7437,7 +7437,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,12 +28,12 @@ minimumReleaseAgeExclude:
   - "@astrojs/markdown-remark"
   - js-yaml@4.3.0
   - svgo@4.0.2
-  - fast-uri@3.1.4
+  - fast-uri@3.1.5
   - sharp@0.35.0
 
 overrides:
   ajv@>=6.0.0 <7.0.0: 6.12.6
-  fast-uri@>=3.0.0 <=3.1.3: ^3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   js-yaml@>=4.0.0 <4.3.0: ^4.3.0
   postcss@<=8.5.17: ^8.5.18
   sharp@<0.35.0: ^0.35.0


### PR DESCRIPTION
## Summary
- advance the existing fast-uri security override to patched v3.1.5
- refresh the frozen lockfile before beta.6 publication

## Validation
- pnpm audit --prod --audit-level high (0 high/critical; 1 moderate, 1 low)
- pnpm build
- pnpm install --frozen-lockfile
- pnpm verify
- guarded public sync --check (zero drift)

## Release impact
No package version changes. This clears the beta.6 prepublication security gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the URI handling dependency to version 3.1.5 for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->