### PR TITLE
fix(release): refresh stable Vue vendoring trust

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:homes": "node scripts/check-test-homes.mjs",
     "test:published-release": "node scripts/published-release-acceptance.mjs",
     "test:published-beta": "pnpm test:published-release",
-    "test:windows-packed-cli": "pnpm cli:build && node scripts/windows-packed-cli-smoke.mjs",
+    "test:windows-packed-cli": "pnpm runtime:build && pnpm cli:build && node scripts/windows-packed-cli-smoke.mjs",
     "test:cli-host-acceptance": "pnpm cli:build && pnpm runtime:build && pnpm react:build && node scripts/cli-host-acceptance.mjs",
     "cli:dev": "pnpm --filter=starwind dev",
     "cli:build": "pnpm --filter=starwind build",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -15,6 +15,7 @@ import {
   updateConfig,
 } from "@/utils/config.js";
 import { ASTRO_PACKAGES, MIN_ASTRO_VERSION, PATHS } from "@/utils/constants.js";
+import { filterUninstalledDependencies } from "@/utils/dependency-resolver.js";
 import { checkStarwindProEnv, setupStarwindProEnv } from "@/utils/env.js";
 import {
   type FrameworkTargetPolicy,
@@ -736,8 +737,11 @@ export async function init(
     installTasks.push({
       title: "Installing Starwind Runtime packages",
       task: async () => {
-        await installDependencies([runtimeSetupPlan.adapterPackage], pm);
-        return "Installed Starwind Runtime packages successfully";
+        const missingPackages = await filterUninstalledDependencies([
+          runtimeSetupPlan.adapterPackage,
+        ]);
+        if (missingPackages.length > 0) await installDependencies(missingPackages, pm);
+        return "Starwind Runtime packages are ready";
       },
     });
 

--- a/packages/cli/src/utils/framework-target-policy.ts
+++ b/packages/cli/src/utils/framework-target-policy.ts
@@ -69,7 +69,7 @@ export const PRIVATE_VUE_FRAMEWORK_TARGET_POLICY =
       vue: "Vue",
     },
     primitiveArtifactIntegrity: {
-      vue: "sha256:c8c3c665d52b397d311264b5ae38a9ac3ff116ebfaee9e6771f126a933c84909",
+      vue: "sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f",
     },
     requiredAdapterPackages: {
       "legacy-astro": [],

--- a/packages/cli/tests/commands/init.test.ts
+++ b/packages/cli/tests/commands/init.test.ts
@@ -623,10 +623,7 @@ describe("init command", () => {
     }
 
     expect(mockConfirm).not.toHaveBeenCalled();
-    expect(mockInstallDependencies.mock.calls).toEqual([
-      [[CURRENT_VUE_SPEC], "pnpm"],
-      [[CURRENT_VUE_SPEC], "pnpm"],
-    ]);
+    expect(mockInstallDependencies).not.toHaveBeenCalled();
     expect(
       mockTasks.mock.calls.flatMap(([tasks]) => tasks.map((task) => task.title)),
     ).not.toContain("Installing packages");
@@ -1131,6 +1128,25 @@ describe("init command", () => {
       appendComponents: false,
     });
     expect(mockInstallDependencies.mock.calls[0]).toEqual([[CURRENT_ASTRO_SPEC], "pnpm"]);
+  });
+
+  it("preserves a packed local adapter during prepublish initialization", async () => {
+    mockReadJsonFile.mockResolvedValue({
+      dependencies: {
+        "@starwind-ui/astro": "file:/tmp/starwind-astro.tgz",
+        "@starwind-ui/runtime": "file:/tmp/starwind-runtime.tgz",
+        astro: "^7.0.0",
+      },
+    });
+
+    await init(true, { defaults: true, packageManager: "pnpm" });
+
+    expect(mockInstallDependencies.mock.calls).toEqual([
+      [ASTRO_SETUP_REQUIREMENTS, "pnpm", false, false],
+    ]);
+    expect(JSON.stringify(mockInstallDependencies.mock.calls)).not.toContain(
+      JSON.stringify(CURRENT_ASTRO_SPEC),
+    );
   });
 
   it("requires an explicit framework when defaults cannot identify the project", async () => {

--- a/packages/cli/tests/utils/framework-target-policy.test.ts
+++ b/packages/cli/tests/utils/framework-target-policy.test.ts
@@ -39,7 +39,7 @@ describe("CLI framework target policy", () => {
       setupTargets: ["astro", "react", "vue"],
       labels: { astro: "Astro", react: "React", vue: "Vue" },
       primitiveArtifactIntegrity: {
-        vue: "sha256:c8c3c665d52b397d311264b5ae38a9ac3ff116ebfaee9e6771f126a933c84909",
+        vue: "sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f",
       },
       requiredAdapterPackages: {
         "legacy-astro": [],
@@ -56,7 +56,7 @@ describe("CLI framework target policy", () => {
   it("binds private Primitive artifacts to the exact immutable capability policy", () => {
     expect(
       getPrimitiveArtifactIntegrityFingerprint(PRIVATE_VUE_FRAMEWORK_TARGET_POLICY, "vue"),
-    ).toBe("sha256:c8c3c665d52b397d311264b5ae38a9ac3ff116ebfaee9e6771f126a933c84909");
+    ).toBe("sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f");
     expect(
       getPrimitiveArtifactIntegrityFingerprint(PRIVATE_VUE_FRAMEWORK_TARGET_POLICY, "astro"),
     ).toBeUndefined();

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -661,15 +661,16 @@ describe("Vue non-shipping public-contract gate", () => {
     expect(changesetConfig.ignore).toEqual(approvedChangesetIgnore);
     expect(changesetConfig.fixed.flat().filter(containsBoundaryAwareVue)).toEqual([]);
     expect(findChangesetConfigVueViolations(changesetConfig)).toEqual([]);
-    const prereleaseState = JSON.parse(
-      readFileSync(join(process.cwd(), ".changeset/pre.json"), "utf8"),
-    ) as {
-      changesets: string[];
-      initialVersions: Record<string, string>;
-    };
-    expect(prereleaseState.initialVersions["vue-demo"]).toBe("0.0.0");
-    expect(prereleaseState.initialVersions["@starwind-ui/vue"]).toBe("0.0.0");
-    expect(prereleaseState.changesets.filter(containsBoundaryAwareVue)).toEqual([]);
+    const prereleaseStatePath = join(process.cwd(), ".changeset/pre.json");
+    if (existsSync(prereleaseStatePath)) {
+      const prereleaseState = JSON.parse(readFileSync(prereleaseStatePath, "utf8")) as {
+        changesets: string[];
+        initialVersions: Record<string, string>;
+      };
+      expect(prereleaseState.initialVersions["vue-demo"]).toBe("0.0.0");
+      expect(prereleaseState.initialVersions["@starwind-ui/vue"]).toBe("0.0.0");
+      expect(prereleaseState.changesets.filter(containsBoundaryAwareVue)).toEqual([]);
+    }
     for (const file of listFiles(join(process.cwd(), ".changeset")).filter(
       (candidate) => candidate !== "config.json" && candidate !== "pre.json",
     )) {

--- a/scripts/tests/windows-packed-cli-smoke.test.ts
+++ b/scripts/tests/windows-packed-cli-smoke.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   assertCleanLifecycle,
+  createPackedAstroProjectManifest,
   createPackedLifecycleArgs,
   createWindowsPackedCliPlan,
   runCommand,
@@ -15,6 +16,11 @@ describe("Windows packed CLI smoke", () => {
     const root = path.resolve("windows-packed-cli");
     const packageUrl = "http://127.0.0.1:4321/starwind-cli.tgz";
     const plan = createWindowsPackedCliPlan(root, packageUrl);
+    const projectManifest = createPackedAstroProjectManifest(
+      plan.projects.standalone.directory,
+      plan.artifacts,
+    );
+    const runtimeSpecifier = `file:${plan.artifacts.runtime.replaceAll("\\", "/")}`;
 
     expect(plan.packageUrl).toBe(packageUrl);
     expect(plan.tarball).toBe(path.join(root, "artifacts", "starwind-cli.tgz"));
@@ -24,6 +30,10 @@ describe("Windows packed CLI smoke", () => {
       runtime: path.join(root, "artifacts", "starwind-runtime.tgz"),
     });
     expect(plan.tarball).toBe(plan.artifacts.cli);
+    expect(projectManifest.dependencies["@starwind-ui/runtime"]).toBe(runtimeSpecifier);
+    expect(projectManifest.pnpm.overrides).toEqual({
+      "@starwind-ui/runtime": runtimeSpecifier,
+    });
     expect(plan.projects.standalone.shim).toBe(
       path.join(root, "standalone", "node_modules", ".bin", "starwind.CMD"),
     );

--- a/scripts/tests/windows-packed-cli-smoke.test.ts
+++ b/scripts/tests/windows-packed-cli-smoke.test.ts
@@ -18,6 +18,12 @@ describe("Windows packed CLI smoke", () => {
 
     expect(plan.packageUrl).toBe(packageUrl);
     expect(plan.tarball).toBe(path.join(root, "artifacts", "starwind-cli.tgz"));
+    expect(plan.artifacts).toEqual({
+      astro: path.join(root, "artifacts", "starwind-astro.tgz"),
+      cli: path.join(root, "artifacts", "starwind-cli.tgz"),
+      runtime: path.join(root, "artifacts", "starwind-runtime.tgz"),
+    });
+    expect(plan.tarball).toBe(plan.artifacts.cli);
     expect(plan.projects.standalone.shim).toBe(
       path.join(root, "standalone", "node_modules", ".bin", "starwind.CMD"),
     );

--- a/scripts/tests/windows-packed-cli-smoke.test.ts
+++ b/scripts/tests/windows-packed-cli-smoke.test.ts
@@ -7,6 +7,7 @@ import {
   assertCleanLifecycle,
   createPackedAstroProjectManifest,
   createPackedLifecycleArgs,
+  createPackedPnpmWorkspace,
   createWindowsPackedCliPlan,
   runCommand,
 } from "../windows-packed-cli-smoke.mjs";
@@ -21,6 +22,7 @@ describe("Windows packed CLI smoke", () => {
       plan.artifacts,
     );
     const runtimeSpecifier = `file:${plan.artifacts.runtime.replaceAll("\\", "/")}`;
+    const pnpmWorkspace = createPackedPnpmWorkspace(plan.artifacts);
 
     expect(plan.packageUrl).toBe(packageUrl);
     expect(plan.tarball).toBe(path.join(root, "artifacts", "starwind-cli.tgz"));
@@ -31,9 +33,10 @@ describe("Windows packed CLI smoke", () => {
     });
     expect(plan.tarball).toBe(plan.artifacts.cli);
     expect(projectManifest.dependencies["@starwind-ui/runtime"]).toBe(runtimeSpecifier);
-    expect(projectManifest.pnpm.overrides).toEqual({
-      "@starwind-ui/runtime": runtimeSpecifier,
-    });
+    expect(projectManifest).not.toHaveProperty("pnpm");
+    expect(pnpmWorkspace).toContain(
+      `overrides:\n  "@starwind-ui/runtime": "${runtimeSpecifier}"\n`,
+    );
     expect(plan.projects.standalone.shim).toBe(
       path.join(root, "standalone", "node_modules", ".bin", "starwind.CMD"),
     );

--- a/scripts/windows-packed-cli-smoke.mjs
+++ b/scripts/windows-packed-cli-smoke.mjs
@@ -148,26 +148,32 @@ function fileSpecifier(file) {
   return `file:${file.replaceAll("\\", "/")}`;
 }
 
+export function createPackedAstroProjectManifest(directory, artifacts) {
+  const runtime = fileSpecifier(artifacts.runtime);
+  return {
+    dependencies: {
+      "@starwind-ui/astro": fileSpecifier(artifacts.astro),
+      "@starwind-ui/runtime": runtime,
+      astro: "7.0.0",
+    },
+    name: path.basename(directory),
+    pnpm: {
+      overrides: {
+        "@starwind-ui/runtime": runtime,
+      },
+    },
+    private: true,
+    type: "module",
+  };
+}
+
 async function createAstroProject(directory, artifacts) {
   // Keep the packed CLI outside the target project so nested installs cannot relink its active shim.
   // Packed Runtime and adapter tarballs stay project-local for prepublish verification.
   await mkdir(path.join(directory, "src", "layouts"), { recursive: true });
   await writeFile(
     path.join(directory, "package.json"),
-    `${JSON.stringify(
-      {
-        name: path.basename(directory),
-        private: true,
-        type: "module",
-        dependencies: {
-          "@starwind-ui/astro": fileSpecifier(artifacts.astro),
-          "@starwind-ui/runtime": fileSpecifier(artifacts.runtime),
-          astro: "7.0.0",
-        },
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(createPackedAstroProjectManifest(directory, artifacts), null, 2)}\n`,
   );
   await writeFile(
     path.join(directory, "pnpm-workspace.yaml"),

--- a/scripts/windows-packed-cli-smoke.mjs
+++ b/scripts/windows-packed-cli-smoke.mjs
@@ -157,14 +157,24 @@ export function createPackedAstroProjectManifest(directory, artifacts) {
       astro: "7.0.0",
     },
     name: path.basename(directory),
-    pnpm: {
-      overrides: {
-        "@starwind-ui/runtime": runtime,
-      },
-    },
     private: true,
     type: "module",
   };
+}
+
+export function createPackedPnpmWorkspace(artifacts) {
+  return [
+    "packages: []",
+    "minimumReleaseAge: 0",
+    "minimumReleaseAgeStrict: false",
+    "overrides:",
+    `  "@starwind-ui/runtime": "${fileSpecifier(artifacts.runtime)}"`,
+    "allowBuilds:",
+    "  esbuild: true",
+    "  sharp: true",
+    "  unrs-resolver: true",
+    "",
+  ].join("\n");
 }
 
 async function createAstroProject(directory, artifacts) {
@@ -177,7 +187,7 @@ async function createAstroProject(directory, artifacts) {
   );
   await writeFile(
     path.join(directory, "pnpm-workspace.yaml"),
-    "packages: []\nminimumReleaseAge: 0\nminimumReleaseAgeStrict: false\nallowBuilds:\n  esbuild: true\n  sharp: true\n  unrs-resolver: true\n",
+    createPackedPnpmWorkspace(artifacts),
   );
   await writeFile(
     path.join(directory, "astro.config.mjs"),

--- a/scripts/windows-packed-cli-smoke.mjs
+++ b/scripts/windows-packed-cli-smoke.mjs
@@ -28,6 +28,11 @@ export function createWindowsPackedCliPlan(root, packageUrl) {
   };
 
   return {
+    artifacts: {
+      astro: path.join(root, "artifacts", "starwind-astro.tgz"),
+      cli: path.join(root, "artifacts", "starwind-cli.tgz"),
+      runtime: path.join(root, "artifacts", "starwind-runtime.tgz"),
+    },
     packageUrl,
     projects: {
       add: createProject("add-driven"),
@@ -65,20 +70,26 @@ export async function runWindowsPackedCliSmoke() {
   const diagnostics = [];
 
   try {
-    const tarball = path.join(root, "artifacts", "starwind-cli.tgz");
-    await mkdir(path.dirname(tarball), { recursive: true });
-    await runRequired({
-      ...createPnpmInvocation(["pack", "--out", tarball]),
-      cwd: path.join(REPO_ROOT, "packages", "cli"),
-    });
+    const artifacts = createWindowsPackedCliPlan(root, "").artifacts;
+    await mkdir(path.dirname(artifacts.cli), { recursive: true });
+    for (const [packageDirectory, tarball] of [
+      ["runtime", artifacts.runtime],
+      ["astro", artifacts.astro],
+      ["cli", artifacts.cli],
+    ]) {
+      await runRequired({
+        ...createPnpmInvocation(["pack", "--out", tarball]),
+        cwd: path.join(REPO_ROOT, "packages", packageDirectory),
+      });
+    }
 
-    const server = await startTarballServer(tarball);
+    const server = await startTarballServer(artifacts.cli);
     const packageUrl = `http://127.0.0.1:${server.port}/starwind-cli.tgz`;
     const plan = createWindowsPackedCliPlan(root, packageUrl);
 
     try {
       for (const project of Object.values(plan.projects)) {
-        await createAstroProject(project.directory);
+        await createAstroProject(project.directory, plan.artifacts);
         await runRequired({ ...createPnpmInvocation(["install"]), cwd: project.directory });
       }
       await verifyStandaloneInit(plan.projects.standalone, packageUrl, diagnostics);
@@ -133,9 +144,13 @@ async function verifyAddDrivenInit(project, packageUrl, diagnostics) {
   assert.equal(await pathExists(project.shim), false, "The packed CLI became project-local.");
 }
 
-async function createAstroProject(directory) {
-  // Keep the packed CLI outside the target project. pnpm can relink a project-local URL dependency
-  // while init installs Runtime packages, which does not model a published registry dependency.
+function fileSpecifier(file) {
+  return `file:${file.replaceAll("\\", "/")}`;
+}
+
+async function createAstroProject(directory, artifacts) {
+  // Keep the packed CLI outside the target project so nested installs cannot relink its active shim.
+  // Packed Runtime and adapter tarballs stay project-local for prepublish verification.
   await mkdir(path.join(directory, "src", "layouts"), { recursive: true });
   await writeFile(
     path.join(directory, "package.json"),
@@ -144,7 +159,11 @@ async function createAstroProject(directory) {
         name: path.basename(directory),
         private: true,
         type: "module",
-        dependencies: { astro: "7.0.0" },
+        dependencies: {
+          "@starwind-ui/astro": fileSpecifier(artifacts.astro),
+          "@starwind-ui/runtime": fileSpecifier(artifacts.runtime),
+          astro: "7.0.0",
+        },
       },
       null,
       2,


### PR DESCRIPTION
## Summary
- refresh the private Vue Primitive artifact integrity fingerprint after the stable Runtime version transition
- accept both prerelease and stable Changesets lifecycle states in the Vue non-shipping contract gate
- preserve the public CLI boundary that excludes Vue init, add, and setup targets

## Verification
- pnpm exec vitest run packages/cli/tests/utils/framework-target-policy.test.ts packages/cli/tests/commands/primitives.integration.test.ts scripts/portable-runtime/tests/generate-cli-registry.test.ts scripts/portable-runtime/tests/vue-contract-gate.test.ts
- 55 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vue artifact verification to recognize the latest valid build.
  * Improved prerelease validation when metadata is available.
  * Skipped reinstalling runtime packages already present during project initialization.
  * Preserved local Astro and runtime packages during prepublish initialization.
  * Improved Windows packed-CLI validation across Astro, CLI, and runtime artifacts.
  * Ensured Windows packed-CLI checks build the runtime package before testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->