### PR TITLE
fix(cli): refresh Vue primitive fingerprint

### DIFF
--- a/packages/cli/src/utils/framework-target-policy.ts
+++ b/packages/cli/src/utils/framework-target-policy.ts
@@ -69,7 +69,7 @@ export const PRIVATE_VUE_FRAMEWORK_TARGET_POLICY =
       vue: "Vue",
     },
     primitiveArtifactIntegrity: {
-      vue: "sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f",
+      vue: "sha256:5ab2236d8a6f98ab2c289cf2bc01d589d13a94f77c4c3de850df97d5ce7c567d",
     },
     requiredAdapterPackages: {
       "legacy-astro": [],

--- a/packages/cli/tests/utils/framework-target-policy.test.ts
+++ b/packages/cli/tests/utils/framework-target-policy.test.ts
@@ -39,7 +39,7 @@ describe("CLI framework target policy", () => {
       setupTargets: ["astro", "react", "vue"],
       labels: { astro: "Astro", react: "React", vue: "Vue" },
       primitiveArtifactIntegrity: {
-        vue: "sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f",
+        vue: "sha256:5ab2236d8a6f98ab2c289cf2bc01d589d13a94f77c4c3de850df97d5ce7c567d",
       },
       requiredAdapterPackages: {
         "legacy-astro": [],
@@ -56,7 +56,7 @@ describe("CLI framework target policy", () => {
   it("binds private Primitive artifacts to the exact immutable capability policy", () => {
     expect(
       getPrimitiveArtifactIntegrityFingerprint(PRIVATE_VUE_FRAMEWORK_TARGET_POLICY, "vue"),
-    ).toBe("sha256:03dce278f309651253115caaa10816de12bd412d9fb751902194c275838d271f");
+    ).toBe("sha256:5ab2236d8a6f98ab2c289cf2bc01d589d13a94f77c4c3de850df97d5ce7c567d");
     expect(
       getPrimitiveArtifactIntegrityFingerprint(PRIVATE_VUE_FRAMEWORK_TARGET_POLICY, "astro"),
     ).toBeUndefined();


### PR DESCRIPTION
Refresh the trusted private Vue Primitive artifact fingerprint after the stable 1.0.0 Primitive version promotion. This keeps the CLI vendoring integrity check aligned with the deterministic generated artifact set.\n\nValidation:\n- focused deterministic Vue registry generation test\n- CLI framework target policy tests\n- Vue Primitive vendoring integration tests\n- CLI typecheck and formatting\n- guarded public sync check\n\nRelease impact: metadata-only correction within the unpublished starwind 3.0.1 candidate. Runtime, Astro, and React package versions remain 1.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Vue framework artifact integrity verification to recognize the latest validated artifact.
  * Updated related validation checks to ensure integrity verification remains accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->