### PR TITLE
fix(ci): verify release candidates efficiently

### DIFF
--- a/.github/workflows/published-release-acceptance.yml
+++ b/.github/workflows/published-release-acceptance.yml
@@ -42,7 +42,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright Chromium
-        run: pnpm --filter=react-demo exec playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium
 
       - name: Test Published Release
         run: pnpm test:published-release -- --version "${{ inputs.version }}" --artifacts .artifacts/published-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
     if: always() && needs.scope.result == 'success' && (needs.verify.result == 'success' || needs.verify.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -78,6 +79,7 @@ jobs:
         run: pnpm styled:versions:stage && pnpm primitive:versions:stage
 
       - name: Create Release Pull Request
+        id: changesets
         # changesets/action@v1.8.0
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b
         with:
@@ -85,3 +87,14 @@ jobs:
           version: pnpm release:version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify Release Pull Request
+        if: steps.changesets.outputs.pullRequestNumber != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          HEAD_REF="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.ref')"
+          HEAD_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.head.sha')"
+          BASE_SHA="$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" --jq '.base.sha')"
+          gh workflow run verify.yml --ref "$HEAD_REF" --field base_sha="$BASE_SHA" --field expected_head_sha="$HEAD_SHA"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,6 +7,16 @@ on:
       private_adapters:
         type: boolean
         default: false
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: Base commit for version-intent checks
+        required: true
+        type: string
+      expected_head_sha:
+        description: Exact Changesets pull request head commit
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -31,11 +41,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify dispatched head
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+        run: test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"
+
       - name: Detect private-adapter-impacting changes
         id: changes
         shell: bash
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha || github.event.before }}
         run: |
           if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
             echo "svelte=true" >> "$GITHUB_OUTPUT"
@@ -94,11 +110,11 @@ jobs:
       - name: Check release metadata
         run: pnpm styled:versions:check && pnpm primitive:versions:check && pnpm runtime:docs:metadata:check
       - name: Verify Styled Component Version Intent
-        if: github.event_name == 'pull_request'
-        run: pnpm styled:versions:check --base "${{ github.event.pull_request.base.sha }}"
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        run: pnpm styled:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"
       - name: Verify Primitive Component Version Intent
-        if: github.event_name == 'pull_request'
-        run: pnpm primitive:versions:check --base "${{ github.event.pull_request.base.sha }}"
+        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        run: pnpm primitive:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"
   node-tests:
     name: Node tests
     runs-on: ubuntu-latest
@@ -137,9 +153,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
-        run: |
-          pnpm --filter=react-demo exec playwright install --with-deps chromium
-          pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps chromium
       - name: Run portable Runtime generator tests
         run: pnpm runtime:generate:test && pnpm runtime:generate:typecheck
 
@@ -161,9 +175,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
-        run: |
-          pnpm --filter=react-demo exec playwright install --with-deps chromium
-          pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps chromium
       - name: Run browser suites
         run: pnpm runtime:test:browser && pnpm react:test:browser
 
@@ -187,9 +199,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
-        run: |
-          pnpm --filter=react-demo exec playwright install --with-deps chromium
-          pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps chromium
       - name: Run quarantined Vue verification
         run: pnpm vue:verify
       - name: Run quarantined Vue CLI host acceptance
@@ -215,9 +225,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Install Playwright Chromium
-        run: |
-          pnpm --filter=react-demo exec playwright install --with-deps chromium
-          pnpm exec playwright install chromium
+        run: pnpm exec playwright install --with-deps chromium
       - name: Run quarantined Svelte verification
         run: pnpm svelte:verify
 

--- a/apps/react-demo/package.json
+++ b/apps/react-demo/package.json
@@ -25,7 +25,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.2",
-    "playwright": "^1.60.0",
+    "playwright": "1.60.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.0"
   }

--- a/apps/vue-demo/package.json
+++ b/apps/vue-demo/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^6.0.4",
-    "playwright": "^1.60.0",
+    "playwright": "1.60.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.0",
     "vue-tsc": "3.3.6"

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "eslint": "^9.39.1",
     "eslint-plugin-astro": "^1.5.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
