### PR TITLE
chore(release): exit runtime beta

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "demo": "0.0.1",

--- a/.changeset/stable-runtime-release.md
+++ b/.changeset/stable-runtime-release.md
@@ -1,0 +1,7 @@
+---
+"@starwind-ui/runtime": major
+"@starwind-ui/astro": major
+"@starwind-ui/react": major
+---
+
+Release the first stable Runtime adapter line for Astro and React.


### PR DESCRIPTION
## Summary

- add the release-only major Changeset for `@starwind-ui/runtime`, `@starwind-ui/astro`, and `@starwind-ui/react`
- exit the Changesets `beta` prerelease state
- target stable versions `1.0.0` for Runtime adapters and `3.0.0` for the CLI

## Verification

- `pnpm release:status`
- guarded public sync check reports zero drift
- private release-policy and sync tests: 56 passed

Package versions remain unchanged in this PR. The generated Version Packages PR will apply them after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Marked the Runtime adapter packages for their first stable major release in Astro and React.
  * Updated the release process to exit pre-release mode and publish stable versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->