### PR TITLE
fix(release): exclude private packages from stable plan

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -14,5 +14,9 @@
     "@starwind-ui/core",
     "@starwind-ui/vue",
     "@starwind-ui/svelte"
-  ]
+  ],
+  "privatePackages": {
+    "version": false,
+    "tag": false
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ overrides:
 
 pnpmfileChecksum: sha256-KXAYsajFRu5/YyKQ1xdizvQd2rAWeo1KyrN3JMpI5h0=
 
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.10': ca272eded02588ce0c2bc5f2a45edb4a8e320c6652be3f3ef08b5ac5c494a79e
+
 importers:
 
   .:
@@ -5193,7 +5196,7 @@ snapshots:
       resolve-from: 5.0.0
       semver: 7.8.1
 
-  '@changesets/assemble-release-plan@6.0.10':
+  '@changesets/assemble-release-plan@6.0.10(patch_hash=ca272eded02588ce0c2bc5f2a45edb4a8e320c6652be3f3ef08b5ac5c494a79e)':
     dependencies:
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.1.4
@@ -5209,7 +5212,7 @@ snapshots:
   '@changesets/cli@2.31.0(@types/node@24.12.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
-      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/assemble-release-plan': 6.0.10(patch_hash=ca272eded02588ce0c2bc5f2a45edb4a8e320c6652be3f3ef08b5ac5c494a79e)
       '@changesets/changelog-git': 0.2.1
       '@changesets/config': 3.1.4
       '@changesets/errors': 0.2.0
@@ -5261,7 +5264,7 @@ snapshots:
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
-      '@changesets/assemble-release-plan': 6.0.10
+      '@changesets/assemble-release-plan': 6.0.10(patch_hash=ca272eded02588ce0c2bc5f2a45edb4a8e320c6652be3f3ef08b5ac5c494a79e)
       '@changesets/config': 3.1.4
       '@changesets/pre': 2.0.2
       '@changesets/read': 0.6.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,3 +39,6 @@ overrides:
   postcss@<=8.5.17: ^8.5.18
   sharp@<0.35.0: ^0.35.0
   svgo@>=4.0.0 <4.0.2: ^4.0.2
+
+patchedDependencies:
+  '@changesets/assemble-release-plan@6.0.10': scripts/portable-runtime/patches/@changesets__assemble-release-plan@6.0.10.patch

--- a/scripts/portable-runtime/patches/@changesets__assemble-release-plan@6.0.10.patch
+++ b/scripts/portable-runtime/patches/@changesets__assemble-release-plan@6.0.10.patch
@@ -1,0 +1,110 @@
+diff --git a/dist/changesets-assemble-release-plan.cjs.js b/dist/changesets-assemble-release-plan.cjs.js
+index a91112a7ddf4b6f242965e0bf99ba2f60f988ede..d2704bdc89cfd6256f991958bf3b952722bd47f1 100644
+--- a/dist/changesets-assemble-release-plan.cjs.js
++++ b/dist/changesets-assemble-release-plan.cjs.js
+@@ -544,10 +544,17 @@ snapshot) {
+   }
+   if ((preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) === "exit") {
+     for (let pkg of packages.packages) {
++      if (shouldSkipPackage.shouldSkipPackage(pkg, {
++        ignore: refinedConfig.ignore,
++        allowPrivatePackages: refinedConfig.privatePackages.version
++      })) {
++        continue;
++      }
++      const preVersion = preInfo.preVersions.get(pkg.packageJson.name);
+       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
+       // we want to give it a patch release.
+       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
+-      if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
++      if (preVersion != null && preVersion !== 0) {
+         const existingRelease = releases.get(pkg.packageJson.name);
+         if (!existingRelease) {
+           releases.set(pkg.packageJson.name, {
+@@ -556,10 +563,7 @@ snapshot) {
+             oldVersion: pkg.packageJson.version,
+             changesets: []
+           });
+-        } else if (existingRelease.type === "none" && !shouldSkipPackage.shouldSkipPackage(pkg, {
+-          ignore: refinedConfig.ignore,
+-          allowPrivatePackages: refinedConfig.privatePackages.version
+-        })) {
++        } else if (existingRelease.type === "none") {
+           existingRelease.type = "patch";
+         }
+       }
+diff --git a/dist/changesets-assemble-release-plan.esm.js b/dist/changesets-assemble-release-plan.esm.js
+index f169d0a18a4acfc6672d52337fc757a21050ae72..54ad0315265c7f3d4cd4ef4f2e200902441fee24 100644
+--- a/dist/changesets-assemble-release-plan.esm.js
++++ b/dist/changesets-assemble-release-plan.esm.js
+@@ -531,10 +531,17 @@ snapshot) {
+   }
+   if ((preInfo === null || preInfo === void 0 ? void 0 : preInfo.state.mode) === "exit") {
+     for (let pkg of packages.packages) {
++      if (shouldSkipPackage(pkg, {
++        ignore: refinedConfig.ignore,
++        allowPrivatePackages: refinedConfig.privatePackages.version
++      })) {
++        continue;
++      }
++      const preVersion = preInfo.preVersions.get(pkg.packageJson.name);
+       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
+       // we want to give it a patch release.
+       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
+-      if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
++      if (preVersion != null && preVersion !== 0) {
+         const existingRelease = releases.get(pkg.packageJson.name);
+         if (!existingRelease) {
+           releases.set(pkg.packageJson.name, {
+@@ -543,10 +550,7 @@ snapshot) {
+             oldVersion: pkg.packageJson.version,
+             changesets: []
+           });
+-        } else if (existingRelease.type === "none" && !shouldSkipPackage(pkg, {
+-          ignore: refinedConfig.ignore,
+-          allowPrivatePackages: refinedConfig.privatePackages.version
+-        })) {
++        } else if (existingRelease.type === "none") {
+           existingRelease.type = "patch";
+         }
+       }
+diff --git a/src/index.ts b/src/index.ts
+index 5ebe2dbba619156233b1c510a557bd32368bf83b..d2215a7f1519430f34deaa0fba7517920bea5391 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -218,10 +218,19 @@ function assembleReleasePlan(
+ 
+   if (preInfo?.state.mode === "exit") {
+     for (let pkg of packages.packages) {
++      if (
++        shouldSkipPackage(pkg, {
++          ignore: refinedConfig.ignore,
++          allowPrivatePackages: refinedConfig.privatePackages.version,
++        })
++      ) {
++        continue;
++      }
++      const preVersion = preInfo.preVersions.get(pkg.packageJson.name);
+       // If a package had a prerelease, but didn't trigger a version bump in the regular release,
+       // we want to give it a patch release.
+       // Detailed explanation at https://github.com/changesets/changesets/pull/382#discussion_r434434182
+-      if (preInfo.preVersions.get(pkg.packageJson.name) !== 0) {
++      if (preVersion != null && preVersion !== 0) {
+         const existingRelease = releases.get(pkg.packageJson.name);
+         if (!existingRelease) {
+           releases.set(pkg.packageJson.name, {
+@@ -230,13 +239,7 @@ function assembleReleasePlan(
+             oldVersion: pkg.packageJson.version,
+             changesets: [],
+           });
+-        } else if (
+-          existingRelease.type === "none" &&
+-          !shouldSkipPackage(pkg, {
+-            ignore: refinedConfig.ignore,
+-            allowPrivatePackages: refinedConfig.privatePackages.version,
+-          })
+-        ) {
++        } else if (existingRelease.type === "none") {
+           existingRelease.type = "patch";
+         }
+       }

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { createSpawnCommand } from "./command-process.mjs";
 import {
   CHANGESET_IGNORED_PACKAGES,
+  CHANGESET_PRIVATE_PACKAGE_POLICY,
   RUNTIME_RELEASE_PACKAGE_SET,
 } from "./runtime-release-policy.mjs";
 
@@ -161,6 +162,11 @@ export function validateReleaseChangesetConfig(config) {
   const errors = [];
   if (JSON.stringify(ignoredPackages) !== JSON.stringify(expectedIgnoredPackages)) {
     errors.push(`Changesets must ignore exactly: ${expectedIgnoredPackages.join(", ")}.`);
+  }
+  if (
+    JSON.stringify(config?.privatePackages) !== JSON.stringify(CHANGESET_PRIVATE_PACKAGE_POLICY)
+  ) {
+    errors.push("Changesets must disable private package versioning and tagging.");
   }
   return { errors, ok: errors.length === 0 };
 }

--- a/scripts/runtime-release-policy.mjs
+++ b/scripts/runtime-release-policy.mjs
@@ -7,6 +7,11 @@ export const CHANGESET_IGNORED_PACKAGES = Object.freeze([
   "@starwind-ui/svelte",
 ]);
 
+export const CHANGESET_PRIVATE_PACKAGE_POLICY = Object.freeze({
+  version: false,
+  tag: false,
+});
+
 export const RUNTIME_FIXED_GROUP = Object.freeze([
   "@starwind-ui/runtime",
   "@starwind-ui/astro",

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -1,4 +1,5 @@
 import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { EventEmitter } from "node:events";
@@ -33,6 +34,7 @@ import {
 import { createSpawnCommand, getPackageManagerCommand } from "../command-process.mjs";
 import {
   CHANGESET_IGNORED_PACKAGES,
+  CHANGESET_PRIVATE_PACKAGE_POLICY,
   RUNTIME_FIXED_GROUP,
   RUNTIME_RELEASE_PACKAGE_SET,
 } from "../runtime-release-policy.mjs";
@@ -177,6 +179,121 @@ describe("release package tooling", () => {
     for (const file of changesetFiles) {
       assertNoPrivateAdapterChangesetReleases(file, await readFile(`.changeset/${file}`, "utf8"));
     }
+  });
+
+  it("keeps ignored private packages out of the stable prerelease exit plan", () => {
+    const rootRequire = createRequire(import.meta.url);
+    const changesetsRequire = createRequire(rootRequire.resolve("@changesets/cli/package.json"));
+    const assembleReleasePlan = changesetsRequire("@changesets/assemble-release-plan").default as (
+      changesets: Array<{
+        id: string;
+        releases: Array<{ name: string; type: "major" }>;
+        summary: string;
+      }>,
+      packages: {
+        root: { dir: string; packageJson: PackageJson };
+        packages: Array<{ dir: string; packageJson: PackageJson }>;
+      },
+      config: Record<string, unknown>,
+      preState: {
+        changesets: string[];
+        initialVersions: Record<string, string>;
+        mode: "exit";
+        tag: string;
+      },
+    ) => { releases: Array<{ name: string; newVersion: string; type: string }> };
+    const makePackage = (name: string, version: string, extra: PackageJson = {}) => ({
+      dir: `/tmp/starwind-changesets-exit/${name.replaceAll("/", "-")}`,
+      packageJson: { name, version, ...extra },
+    });
+    const packages = {
+      root: {
+        dir: "/tmp/starwind-changesets-exit",
+        packageJson: { name: "root", private: true, version: "0.0.0" },
+      },
+      packages: [
+        makePackage("@starwind-ui/runtime", "0.1.0-beta.1"),
+        makePackage("@starwind-ui/astro", "0.1.0-beta.1", {
+          dependencies: { "@starwind-ui/runtime": "workspace:^" },
+        }),
+        makePackage("@starwind-ui/react", "0.1.0-beta.1", {
+          dependencies: { "@starwind-ui/runtime": "workspace:^" },
+        }),
+        makePackage("starwind", "3.0.0-beta.1"),
+        makePackage("@starwind-ui/core", "2.0.1", { private: true }),
+        makePackage("@starwind-ui/vue", "0.0.0", {
+          dependencies: { "@starwind-ui/runtime": "workspace:^" },
+          private: true,
+        }),
+        makePackage("@starwind-ui/svelte", "0.0.0", {
+          dependencies: { "@starwind-ui/runtime": "workspace:^" },
+          private: true,
+        }),
+      ],
+    };
+    const changesets = [
+      {
+        id: "runtime-stable",
+        releases: [{ name: "@starwind-ui/runtime", type: "major" as const }],
+        summary: "Release Runtime as stable.",
+      },
+      {
+        id: "cli-stable",
+        releases: [{ name: "starwind", type: "major" as const }],
+        summary: "Release the CLI as stable.",
+      },
+    ];
+    const initialVersions = Object.fromEntries(
+      packages.packages.map(({ packageJson }) => [packageJson.name, packageJson.version]),
+    ) as Record<string, string>;
+
+    const plan = assembleReleasePlan(
+      changesets,
+      packages,
+      {
+        ___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH: {
+          onlyUpdatePeerDependentsWhenOutOfRange: false,
+          updateInternalDependents: "out-of-range",
+        },
+        access: "public",
+        baseBranch: "main",
+        bumpVersionsWithWorkspaceProtocolOnly: false,
+        changedFilePatterns: ["**"],
+        changelog: false,
+        commit: false,
+        fixed: [["@starwind-ui/runtime", "@starwind-ui/astro", "@starwind-ui/react"]],
+        ignore: ["@starwind-ui/core", "@starwind-ui/vue", "@starwind-ui/svelte"],
+        linked: [],
+        prettier: true,
+        privatePackages: CHANGESET_PRIVATE_PACKAGE_POLICY,
+        snapshot: { prereleaseTemplate: null, useCalculatedVersion: false },
+        updateInternalDependencies: "patch",
+      },
+      {
+        changesets: changesets.map(({ id }) => id),
+        initialVersions,
+        mode: "exit",
+        tag: "beta",
+      },
+    );
+    const versionedReleases = Object.fromEntries(
+      plan.releases
+        .filter(({ type }) => type !== "none")
+        .map(({ name, newVersion }) => [name, newVersion]),
+    );
+
+    expect(versionedReleases).toEqual({
+      "@starwind-ui/astro": "1.0.0",
+      "@starwind-ui/react": "1.0.0",
+      "@starwind-ui/runtime": "1.0.0",
+      starwind: "3.0.0",
+    });
+    expect(plan.releases.find(({ name }) => name === "@starwind-ui/core")).toBeUndefined();
+    expect(
+      plan.releases
+        .filter(({ name }) => PRIVATE_ADAPTER_PACKAGE_NAMES.has(name))
+        .every(({ newVersion, type }) => newVersion === "0.0.0" && type === "none"),
+    ).toBe(true);
   });
 
   it("rejects single-quoted private package releases in Changeset frontmatter", () => {
@@ -662,9 +779,21 @@ describe("release package tooling", () => {
         tag: "beta",
       }).ok,
     ).toBe(false);
+    expect(
+      validateReleaseChangesetConfig({
+        ignore: [...CHANGESET_IGNORED_PACKAGES],
+        privatePackages: CHANGESET_PRIVATE_PACKAGE_POLICY,
+      }).ok,
+    ).toBe(true);
     expect(validateReleaseChangesetConfig({ ignore: [...CHANGESET_IGNORED_PACKAGES] }).ok).toBe(
-      true,
+      false,
     );
+    expect(
+      validateReleaseChangesetConfig({
+        ignore: [...CHANGESET_IGNORED_PACKAGES],
+        privatePackages: { version: true, tag: false },
+      }).ok,
+    ).toBe(false);
     expect(validateReleaseChangesetConfig({ ignore: ["demo"] }).ok).toBe(false);
   });
 


### PR DESCRIPTION
Fix the Changesets prerelease-exit plan so ignored private packages stay outside the stable release.\n\n- disable private package versioning and tagging in policy\n- patch the upstream Changesets 6.0.10 exit-mode guard\n- add a synthetic stable-plan regression\n\nPrivate release gate passed, and the public sync check reports zero drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Management**
  * Private packages are no longer automatically versioned or tagged during releases.
  * Release validation now ensures private-package settings follow the required policy.

* **Bug Fixes**
  * Prerelease exits now correctly exclude skipped private packages.
  * Prevented invalid prerelease versions from generating unintended releases.
  * Existing “none” releases are handled as patches without duplicate processing.

* **Tests**
  * Added coverage for stable prerelease exits and private-package release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->