-    "playwright": "1.62.0",
+    "playwright": "1.60.0",
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.7.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -53,6 +53,8 @@
     "@types/node": "^24.12.4",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
+    "@vitest/browser-playwright": "^4.1.8",
+    "playwright": "1.60.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "tsup": "^8.5.1",

--- a/packages/react/tests/vitest.config.ts
+++ b/packages/react/tests/vitest.config.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { defineConfig } from "vitest/config";
-import { playwright } from "../../runtime/node_modules/@vitest/browser-playwright/dist/index.js";
+import { playwright } from "@vitest/browser-playwright";
 
 import { createSourceBackedRuntimeAliases } from "./source-backed-runtime-aliases";
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -190,6 +190,7 @@
   "devDependencies": {
     "@types/node": "^24.12.4",
     "@vitest/browser-playwright": "^4.1.8",
+    "playwright": "1.60.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vitest": "^4.1.8"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -186,6 +186,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.12.4",
+    "@vitest/browser-playwright": "^4.1.8",
+    "playwright": "1.60.0",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
     "vue": "3.5.39",

--- a/packages/vue/tests/browser-project.ts
+++ b/packages/vue/tests/browser-project.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import { playwright } from "../../runtime/node_modules/@vitest/browser-playwright/dist/index.js";
+import { playwright } from "@vitest/browser-playwright";
 import { defineConfig } from "../../runtime/node_modules/vitest/dist/config.js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,8 +58,8 @@ importers:
         specifier: ^6.10.2
         version: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       playwright:
-        specifier: 1.62.0
-        version: 1.62.0
+        specifier: 1.60.0
+        version: 1.60.0
       prettier:
         specifier: ^3.6.2
         version: 3.8.3
@@ -201,7 +201,7 @@ importers:
         specifier: ^5.1.2
         version: 5.2.0(vite@8.1.3(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
       playwright:
-        specifier: ^1.60.0
+        specifier: 1.60.0
         version: 1.60.0
       typescript:
         specifier: ^5.9.3
@@ -238,7 +238,7 @@ importers:
         specifier: ^6.0.4
         version: 6.0.8(vite@8.1.3(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
       playwright:
-        specifier: ^1.60.0
+        specifier: 1.60.0
         version: 1.60.0
       typescript:
         specifier: ^5.9.3
@@ -330,6 +330,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       react:
         specifier: ^19.2.0
         version: 19.2.7
@@ -358,6 +364,9 @@ importers:
       '@vitest/browser-playwright':
         specifier: ^4.1.8
         version: 4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -408,6 +417,12 @@ importers:
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
+      '@vitest/browser-playwright':
+        specifier: ^4.1.8
+        version: 4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.22.4)(typescript@5.9.3)(yaml@2.9.0)
@@ -3700,19 +3715,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright-core@1.62.0:
-    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
-    engines: {node: '>=20'}
-    hasBin: true
-
   playwright@1.60.0:
     resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.62.0:
-    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
-    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -6358,20 +6363,6 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.62.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
-    dependencies:
-      '@vitest/browser': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
-      playwright: 1.62.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-    optional: true
-
   '@vitest/browser@4.1.8(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
@@ -8274,17 +8265,9 @@ snapshots:
 
   playwright-core@1.60.0: {}
 
-  playwright-core@1.62.0: {}
-
   playwright@1.60.0:
     dependencies:
       playwright-core: 1.60.0
-    optionalDependencies:
-      fsevents: 2.3.2
-
-  playwright@1.62.0:
-    dependencies:
-      playwright-core: 1.62.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9136,7 +9119,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-playwright': 4.1.8(playwright@1.62.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.60.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
     transitivePeerDependencies:
       - msw

--- a/scripts/tests/root-verification-scripts.test.ts
+++ b/scripts/tests/root-verification-scripts.test.ts
@@ -15,10 +15,21 @@ type Workflow = {
   jobs: Record<
     string,
     {
+      env?: Record<string, string>;
       if?: string;
+      id?: string;
       name?: string;
       needs?: string | string[];
-      steps?: Array<{ if?: string; name?: string; run?: string }>;
+      permissions?: Record<string, string>;
+      steps?: Array<{
+        env?: Record<string, string>;
+        id?: string;
+        if?: string;
+        name?: string;
+        run?: string;
+        uses?: string;
+        with?: Record<string, unknown>;
+      }>;
       uses?: string;
       with?: Record<string, unknown>;
     }
@@ -159,6 +170,12 @@ describe("root verification scripts", () => {
     expect(verifyWorkflow.on).toMatchObject({
       pull_request: null,
       workflow_call: { inputs: { private_adapters: { default: false, type: "boolean" } } },
+      workflow_dispatch: {
+        inputs: {
+          base_sha: { required: true, type: "string" },
+          expected_head_sha: { required: true, type: "string" },
+        },
+      },
     });
     expect(verifyWorkflow.permissions).toEqual({ contents: "read" });
     expect(Object.keys(verifyWorkflow.jobs)).toEqual(
@@ -202,9 +219,7 @@ describe("root verification scripts", () => {
       expect.arrayContaining([
         expect.objectContaining({
           name: "Install Playwright Chromium",
-          run: expect.stringContaining(
-            "pnpm --filter=react-demo exec playwright install --with-deps chromium",
-          ),
+          run: "pnpm exec playwright install --with-deps chromium",
         }),
       ]),
     );
@@ -213,10 +228,7 @@ describe("root verification scripts", () => {
     );
     expect(browserInstallSteps).toHaveLength(4);
     for (const step of browserInstallSteps) {
-      expect(step.run).toContain(
-        "pnpm --filter=react-demo exec playwright install --with-deps chromium",
-      );
-      expect(step.run).toContain("pnpm exec playwright install chromium");
+      expect(step.run).toBe("pnpm exec playwright install --with-deps chromium");
     }
     expect(verifyWorkflow.jobs.verify).toMatchObject({
       name: "Verify",
@@ -241,10 +253,10 @@ describe("root verification scripts", () => {
       ]),
     );
     expect(verifyRuns).toContain(
-      'pnpm styled:versions:check --base "${{ github.event.pull_request.base.sha }}"',
+      'pnpm styled:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
     );
     expect(verifyRuns).toContain(
-      'pnpm primitive:versions:check --base "${{ github.event.pull_request.base.sha }}"',
+      'pnpm primitive:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
     );
     expect(
       verifyRuns.filter((command) => command.includes("pnpm runtime:generate:test")),
@@ -274,9 +286,23 @@ describe("root verification scripts", () => {
         expect.objectContaining({
           run: "pnpm styled:versions:stage && pnpm primitive:versions:stage",
         }),
+        expect.objectContaining({
+          id: "changesets",
+          name: "Create Release Pull Request",
+        }),
+        expect.objectContaining({
+          if: "steps.changesets.outputs.pullRequestNumber != ''",
+          name: "Verify Release Pull Request",
+          run: expect.stringContaining("gh workflow run verify.yml"),
+        }),
       ]),
     );
     expect(releaseWorkflowSource).toContain("commitMode: github-api");
+    expect(releaseWorkflow.jobs.release.permissions).toEqual({
+      actions: "write",
+      contents: "write",
+      "pull-requests": "write",
+    });
     expect(releaseWorkflowSource).toContain("version: pnpm release:version");
   });
 });


### PR DESCRIPTION
## Changes

- dispatch the shipping Verify workflow for each Changesets version pull request
- validate the exact generated pull request head and base before verification
- consolidate every Playwright consumer on exact version 1.60.0
- remove duplicate Chromium installs and cross-package browser-provider imports

## Validation

- Runtime browser suite passed three consecutive runs: 55 files and 1,446 tests per run
- React browser suite passed: 48 tests
- Vue browser runner passed: 37 files across 36 Chromium projects
- repository check, test-home check, release status, public-sync tests, and frozen public install passed
- Playwright 1.62 was rejected after three repeatable Runtime failures in timer and portal cases

## Release impact

No package release is scheduled. These changes affect development dependencies, test ownership, and GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release and verification workflows to validate the intended commit and base revision.
  * Standardized Playwright installation across browser-based test jobs.
  * Improved reliability of automated release pull request verification.

* **Tests**
  * Expanded workflow checks for manual verification, release permissions, version checks, and Playwright setup.

* **Chores**
  * Pinned Playwright to version 1.60.0 for consistent testing across packages and demo applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->