### PR TITLE
fix(runtime): hand off focus from portaled overlays

### DIFF
--- a/.changeset/menu-focus-boundary.md
+++ b/.changeset/menu-focus-boundary.md
@@ -1,5 +1,5 @@
 ---
-"@starwind-ui/runtime": patch
+"@starwind-ui/runtime": minor
 ---
 
 Add Menu-backed focus handoff for Menu, Dropdown, and Context Menu, including `focus-out` close details.

--- a/.changeset/menu-focus-boundary.md
+++ b/.changeset/menu-focus-boundary.md
@@ -1,0 +1,5 @@
+---
+"@starwind-ui/runtime": patch
+---
+
+Add Menu-backed focus handoff for Menu, Dropdown, and Context Menu, including `focus-out` close details.

--- a/.changeset/select-focus-boundary.md
+++ b/.changeset/select-focus-boundary.md
@@ -1,0 +1,5 @@
+---
+"@starwind-ui/runtime": patch
+---
+
+Fix Select Tab handoff and add public `focus-out` close details.

--- a/.changeset/select-focus-boundary.md
+++ b/.changeset/select-focus-boundary.md
@@ -1,5 +1,5 @@
 ---
-"@starwind-ui/runtime": patch
+"@starwind-ui/runtime": minor
 ---
 
 Fix Select Tab handoff and add public `focus-out` close details.

--- a/packages/runtime/src/components/menu/menu.ts
+++ b/packages/runtime/src/components/menu/menu.ts
@@ -9,6 +9,11 @@ import {
 import { createCancelableDetails } from "../../internal/cancelable-details";
 import { dispatchCustomEvent } from "../../internal/events";
 import {
+  createFocusBoundary,
+  type FocusBoundaryHandle,
+  getNextDocumentTabStop,
+} from "../../internal/focus-boundary";
+import {
   createFloatingPositioner,
   type FloatingAlign,
   type FloatingPositioner,
@@ -19,12 +24,16 @@ import {
   createFloatingListLifecycle,
   type FloatingListLifecycle,
 } from "../../internal/floating-list-lifecycle";
-import { runOverlayOpenChangeShell } from "../../internal/overlay-open-change";
+import {
+  type OverlayOpenChangeShellResult,
+  runOverlayOpenChangeShell,
+} from "../../internal/overlay-open-change";
 import { showElement } from "../../internal/presence";
 import { lockDocumentScroll } from "../../internal/scroll-lock";
 
 export type MenuOpenChangeReason =
   | "escape-key"
+  | "focus-out"
   | "imperative-action"
   | "item-press"
   | "outside-press"
@@ -200,6 +209,7 @@ class MenuController implements MenuInstance {
   private readonly abortController = new AbortController();
   private readonly controlled: boolean;
   private readonly elements: MenuElements;
+  private readonly focusBoundary: FocusBoundaryHandle;
   private readonly closeDelay: number;
   private readonly onCloseComplete?: (details: MenuCloseCompleteDetails) => void;
   private readonly onOpenChange?: (open: boolean, details: MenuOpenChangeDetails) => void;
@@ -254,6 +264,14 @@ class MenuController implements MenuInstance {
       options.defaultOpen ??
       readBooleanAttribute(root, MENU_DEFAULT_OPEN_ATTRIBUTE, false);
     this.lifecycle = this.createLifecycle();
+    this.focusBoundary = createFocusBoundary({
+      containsTarget: (target) => this.containsTarget(target),
+      onFocusDeparture: ({ lastFocusOwner }) => {
+        this.handleSettledFocusDeparture(lastFocusOwner);
+      },
+      ownerDocument: root.ownerDocument,
+      surfaces: this.getFocusBoundarySurfaces(),
+    });
 
     this.setupAccessibility();
     this.bindEvents();
@@ -346,6 +364,7 @@ class MenuController implements MenuInstance {
     if (this.destroyed) return;
 
     this.abortController.abort();
+    this.focusBoundary.destroy();
     this.clearHoverCloseTimer();
     this.clearTypeaheadTimer();
     this.submenus.forEach((submenu) => submenu.destroy());
@@ -501,6 +520,9 @@ class MenuController implements MenuInstance {
         if (!this.openState) return;
 
         switch (event.key) {
+          case "Tab":
+            this.handleRootTabKeyDown(event);
+            break;
           case "ArrowDown":
             event.preventDefault();
             this.focusItem(this.activeIndex < 0 ? 0 : this.activeIndex + 1);
@@ -571,17 +593,20 @@ class MenuController implements MenuInstance {
     }
   }
 
-  private requestOpen(open: boolean, request: OpenRequest): void {
+  private requestOpen(
+    open: boolean,
+    request: OpenRequest,
+  ): OverlayOpenChangeShellResult<MenuOpenChangeDetails> | null {
     if (open === this.openState && !this.controlled && !request.forceApply) {
       if (open && request.focusItem) {
         this.pendingFocusItem = request.focusItem;
         this.queuePendingFocusItem();
       }
-      return;
+      return null;
     }
 
     const previousOpen = this.openState;
-    runOverlayOpenChangeShell({
+    return runOverlayOpenChangeShell({
       root: this.root,
       controlled: this.controlled && !request.forceApply,
       createDetails: createOpenChangeDetails,
@@ -589,6 +614,8 @@ class MenuController implements MenuInstance {
       previousOpen,
       request,
       onApplyControlledOpenState: () => {
+        if (this.destroyed) return;
+
         this.prepareOpenChangeApplication(open, request);
 
         if (open) {
@@ -602,12 +629,16 @@ class MenuController implements MenuInstance {
         this.completeOpenChangeApplication(open, request);
       },
       onApplyUncontrolledOpenState: () => {
+        if (this.destroyed) return;
+
         this.prepareOpenChangeApplication(open, request);
         this.openState = open;
         this.applyOpenState(open, request);
         this.completeOpenChangeApplication(open, request);
       },
       onCanceledOpenChange: () => {
+        if (this.destroyed) return;
+
         if (this.openState === open && previousOpen !== open) {
           this.setOpen(previousOpen, { emit: false, reason: request.reason });
         }
@@ -666,6 +697,7 @@ class MenuController implements MenuInstance {
           this.requestOpen(false, { event, reason: "escape-key" });
         },
         onOutsidePointerDown: (event) => {
+          this.focusBoundary.suppressNextDeparture();
           this.requestOpen(false, { event, reason: "outside-press" });
         },
       },
@@ -747,6 +779,15 @@ class MenuController implements MenuInstance {
     return this.elements.positioner ?? this.elements.popup;
   }
 
+  private getFocusBoundarySurfaces(): HTMLElement[] {
+    return uniqueElements([
+      this.root,
+      this.getPortalElement(),
+      ...(this.elements.portal ? [this.elements.portal] : []),
+      ...this.submenus.flatMap((submenu) => submenu.getFocusBoundarySurfaces()),
+    ]);
+  }
+
   private containsTarget(target: Node): boolean {
     const portalElement = this.getPortalElement();
 
@@ -756,6 +797,52 @@ class MenuController implements MenuInstance {
       this.submenus.some((submenu) => submenu.containsTarget(target)) ||
       Boolean(this.elements.portal?.contains(target))
     );
+  }
+
+  private handleRootTabKeyDown(event: KeyboardEvent): void {
+    if (event.defaultPrevented) return;
+
+    const activeElement = this.root.ownerDocument.activeElement;
+    if (!(activeElement instanceof HTMLElement) || !this.containsTarget(activeElement)) return;
+
+    const focusTarget = event.shiftKey
+      ? this.getOpeningTrigger()
+      : getNextDocumentTabStop(this.root, this.getFocusBoundarySurfaces());
+
+    event.preventDefault();
+    const result = this.requestOpen(false, { event, reason: "focus-out" });
+    if (this.destroyed) return;
+
+    if (result?.status === "applied") {
+      if (focusTarget?.isConnected) {
+        this.focusBoundary.suppressNextDeparture();
+        focusTarget.focus();
+      }
+      return;
+    }
+
+    if (activeElement.isConnected) {
+      this.focusBoundary.suppressNextDeparture();
+      activeElement.focus();
+    }
+  }
+
+  private handleSettledFocusDeparture(lastFocusOwner: HTMLElement | null): void {
+    if (!this.openState || this.destroyed) return;
+
+    const result = this.requestOpen(false, { reason: "focus-out" });
+    if (this.destroyed) return;
+    if (result?.status === "applied" || !lastFocusOwner?.isConnected) return;
+
+    this.focusBoundary.suppressNextDeparture();
+    lastFocusOwner.focus();
+  }
+
+  private getOpeningTrigger(): HTMLElement | null {
+    if (this.restoreFocusTrigger) {
+      return this.restoreFocusTrigger.isConnected ? this.restoreFocusTrigger : null;
+    }
+    return this.elements.triggers.find((trigger) => trigger.isConnected) ?? null;
   }
 
   private clearFloatingStyles(): void {
@@ -988,6 +1075,22 @@ class MenuController implements MenuInstance {
     this.requestOpen(false, { event, reason: "item-press", trigger: item });
   }
 
+  handleOwnedPopupForwardTab(event: KeyboardEvent): void {
+    this.handleRootTabKeyDown(event);
+  }
+
+  getFocusBoundaryFallback(): HTMLElement | null {
+    return this.elements.popup.isConnected ? this.elements.popup : null;
+  }
+
+  containsOwnedTarget(target: Node): boolean {
+    return this.containsTarget(target);
+  }
+
+  suppressFocusDeparture(): void {
+    this.focusBoundary.suppressNextDeparture();
+  }
+
   private closeSubmenus(): void {
     this.submenus.forEach((submenu) => submenu.close());
   }
@@ -1020,6 +1123,7 @@ class MenuSubmenuController {
 
   private readonly abortController = new AbortController();
   private readonly elements: MenuSubmenuElements;
+  private readonly focusBoundary: FocusBoundaryHandle;
   private readonly lifecycle: FloatingListLifecycle<undefined>;
   private readonly itemCollection: MenuItemCollection;
   private readonly owner: MenuController;
@@ -1050,6 +1154,14 @@ class MenuSubmenuController {
       `[${MENU_SUBMENU_ROOT_ATTRIBUTE}]`,
     ).map((submenuRoot) => new MenuSubmenuController(submenuRoot, owner, this));
     this.lifecycle = this.createLifecycle();
+    this.focusBoundary = createFocusBoundary({
+      containsTarget: (target) => this.containsTarget(target),
+      onFocusDeparture: ({ activeElement }) => {
+        this.handleSettledFocusDeparture(activeElement);
+      },
+      ownerDocument: root.ownerDocument,
+      surfaces: this.getFocusBoundarySurfaces(),
+    });
 
     this.setupAccessibility();
     this.bindEvents();
@@ -1098,6 +1210,7 @@ class MenuSubmenuController {
     if (this.destroyed) return;
 
     this.abortController.abort();
+    this.focusBoundary.destroy();
     this.clearHoverCloseTimer();
     this.clearTypeaheadTimer();
     this.submenus.forEach((submenu) => submenu.destroy());
@@ -1118,6 +1231,19 @@ class MenuSubmenuController {
       this.submenus.some((submenu) => submenu.containsTarget(target)) ||
       Boolean(this.elements.portal?.contains(target))
     );
+  }
+
+  getFocusBoundarySurfaces(): HTMLElement[] {
+    return uniqueElements([
+      this.root,
+      this.getPortalElement(),
+      ...(this.elements.portal ? [this.elements.portal] : []),
+      ...this.submenus.flatMap((submenu) => submenu.getFocusBoundarySurfaces()),
+    ]);
+  }
+
+  getFocusBoundaryFallback(): HTMLElement | null {
+    return this.elements.popup.isConnected ? this.elements.popup : null;
   }
 
   closeSiblingSubmenus(activeSubmenu: MenuSubmenuController): void {
@@ -1247,6 +1373,9 @@ class MenuSubmenuController {
         if (!this.openState) return;
 
         switch (event.key) {
+          case "Tab":
+            this.handleTabKeyDown(event);
+            break;
           case "ArrowDown":
             event.preventDefault();
             this.focusItem(this.activeIndex < 0 ? 0 : this.activeIndex + 1);
@@ -1370,6 +1499,35 @@ class MenuSubmenuController {
 
   private getPortalElement(): HTMLElement {
     return this.elements.positioner ?? this.elements.popup;
+  }
+
+  private handleTabKeyDown(event: KeyboardEvent): void {
+    if (event.defaultPrevented) return;
+
+    const activeElement = this.root.ownerDocument.activeElement;
+    if (!(activeElement instanceof HTMLElement) || !this.containsTarget(activeElement)) return;
+
+    if (!event.shiftKey) {
+      this.owner.handleOwnedPopupForwardTab(event);
+      return;
+    }
+
+    event.preventDefault();
+    const focusTarget = this.elements.trigger.isConnected
+      ? this.elements.trigger
+      : this.parent.getFocusBoundaryFallback();
+    this.focusBoundary.suppressNextDeparture();
+    this.owner.suppressFocusDeparture();
+    this.close();
+    if (focusTarget?.isConnected) {
+      focusTarget.focus();
+    }
+  }
+
+  private handleSettledFocusDeparture(activeElement: Element | null): void {
+    if (!this.openState || this.destroyed) return;
+    if (!activeElement || !this.owner.containsOwnedTarget(activeElement)) return;
+    this.close();
   }
 
   private clearFloatingStyles(): void {

--- a/packages/runtime/src/components/menu/menu.ts
+++ b/packages/runtime/src/components/menu/menu.ts
@@ -839,9 +839,8 @@ class MenuController implements MenuInstance {
   }
 
   private getOpeningTrigger(): HTMLElement | null {
-    if (this.restoreFocusTrigger) {
-      return this.restoreFocusTrigger.isConnected ? this.restoreFocusTrigger : null;
-    }
+    if (this.restoreFocusTrigger?.isConnected) return this.restoreFocusTrigger;
+
     return this.elements.triggers.find((trigger) => trigger.isConnected) ?? null;
   }
 

--- a/packages/runtime/src/components/select/select.ts
+++ b/packages/runtime/src/components/select/select.ts
@@ -7,6 +7,7 @@ import {
   readNumberAttribute,
   resolveAsChildControl,
   setBooleanAttribute,
+  uniqueElements,
 } from "../../internal/dom";
 import {
   createCancelableDetails,
@@ -14,6 +15,11 @@ import {
 } from "../../internal/cancelable-details";
 import { dispatchCustomEvent } from "../../internal/events";
 import { attachFormValueRevision } from "../../internal/form-value-revision";
+import {
+  createFocusBoundary,
+  type FocusBoundaryHandle,
+  getNextDocumentTabStop,
+} from "../../internal/focus-boundary";
 import {
   createFloatingPositioner,
   type FloatingPositioner,
@@ -26,13 +32,17 @@ import {
   createFloatingListLifecycle,
   type FloatingListLifecycle,
 } from "../../internal/floating-list-lifecycle";
-import { runOverlayOpenChangeShell } from "../../internal/overlay-open-change";
+import {
+  type OverlayOpenChangeShellResult,
+  runOverlayOpenChangeShell,
+} from "../../internal/overlay-open-change";
 import { showElement } from "../../internal/presence";
 import { lockDocumentScroll } from "../../internal/scroll-lock";
 import { registerFieldControlBridge } from "../field/field-control-bridge";
 
 export type SelectOpenChangeReason =
   | "escape-key"
+  | "focus-out"
   | "imperative-action"
   | "item-press"
   | "outside-press"
@@ -233,6 +243,7 @@ class SelectController implements SelectInstance {
   private readonly controlledOpen: boolean;
   private readonly controlledValue: boolean;
   private readonly elements: SelectElements;
+  private readonly focusBoundary: FocusBoundaryHandle;
   private readonly onOpenChange?: (open: boolean, details: SelectOpenChangeDetails) => void;
   private readonly onValueChange?: (
     value: string | null,
@@ -260,6 +271,7 @@ class SelectController implements SelectInstance {
   private itemCache: HTMLElement[] | null = null;
   private itemIndexCache: Map<HTMLElement, number> | null = null;
   private itemObserver: MutationObserver | null = null;
+  private lastEligibleFocusOwner: HTMLElement | null = null;
   private alignedPositionRetryFrame: number | null = null;
   private readonly boundScrollArrows = new WeakSet<HTMLElement>();
   private readonly boundScrollContainers = new WeakSet<HTMLElement>();
@@ -308,6 +320,14 @@ class SelectController implements SelectInstance {
     this.initialValue = readInitialResetValue(options, root, this.elements.input);
     this.valueState = readInitialValue(options, root);
     this.lifecycle = this.createLifecycle();
+    this.focusBoundary = createFocusBoundary({
+      containsTarget: (target) => this.containsTarget(target),
+      onFocusDeparture: ({ lastFocusOwner }) => {
+        this.handleSettledFocusDeparture(lastFocusOwner);
+      },
+      ownerDocument: root.ownerDocument,
+      surfaces: this.getFocusBoundarySurfaces(),
+    });
 
     this.setupAccessibility();
     this.bindEvents();
@@ -458,6 +478,7 @@ class SelectController implements SelectInstance {
     if (this.destroyed) return;
 
     this.abortController.abort();
+    this.focusBoundary.destroy();
     this.detachFormResetListener();
     this.clearResetTimer();
     this.stopScrollArrow();
@@ -472,6 +493,7 @@ class SelectController implements SelectInstance {
     this.stopItemObserver();
     this.renderOpenState(false);
     this.activeItem = null;
+    this.lastEligibleFocusOwner = null;
     this.lifecycle.destroy();
     this.elements.popup.hidden = true;
     instances.delete(this.root);
@@ -518,6 +540,17 @@ class SelectController implements SelectInstance {
   private bindEvents(): void {
     const { signal } = this.abortController;
     const { popup, trigger } = this.elements;
+
+    this.root.ownerDocument.addEventListener(
+      "focusin",
+      (event) => {
+        if (!(event.target instanceof HTMLElement)) return;
+
+        const focusOwner = this.getEligibleFocusBoundaryOwner(event.target);
+        if (focusOwner) this.lastEligibleFocusOwner = focusOwner;
+      },
+      { signal },
+    );
 
     this.root.addEventListener(
       "starwind:set-value",
@@ -670,7 +703,7 @@ class SelectController implements SelectInstance {
             this.selectItem(this.getItems()[this.activeIndex]!, event);
             break;
           case "Tab":
-            event.preventDefault();
+            this.handleTabKeyDown(event);
             break;
           default:
             if (isTypeaheadKey(event)) {
@@ -721,17 +754,20 @@ class SelectController implements SelectInstance {
     arrow.addEventListener("pointercancel", stop, { signal });
   }
 
-  private requestOpen(open: boolean, request: OpenRequest): void {
+  private requestOpen(
+    open: boolean,
+    request: OpenRequest,
+  ): OverlayOpenChangeShellResult<SelectOpenChangeDetails> | null {
     if (open === this.openState && !this.controlledOpen && !request.forceApply) {
       if (open && request.focus) {
         this.pendingFocus = request.focus;
         this.queuePendingFocus();
       }
-      return;
+      return null;
     }
 
     const previousOpen = this.openState;
-    runOverlayOpenChangeShell({
+    return runOverlayOpenChangeShell({
       root: this.root,
       controlled: this.controlledOpen && !request.forceApply,
       createDetails: createOpenChangeDetails,
@@ -739,10 +775,14 @@ class SelectController implements SelectInstance {
       previousOpen,
       request,
       onApplyControlledOpenState: () => {
+        if (this.destroyed) return;
+
         this.prepareOpenChangeApplication(open, request);
         this.completeOpenChangeApplication(open, request);
       },
       onApplyUncontrolledOpenState: () => {
+        if (this.destroyed) return;
+
         this.prepareOpenChangeApplication(open, request);
         this.openState = open;
         this.applyOpenState(open, request);
@@ -750,6 +790,8 @@ class SelectController implements SelectInstance {
       },
       onNotifyOpenChangeSubscribers: (details) => this.notifyOpen(details),
       onCanceledOpenChange: () => {
+        if (this.destroyed) return;
+
         if (this.openState === open && previousOpen !== open) {
           this.setOpen(previousOpen, { emit: false });
         }
@@ -758,6 +800,59 @@ class SelectController implements SelectInstance {
         this.onOpenChange?.(nextOpen, details);
       },
     });
+  }
+
+  private handleTabKeyDown(event: KeyboardEvent): void {
+    if (event.defaultPrevented) return;
+
+    const activeElement = this.root.ownerDocument.activeElement;
+    if (!(activeElement instanceof HTMLElement)) return;
+
+    const activeItem = this.getItemByTarget(activeElement);
+    if (activeItem !== activeElement || isDisabledElement(activeItem)) return;
+
+    const focusTarget = event.shiftKey
+      ? this.elements.trigger
+      : getNextDocumentTabStop(this.root, [
+          this.elements.portal,
+          this.elements.positioner,
+          this.elements.popup,
+        ]);
+
+    event.preventDefault();
+    const result = this.requestOpen(false, { event, reason: "focus-out" });
+    if (this.destroyed) return;
+
+    if (result?.status === "applied") {
+      if (focusTarget?.isConnected) {
+        this.focusBoundary.suppressNextDeparture();
+        focusTarget.focus();
+      }
+      return;
+    }
+
+    if (
+      activeItem.isConnected &&
+      this.getItemByTarget(activeItem) === activeItem &&
+      !isDisabledElement(activeItem)
+    ) {
+      activeItem.focus();
+    }
+  }
+
+  private handleSettledFocusDeparture(lastFocusOwner: HTMLElement | null): void {
+    if (!this.openState || this.destroyed) return;
+
+    const result = this.requestOpen(false, { reason: "focus-out" });
+    if (this.destroyed || result?.status === "applied") return;
+
+    const focusOwner =
+      this.getEligibleFocusBoundaryOwner(lastFocusOwner) ??
+      this.getEligibleFocusBoundaryOwner(this.lastEligibleFocusOwner);
+    if (!focusOwner) return;
+
+    this.focusBoundary.suppressNextDeparture();
+    focusOwner.focus();
   }
 
   private prepareOpenChangeApplication(open: boolean, request: OpenRequest): void {
@@ -985,6 +1080,7 @@ class SelectController implements SelectInstance {
           this.requestOpen(false, { event, reason: "escape-key" });
         },
         onOutsidePointerDown: (event) => {
+          this.focusBoundary.suppressNextDeparture();
           this.requestOpen(false, { event, reason: "outside-press" });
         },
       },
@@ -1060,6 +1156,14 @@ class SelectController implements SelectInstance {
     return this.elements.positioner ?? this.elements.popup;
   }
 
+  private getFocusBoundarySurfaces(): HTMLElement[] {
+    return uniqueElements([
+      this.elements.trigger,
+      this.getPortalElement(),
+      ...(this.elements.portal ? [this.elements.portal] : []),
+    ]);
+  }
+
   private containsTarget(target: Node): boolean {
     const portalElement = this.getPortalElement();
 
@@ -1068,6 +1172,13 @@ class SelectController implements SelectInstance {
       portalElement.contains(target) ||
       Boolean(this.elements.portal?.contains(target))
     );
+  }
+
+  private getEligibleFocusBoundaryOwner(element: HTMLElement | null): HTMLElement | null {
+    if (!element?.isConnected || isDisabledElement(element)) return null;
+    if (element === this.elements.trigger) return element;
+
+    return this.getItemByTarget(element) === element ? element : null;
   }
 
   private readonly handleFormReset = (): void => {

--- a/packages/runtime/src/internal/focus-boundary.ts
+++ b/packages/runtime/src/internal/focus-boundary.ts
@@ -1,0 +1,244 @@
+const documentTabStopSelector = [
+  "a[href]",
+  "area[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "iframe",
+  "[contenteditable]:not([contenteditable='false'])",
+  "[tabindex]",
+].join(",");
+
+export type FocusBoundaryDeparture = {
+  activeElement: Element | null;
+  lastFocusOwner: HTMLElement | null;
+};
+
+export type FocusBoundaryOptions = {
+  containsTarget: (target: Node) => boolean;
+  onFocusDeparture: (departure: FocusBoundaryDeparture) => void;
+  ownerDocument: Document;
+  surfaces: Iterable<HTMLElement | null>;
+};
+
+export type FocusBoundaryHandle = {
+  destroy(): void;
+  setLastFocusOwner(element: HTMLElement | null): void;
+  setSurfaces(surfaces: Iterable<HTMLElement | null>): void;
+  suppressNextDeparture(): void;
+};
+
+export function getNextDocumentTabStop(
+  logicalOwner: HTMLElement,
+  excludedSurfaces: Iterable<HTMLElement | null> = [],
+): HTMLElement | null {
+  const ownerDocument = logicalOwner.ownerDocument;
+  if (!logicalOwner.isConnected || !ownerDocument.body.contains(logicalOwner)) return null;
+
+  const excluded = Array.from(excludedSurfaces).filter(
+    (surface): surface is HTMLElement => surface !== null,
+  );
+  const NodeConstructor = ownerDocument.defaultView?.Node ?? Node;
+  const candidates = ownerDocument.querySelectorAll<HTMLElement>(documentTabStopSelector);
+
+  for (const candidate of candidates) {
+    if (!isEligibleFocusOwner(candidate, ownerDocument)) continue;
+    if (logicalOwner.contains(candidate)) continue;
+    if (excluded.some((surface) => surface.contains(candidate))) continue;
+    if (
+      !(
+        logicalOwner.compareDocumentPosition(candidate) &
+        NodeConstructor.DOCUMENT_POSITION_FOLLOWING
+      )
+    ) {
+      continue;
+    }
+
+    return candidate;
+  }
+
+  return null;
+}
+
+export function createFocusBoundary(options: FocusBoundaryOptions): FocusBoundaryHandle {
+  const { containsTarget, onFocusDeparture, ownerDocument } = options;
+  const observedSurfaces = new Set<HTMLElement>();
+  let destroyed = false;
+  let lastFocusOwner: HTMLElement | null = null;
+  let pendingCheck = false;
+  let pendingCheckVersion = 0;
+  let suppressionPending = false;
+  let suppressionTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+
+  const handleFocusIn = (event: FocusEvent): void => {
+    if (!isDocumentNode(event.target, ownerDocument) || !containsTarget(event.target)) return;
+    if (!(event.target instanceof (ownerDocument.defaultView?.HTMLElement ?? HTMLElement))) return;
+
+    const focusOwner = event.target as HTMLElement;
+    if (isEligibleFocusOwner(focusOwner, ownerDocument, { allowNegativeTabIndex: true })) {
+      lastFocusOwner = focusOwner;
+    }
+  };
+
+  const runPendingCheck = (version: number): void => {
+    if (destroyed || version !== pendingCheckVersion) return;
+    pendingCheck = false;
+
+    const activeElement = ownerDocument.activeElement;
+    if (isDocumentNode(activeElement, ownerDocument) && containsTarget(activeElement)) return;
+
+    if (suppressionPending) {
+      clearSuppression();
+      return;
+    }
+
+    const eligibleLastFocusOwner =
+      lastFocusOwner &&
+      isEligibleFocusOwner(lastFocusOwner, ownerDocument, { allowNegativeTabIndex: true })
+        ? lastFocusOwner
+        : null;
+
+    onFocusDeparture({ activeElement, lastFocusOwner: eligibleLastFocusOwner });
+  };
+
+  const scheduleDepartureCheck = (): void => {
+    if (destroyed || pendingCheck) return;
+
+    pendingCheck = true;
+    const version = ++pendingCheckVersion;
+    queueMicrotask(() => runPendingCheck(version));
+  };
+
+  const handleFocusOut = (): void => {
+    scheduleDepartureCheck();
+  };
+
+  const setSurfaces = (surfaces: Iterable<HTMLElement | null>): void => {
+    if (destroyed) return;
+
+    const nextSurfaces = new Set(
+      Array.from(surfaces).filter(
+        (surface): surface is HTMLElement =>
+          surface !== null && surface.ownerDocument === ownerDocument,
+      ),
+    );
+
+    observedSurfaces.forEach((surface) => {
+      if (nextSurfaces.has(surface)) return;
+      surface.removeEventListener("focusin", handleFocusIn);
+      surface.removeEventListener("focusout", handleFocusOut);
+      observedSurfaces.delete(surface);
+    });
+
+    nextSurfaces.forEach((surface) => {
+      if (observedSurfaces.has(surface)) return;
+      surface.addEventListener("focusin", handleFocusIn);
+      surface.addEventListener("focusout", handleFocusOut);
+      observedSurfaces.add(surface);
+    });
+  };
+
+  const clearSuppression = (): void => {
+    suppressionPending = false;
+    if (suppressionTimer === null) return;
+
+    globalThis.clearTimeout(suppressionTimer);
+    suppressionTimer = null;
+  };
+
+  setSurfaces(options.surfaces);
+
+  return {
+    destroy(): void {
+      if (destroyed) return;
+
+      destroyed = true;
+      pendingCheck = false;
+      pendingCheckVersion += 1;
+      clearSuppression();
+      observedSurfaces.forEach((surface) => {
+        surface.removeEventListener("focusin", handleFocusIn);
+        surface.removeEventListener("focusout", handleFocusOut);
+      });
+      observedSurfaces.clear();
+      lastFocusOwner = null;
+    },
+    setLastFocusOwner(element): void {
+      if (destroyed) return;
+
+      lastFocusOwner =
+        element && isEligibleFocusOwner(element, ownerDocument, { allowNegativeTabIndex: true })
+          ? element
+          : null;
+    },
+    setSurfaces,
+    suppressNextDeparture(): void {
+      if (destroyed) return;
+
+      clearSuppression();
+      suppressionPending = true;
+      suppressionTimer = globalThis.setTimeout(() => {
+        suppressionPending = false;
+        suppressionTimer = null;
+      }, 0);
+    },
+  };
+}
+
+function isEligibleFocusOwner(
+  element: HTMLElement,
+  ownerDocument: Document,
+  options: { allowNegativeTabIndex?: boolean } = {},
+): boolean {
+  if (!isBaseFocusOwnerEligible(element, ownerDocument, options)) return false;
+  if (!options.allowNegativeTabIndex && !isSequentialRadioTabStop(element, ownerDocument))
+    return false;
+
+  return true;
+}
+
+function isBaseFocusOwnerEligible(
+  element: HTMLElement,
+  ownerDocument: Document,
+  options: { allowNegativeTabIndex?: boolean } = {},
+): boolean {
+  if (!element.isConnected || element.ownerDocument !== ownerDocument) return false;
+  if (!options.allowNegativeTabIndex && element.tabIndex < 0) return false;
+  if (element.localName === "input" && (element as HTMLInputElement).type === "hidden")
+    return false;
+  if (element.matches(":disabled") || element.getAttribute("aria-disabled") === "true")
+    return false;
+  if (element.closest("[inert]")) return false;
+  if (!element.checkVisibility({ visibilityProperty: true })) return false;
+
+  let current: HTMLElement | null = element;
+  while (current) {
+    if (current.hidden || current.getAttribute("aria-hidden") === "true") return false;
+    current = current.parentElement;
+  }
+
+  return true;
+}
+
+function isSequentialRadioTabStop(element: HTMLElement, ownerDocument: Document): boolean {
+  const InputConstructor = ownerDocument.defaultView?.HTMLInputElement ?? HTMLInputElement;
+  if (!(element instanceof InputConstructor) || element.type !== "radio") return true;
+  if (element.name === "" || element.checked) return true;
+
+  return !Array.from(ownerDocument.querySelectorAll<HTMLInputElement>("input[type='radio']")).some(
+    (radio) =>
+      radio !== element &&
+      radio.checked &&
+      radio.name === element.name &&
+      radio.form === element.form &&
+      radio.getRootNode() === element.getRootNode() &&
+      isBaseFocusOwnerEligible(radio, ownerDocument),
+  );
+}
+
+function isDocumentNode(value: EventTarget | null, ownerDocument: Document): value is Node {
+  const NodeConstructor = ownerDocument.defaultView?.Node ?? Node;
+  return value instanceof NodeConstructor;
+}

--- a/packages/runtime/tests/components/context-menu/context-menu.browser.test.ts
+++ b/packages/runtime/tests/components/context-menu/context-menu.browser.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { createContextMenu } from "../../../src/components/context-menu/context-menu";
+import {
+  createContextMenu,
+  type ContextMenuOpenChangeReason,
+} from "../../../src/components/context-menu/context-menu";
 
 describe("createContextMenu", () => {
   beforeEach(() => {
@@ -572,6 +575,80 @@ describe("createContextMenu", () => {
 
     expect(contextMenu.getOpen()).toBe(false);
     expect(getPopup().hidden).toBe(true);
+  });
+
+  it("inherits keyboard Tab handoff and focus-out details from Menu", async () => {
+    const inheritedReason: ContextMenuOpenChangeReason = "focus-out";
+    const root = renderContextMenu({ modal: false });
+    const nextControl = document.createElement("button");
+    nextControl.textContent = "Next control";
+    document.body.append(nextControl);
+    const order: string[] = [];
+    const onOpenChange = vi.fn((open: boolean) => {
+      if (!open) order.push("callback");
+    });
+    const onCloseComplete = vi.fn();
+    root.addEventListener("starwind:open-change", (event) => {
+      if (!(event as CustomEvent<{ open: boolean }>).detail.open) order.push("dom");
+    });
+    const closeCompleteListener = vi.fn();
+    root.addEventListener("starwind:close-complete", closeCompleteListener);
+    const contextMenu = createContextMenu(root, { onCloseComplete, onOpenChange });
+    contextMenu.subscribe("openChange", (details) => {
+      if (!details.open) order.push("subscriber");
+    });
+    const closeCompleteSubscriber = vi.fn();
+    contextMenu.subscribe("closeComplete", closeCompleteSubscriber);
+
+    getTrigger().dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key: "ContextMenu" }));
+    await waitForFloatingPosition();
+
+    expect(contextMenu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getItem());
+
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    expect(getItem().dispatchEvent(tabEvent)).toBe(false);
+
+    const expectedDetails = expect.objectContaining({
+      event: tabEvent,
+      open: false,
+      reason: inheritedReason,
+    });
+    expect(contextMenu.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(nextControl);
+    expect(order).toEqual(["callback", "dom", "subscriber"]);
+    expect(onOpenChange).toHaveBeenCalledWith(false, expectedDetails);
+    expect(onCloseComplete).toHaveBeenCalledWith(expectedDetails);
+    expect(closeCompleteListener).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: expectedDetails }),
+    );
+    expect(closeCompleteSubscriber).toHaveBeenCalledWith(expectedDetails);
+  });
+
+  it("keeps outside pointer focus movement on the sole outside-press reason", async () => {
+    const root = renderContextMenu({ modal: false });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const reasons: ContextMenuOpenChangeReason[] = [];
+    const contextMenu = createContextMenu(root, {
+      modal: false,
+      onOpenChange: (open, details) => {
+        if (!open) reasons.push(details.reason);
+      },
+      open: true,
+    });
+
+    getItem().focus();
+    outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(contextMenu.getOpen()).toBe(true);
+    expect(reasons).toEqual(["outside-press"]);
   });
 
   it("opens from a touch long press", () => {

--- a/packages/runtime/tests/components/menu/menu.browser.test.ts
+++ b/packages/runtime/tests/components/menu/menu.browser.test.ts
@@ -1234,6 +1234,341 @@ describe("createMenu", () => {
     expect(document.activeElement).toBe(getTrigger());
   });
 
+  it("closes in transaction order and hands forward Tab to the next document control", async () => {
+    const root = renderMenu();
+    const nextControl = document.createElement("button");
+    nextControl.textContent = "Next control";
+    document.body.append(nextControl);
+    const order: string[] = [];
+    const onOpenChange = vi.fn((open: boolean) => {
+      if (!open) order.push("callback");
+    });
+    root.addEventListener("starwind:open-change", (event) => {
+      if (!(event as CustomEvent<{ open: boolean }>).detail.open) order.push("dom");
+    });
+    const closeCompleteListener = vi.fn();
+    root.addEventListener("starwind:close-complete", closeCompleteListener);
+    const menu = createMenu(root, { onOpenChange });
+    menu.subscribe("openChange", (details) => {
+      if (!details.open) order.push("subscriber");
+    });
+
+    getTrigger().click();
+    await waitForFloatingPosition();
+    getItems()[0].focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+
+    expect(getPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(nextControl);
+    expect(order).toEqual(["callback", "dom", "subscriber"]);
+    expect(closeCompleteListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ open: false, reason: "focus-out" }),
+      }),
+    );
+  });
+
+  it("returns reverse Tab to the opening trigger after an accepted focus-out close", async () => {
+    const root = renderMenu();
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    getTrigger().click();
+    await waitForFloatingPosition();
+    getItems()[0].focus();
+    onOpenChange.mockClear();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    });
+
+    expect(getPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(getTrigger());
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ event: tabEvent, reason: "focus-out" }),
+    );
+  });
+
+  it("keeps keyboard focus inside when the callback cancels a Tab close", async () => {
+    const root = renderMenu();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const menu = createMenu(root, { onOpenChange });
+    const subscriber = vi.fn();
+    menu.subscribe("openChange", subscriber);
+
+    menu.setOpen(true, { emit: false });
+    getItems()[0].focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    getPopup().dispatchEvent(tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(menu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getItems()[0]);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ isCanceled: true, reason: "focus-out" }),
+    );
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("restores the last Menu focus owner when a settled departure is canceled by DOM", async () => {
+    const root = renderMenu();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const menu = createMenu(root);
+    const subscriber = vi.fn();
+    menu.subscribe("openChange", subscriber);
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") event.preventDefault();
+    });
+
+    menu.setOpen(true, { emit: false });
+    getItems()[1].focus();
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getItems()[1]);
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("keeps the root open across submenu portals and closes once after focus leaves the tree", async () => {
+    const root = renderMenuWithSubmenu();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    getSubmenuTrigger().click();
+    getSubmenuPopup().querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+  });
+
+  it("moves focus after accepted controlled Tab intent and preserves focus-out completion", async () => {
+    vi.useFakeTimers();
+    const root = renderMenuWithAnimatedPopup();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const onOpenChange = vi.fn();
+    const closeCompleteListener = vi.fn();
+    root.addEventListener("starwind:close-complete", closeCompleteListener);
+    const menu = createMenu(root, { onOpenChange, open: true });
+    const subscriber = vi.fn();
+    menu.subscribe("openChange", subscriber);
+
+    getItems()[0].focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(menu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(nextControl);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+    expect(subscriber).toHaveBeenCalledWith(expect.objectContaining({ reason: "focus-out" }));
+
+    menu.setOpen(false, { emit: false });
+    expect(closeCompleteListener).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(200);
+
+    expect(closeCompleteListener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ open: false, reason: "focus-out" }),
+      }),
+    );
+  });
+
+  it("keeps outside pointer dismissal as the only proposal when focus also leaves", async () => {
+    const root = renderMenu();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const reasons: string[] = [];
+    const menu = createMenu(root, {
+      onOpenChange: (open, details) => {
+        if (!open) reasons.push(details.reason);
+      },
+      open: true,
+    });
+
+    getItems()[0].focus();
+    outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(reasons).toEqual(["outside-press"]);
+  });
+
+  it("handles missing focus destinations and cancels pending departure work on destroy", async () => {
+    const root = renderMenu();
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    getItems()[0].focus();
+    expect(() => {
+      getPopup().dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+      );
+    }).not.toThrow();
+    expect(menu.getOpen()).toBe(false);
+
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    menu.setOpen(true, { emit: false });
+    getItems()[0].focus();
+    onOpenChange.mockClear();
+    outside.focus();
+    menu.destroy();
+    await settleFocusBoundary();
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    document.body.innerHTML = "";
+    const disconnectedRoot = renderMenu();
+    const disconnectedMenu = createMenu(disconnectedRoot);
+    const disconnectedTrigger = getTrigger();
+    disconnectedTrigger.click();
+    await waitForFloatingPosition();
+    getItems()[0].focus();
+    disconnectedTrigger.remove();
+
+    expect(() => {
+      getPopup().dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Tab",
+          shiftKey: true,
+        }),
+      );
+    }).not.toThrow();
+    expect(disconnectedMenu.getOpen()).toBe(false);
+  });
+
+  it("stops accepted Tab work when the open-change callback destroys the Menu", async () => {
+    vi.useFakeTimers();
+    const root = renderMenuWithAnimatedPopup();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const closeCompleteListener = vi.fn();
+    root.addEventListener("starwind:close-complete", closeCompleteListener);
+    let menu: ReturnType<typeof createMenu>;
+    menu = createMenu(root, {
+      onOpenChange: (open, details) => {
+        if (!open && details.reason === "focus-out") menu.destroy();
+      },
+    });
+
+    menu.setOpen(true, { emit: false });
+    const item = getItems()[0];
+    item.focus();
+
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).toBe(document.body);
+    expect(document.activeElement).not.toBe(nextControl);
+    expect(closeCompleteListener).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+    expect(closeCompleteListener).not.toHaveBeenCalled();
+  });
+
+  it("stops canceled settled-departure work when the callback destroys the Menu", async () => {
+    const root = renderMenu();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    let menu: ReturnType<typeof createMenu>;
+    menu = createMenu(root, {
+      onOpenChange: (open, details) => {
+        if (open || details.reason !== "focus-out") return;
+
+        details.cancel();
+        menu.destroy();
+      },
+    });
+
+    menu.setOpen(true, { emit: false });
+    getItems()[0].focus();
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it("stops accepted Tab work when the DOM open-change listener destroys the Menu", async () => {
+    vi.useFakeTimers();
+    const root = renderMenuWithAnimatedPopup();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const closeCompleteListener = vi.fn();
+    root.addEventListener("starwind:close-complete", closeCompleteListener);
+    let menu: ReturnType<typeof createMenu>;
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") menu.destroy();
+    });
+    menu = createMenu(root);
+
+    menu.setOpen(true, { emit: false });
+    const item = getItems()[0];
+    item.focus();
+
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).toBe(document.body);
+    expect(document.activeElement).not.toBe(nextControl);
+    expect(closeCompleteListener).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+    expect(closeCompleteListener).not.toHaveBeenCalled();
+  });
+
   it("supports controlled mode and cancelable open changes", async () => {
     const root = renderMenu();
     const onOpenChange = vi.fn();
@@ -1662,6 +1997,358 @@ describe("createMenu", () => {
     expect(getSubmenuPopup().hidden).toBe(true);
     expect(getSubmenuTrigger().getAttribute("aria-expanded")).toBe("false");
     expect(document.activeElement).toBe(getSubmenuTrigger());
+  });
+
+  it("closes one submenu on Shift+Tab and returns focus without closing the root", () => {
+    const root = renderMenuWithSubmenu();
+    const submenuRoot = root.querySelector<HTMLElement>("[data-sw-menu-submenu-root]")!;
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    getSubmenuTrigger().click();
+    const submenuItem = getSubmenuPopup().querySelector<HTMLElement>("[data-sw-menu-item]")!;
+    submenuItem.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    });
+
+    expect(getSubmenuPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoot.getAttribute("data-state")).toBe("closed");
+    expect(getSubmenuPopup().hidden).toBe(true);
+    expect(document.activeElement).toBe(getSubmenuTrigger());
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("closes only the deepest nested submenu on reverse Tab", () => {
+    const root = renderMenuWithNestedSubmenus();
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const menu = createMenu(root);
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    submenuPopups[1]!.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Tab",
+        shiftKey: true,
+      }),
+    );
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("open");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("closed");
+    expect(submenuPopups[0]!.hidden).toBe(false);
+    expect(submenuPopups[1]!.hidden).toBe(true);
+    expect(document.activeElement).toBe(submenuTriggers[1]);
+  });
+
+  it("routes forward Tab from a nested portal through one root focus-out handoff", () => {
+    const root = renderMenuWithNestedSubmenus();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+
+    expect(submenuPopups[1]!.dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(nextControl);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ event: tabEvent, reason: "focus-out" }),
+    );
+  });
+
+  it("keeps nested branches open when the root forward handoff is canceled", () => {
+    const root = renderMenuWithNestedSubmenus();
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const menu = createMenu(root, { onOpenChange });
+    const subscriber = vi.fn();
+    menu.subscribe("openChange", subscriber);
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    const deepestItem = submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!;
+    deepestItem.focus();
+    submenuPopups[1]!.dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("open");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("open");
+    expect(document.activeElement).toBe(deepestItem);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("closes the smallest departed submenu branch after focus settles", async () => {
+    const root = renderMenuWithNestedSubmenus();
+    const rootItem = document.createElement("div");
+    rootItem.setAttribute("data-sw-menu-item", "");
+    rootItem.textContent = "Root item";
+    getPopup().prepend(rootItem);
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    const deepestItem = submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!;
+    deepestItem.focus();
+    submenuTriggers[1]!.focus();
+    await settleFocusBoundary();
+
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("open");
+
+    submenuTriggers[0]!.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("open");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("closed");
+
+    submenuTriggers[1]!.click();
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("open");
+
+    rootItem.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("closed");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("closed");
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it("emits one root focus-out proposal after focus leaves nested open branches", async () => {
+    const root = renderMenuWithNestedSubmenus();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(false);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("closed");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("closed");
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+  });
+
+  it("preserves every nested branch when complete-tree focus-out is canceled", async () => {
+    const root = renderMenuWithNestedSubmenus();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    const deepestItem = submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!;
+    deepestItem.focus();
+    outside.focus();
+    await settleFocusBoundary();
+
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoots[0]!.getAttribute("data-state")).toBe("open");
+    expect(submenuRoots[1]!.getAttribute("data-state")).toBe("open");
+    expect(submenuPopups[0]!.hidden).toBe(false);
+    expect(submenuPopups[1]!.hidden).toBe(false);
+    expect(document.activeElement).toBe(deepestItem);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+  });
+
+  it("does not start animated branch closes before a canceled root decision", async () => {
+    vi.useFakeTimers();
+    const root = renderMenuWithNestedSubmenus();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const submenuRoots = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-root]"),
+    );
+    const submenuTriggers = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-submenu-trigger]"),
+    );
+    const submenuPopups = Array.from(
+      root.querySelectorAll<HTMLElement>("[data-sw-menu-popup]"),
+    ).slice(1);
+    submenuPopups.forEach(setAnimatedClose);
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTriggers[0]!.click();
+    submenuTriggers[1]!.click();
+    const deepestItem = submenuPopups[1]!.querySelector<HTMLElement>("[data-sw-menu-item]")!;
+    deepestItem.focus();
+    outside.focus();
+    await settleFocusBoundary();
+
+    submenuRoots.forEach((submenuRoot) => {
+      expect(submenuRoot.getAttribute("data-state")).toBe("open");
+    });
+    submenuPopups.forEach((submenuPopup) => {
+      expect(submenuPopup.hidden).toBe(false);
+      expect(submenuPopup.hasAttribute("data-ending-style")).toBe(false);
+    });
+    expect(menu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(deepestItem);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    submenuRoots.forEach((submenuRoot) => {
+      expect(submenuRoot.getAttribute("data-state")).toBe("open");
+    });
+    submenuPopups.forEach((submenuPopup) => {
+      expect(submenuPopup.hidden).toBe(false);
+    });
+  });
+
+  it("handles animated reverse close, disconnected triggers, and pending destroy work", async () => {
+    vi.useFakeTimers();
+    const root = renderMenuWithSubmenu();
+    const submenuRoot = root.querySelector<HTMLElement>("[data-sw-menu-submenu-root]")!;
+    const submenuTrigger = getSubmenuTrigger();
+    const submenuPopup = getSubmenuPopup();
+    setAnimatedClose(submenuPopup);
+    const onOpenChange = vi.fn();
+    const menu = createMenu(root, { onOpenChange });
+
+    menu.setOpen(true, { emit: false });
+    submenuTrigger.click();
+    submenuPopup.querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    submenuTrigger.remove();
+
+    expect(() => {
+      submenuPopup.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Tab",
+          shiftKey: true,
+        }),
+      );
+    }).not.toThrow();
+    expect(menu.getOpen()).toBe(true);
+    expect(submenuRoot.getAttribute("data-state")).toBe("closed");
+    expect(submenuPopup.hidden).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(submenuPopup.hidden).toBe(true);
+    expect(menu.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getPopup());
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    menu.destroy();
+    await settleFocusBoundary();
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    document.body.innerHTML = "";
+    const cleanupRoot = renderMenuWithSubmenu();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const cleanupOnOpenChange = vi.fn();
+    const cleanupMenu = createMenu(cleanupRoot, { onOpenChange: cleanupOnOpenChange });
+    cleanupMenu.setOpen(true, { emit: false });
+    getSubmenuTrigger().click();
+    getSubmenuPopup().querySelector<HTMLElement>("[data-sw-menu-item]")!.focus();
+    outside.focus();
+    cleanupMenu.destroy();
+    await settleFocusBoundary();
+
+    expect(cleanupOnOpenChange).not.toHaveBeenCalled();
+    expect(getSubmenuPopup().hidden).toBe(true);
   });
 
   it("keeps submenu popups mounted while close animations finish and cleans them up on destroy", async () => {
@@ -2535,6 +3222,11 @@ function dispatchScrollUpdate(): void {
 
 function dispatchMousePointer(element: HTMLElement, type: "pointerenter" | "pointerleave"): void {
   element.dispatchEvent(new PointerEvent(type, { bubbles: true, pointerType: "mouse" }));
+}
+
+async function settleFocusBoundary(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 function mockRect(

--- a/packages/runtime/tests/components/menu/menu.browser.test.ts
+++ b/packages/runtime/tests/components/menu/menu.browser.test.ts
@@ -1301,6 +1301,32 @@ describe("createMenu", () => {
     );
   });
 
+  it("falls back to a connected trigger when the opening trigger disconnects", async () => {
+    const root = renderMenu();
+    const openingTrigger = getTrigger();
+    const fallbackTrigger = document.createElement("button");
+    fallbackTrigger.setAttribute("data-sw-menu-trigger", "");
+    fallbackTrigger.textContent = "Fallback trigger";
+    root.append(fallbackTrigger);
+    const menu = createMenu(root);
+
+    openingTrigger.click();
+    await waitForFloatingPosition();
+    getItems()[0].focus();
+    openingTrigger.remove();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    });
+
+    expect(getPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(fallbackTrigger);
+  });
+
   it("keeps keyboard focus inside when the callback cancels a Tab close", async () => {
     const root = renderMenu();
     const nextControl = document.createElement("button");

--- a/packages/runtime/tests/components/navigation-menu/navigation-menu.browser.test.ts
+++ b/packages/runtime/tests/components/navigation-menu/navigation-menu.browser.test.ts
@@ -983,6 +983,41 @@ describe("createNavigationMenu", () => {
     expect(reasons).toEqual(["trigger-press", "focus-out"]);
   });
 
+  it("retains controlled value and popup focus when final Tab is canceled by DOM", () => {
+    const root = renderNavigationMenuWithPopupFocusControls();
+    const onValueChange = vi.fn();
+    const menu = createNavigationMenu(root, { onValueChange, value: "last" });
+    const subscriber = vi.fn();
+    menu.subscribe("valueChange", subscriber);
+    const popupControl = getLink("last-primary");
+    let eventDetails: NavigationMenuValueChangeDetails | null = null;
+    root.addEventListener("starwind:value-change", (event) => {
+      const details = (event as CustomEvent<NavigationMenuValueChangeDetails>).detail;
+      if (details.reason !== "focus-out") return;
+
+      eventDetails = details;
+      event.preventDefault();
+    });
+    popupControl.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+
+    expect(popupControl.dispatchEvent(tabEvent)).toBe(false);
+
+    expect(menu.getValue()).toBe("last");
+    expect(getPopup().hidden).toBe(false);
+    expect(document.activeElement).toBe(popupControl);
+    expect(onValueChange).toHaveBeenCalledWith(
+      null,
+      expect.objectContaining({ event: tabEvent, reason: "focus-out", value: null }),
+    );
+    expect(eventDetails).toEqual(expect.objectContaining({ isCanceled: true }));
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
   it("respects closeOnEscape false when Escape is pressed from focused content", () => {
     const root = renderNavigationMenuWithKeyboard();
     const menu = createNavigationMenu(root, { closeOnEscape: false, defaultValue: "first" });

--- a/packages/runtime/tests/components/select/select.browser.test.ts
+++ b/packages/runtime/tests/components/select/select.browser.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { createPopover } from "../../../src/components/popover/popover";
 import { createSelect } from "../../../src/components/select/select";
 
 describe("createSelect", () => {
@@ -82,6 +83,39 @@ describe("createSelect", () => {
     external.setOpen(false, { emit: false });
 
     expect(document.body.hasAttribute("data-sw-scroll-locked")).toBe(false);
+  });
+
+  it("keeps controlled popup and modal lock coherent until settled departure sync", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange, open: true });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    getItem("system").focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(getPopup().hidden).toBe(false);
+    expect(document.body.hasAttribute("data-sw-scroll-locked")).toBe(true);
+    expect(document.activeElement).toBe(outside);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+    expect(subscriber).toHaveBeenCalledOnce();
+
+    select.setOpen(false, { emit: false });
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(document.body.hasAttribute("data-sw-scroll-locked")).toBe(false);
+    expect(document.activeElement).toBe(outside);
+    expect(onOpenChange).toHaveBeenCalledOnce();
   });
 
   it("initializes an uncontrolled select with default value and hidden form value", () => {
@@ -473,6 +507,708 @@ describe("createSelect", () => {
 
     expect(document.activeElement).toBe(getItem("light"));
     expect(getItem("light")).toHaveAttribute("data-highlighted");
+  });
+
+  it("closes in transaction order and hands forward Tab past the logical Select root", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const rootRemainder = document.createElement("button");
+    rootRemainder.textContent = "Root remainder";
+    root.append(rootRemainder);
+    const portalControl = document.createElement("button");
+    portalControl.textContent = "Portal control";
+    getPositioner().append(portalControl);
+    const nextControl = document.createElement("button");
+    nextControl.textContent = "Next control";
+    document.body.append(nextControl);
+    const order: string[] = [];
+    const onOpenChange = vi.fn((open: boolean) => {
+      if (!open) order.push("callback");
+    });
+    const onValueChange = vi.fn();
+    root.addEventListener("starwind:open-change", (event) => {
+      if (!(event as CustomEvent<{ open: boolean }>).detail.open) order.push("dom");
+    });
+    const select = createSelect(root, { onOpenChange, onValueChange });
+    select.subscribe("openChange", (details) => {
+      if (!details.open) order.push("subscriber");
+    });
+
+    getTrigger().click();
+    await waitForFloatingPosition();
+    const activeItem = getItem("system");
+    activeItem.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+
+    expect(getPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(select.getOpen()).toBe(false);
+    expect(select.getValue()).toBe("system");
+    expect(document.activeElement).toBe(nextControl);
+    expect(activeItem.hasAttribute("data-highlighted")).toBe(false);
+    expect(order).toEqual(["callback", "dom", "subscriber"]);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ event: tabEvent, reason: "focus-out" }),
+    );
+    expect(onValueChange).not.toHaveBeenCalled();
+  });
+
+  it("returns reverse Tab to the trigger through an accepted focus-out close", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange });
+
+    getTrigger().click();
+    await waitForFloatingPosition();
+    const activeItem = getItem("dark");
+    activeItem.focus();
+    onOpenChange.mockClear();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+      shiftKey: true,
+    });
+
+    expect(getPopup().dispatchEvent(tabEvent)).toBe(false);
+
+    expect(select.getOpen()).toBe(false);
+    expect(select.getValue()).toBe("system");
+    expect(document.activeElement).toBe(getTrigger());
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ event: tabEvent, reason: "focus-out" }),
+    );
+  });
+
+  it("keeps option focus when the callback cancels a Tab close", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const select = createSelect(root, { onOpenChange });
+    const subscriber = vi.fn();
+    const valueSubscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+    select.subscribe("valueChange", valueSubscriber);
+
+    select.setOpen(true, { emit: false });
+    const activeItem = getItem("dark");
+    activeItem.focus();
+    const tabEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Tab",
+    });
+    getPopup().dispatchEvent(tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(select.getOpen()).toBe(true);
+    expect(select.getValue()).toBe("system");
+    expect(document.activeElement).toBe(activeItem);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ isCanceled: true, reason: "focus-out" }),
+    );
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+    expect(valueSubscriber).not.toHaveBeenCalled();
+  });
+
+  it("does not restore a canceled Tab to an option disabled during the callback", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const activeItem = getItem("dark");
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (open || details.reason !== "focus-out") return;
+
+        details.cancel();
+        activeItem.setAttribute("data-disabled", "");
+        outside.focus();
+      },
+    });
+
+    select.setOpen(true, { emit: false });
+    activeItem.focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(outside);
+    expect(document.activeElement).not.toBe(activeItem);
+
+    select.destroy();
+  });
+
+  it("keeps option focus when the DOM event cancels a reverse Tab close", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") event.preventDefault();
+    });
+    const select = createSelect(root);
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    const activeItem = getItem("light");
+    activeItem.focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Tab",
+        shiftKey: true,
+      }),
+    );
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(activeItem);
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("hands off accepted controlled Tab intent before owner synchronization", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange, open: true });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    const activeItem = getItem("auto");
+    activeItem.focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(getPopup().hidden).toBe(false);
+    expect(select.getValue()).toBe("system");
+    expect(document.activeElement).toBe(nextControl);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(subscriber).toHaveBeenCalledWith(expect.objectContaining({ reason: "focus-out" }));
+
+    select.setOpen(false, { emit: false });
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(activeItem.hasAttribute("data-highlighted")).toBe(false);
+    expect(document.activeElement).toBe(nextControl);
+  });
+
+  it("closes safely when Tab destinations are missing or disconnected", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const select = createSelect(root);
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    expect(() => {
+      getPopup().dispatchEvent(
+        new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+      );
+    }).not.toThrow();
+    expect(select.getOpen()).toBe(false);
+
+    select.setOpen(true, { emit: false });
+    getItem("dark").focus();
+    getTrigger().remove();
+    expect(() => {
+      getPopup().dispatchEvent(
+        new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Tab",
+          shiftKey: true,
+        }),
+      );
+    }).not.toThrow();
+    expect(select.getOpen()).toBe(false);
+  });
+
+  it("stops accepted Tab work when the open-change callback destroys the Select", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    let select: ReturnType<typeof createSelect>;
+    select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (!open && details.reason === "focus-out") select.destroy();
+      },
+    });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).not.toBe(nextControl);
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("stops accepted Tab work when the DOM open-change listener destroys the Select", () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const nextControl = document.createElement("button");
+    document.body.append(nextControl);
+    let select: ReturnType<typeof createSelect>;
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") select.destroy();
+    });
+    select = createSelect(root);
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    getPopup().dispatchEvent(
+      new KeyboardEvent("keydown", { bubbles: true, cancelable: true, key: "Tab" }),
+    );
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).not.toBe(nextControl);
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("closes once after programmatic focus leaves the portaled Select tree", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(false);
+    expect(select.getValue()).toBe("system");
+    expect(document.activeElement).toBe(outside);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+    expect(subscriber).toHaveBeenCalledOnce();
+    expect(subscriber).toHaveBeenCalledWith(expect.objectContaining({ reason: "focus-out" }));
+  });
+
+  it("restores the last eligible option when a settled departure is canceled by callback", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn((open, details) => {
+      if (!open && details.reason === "focus-out") details.cancel();
+    });
+    const select = createSelect(root, { onOpenChange });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    const activeItem = getItem("auto");
+    activeItem.focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(activeItem);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ isCanceled: true, reason: "focus-out" }),
+    );
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("keeps outside pointer dismissal as the only controlled departure proposal", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const reasons: string[] = [];
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (!open) reasons.push(details.reason);
+      },
+      open: true,
+    });
+
+    getItem("system").focus();
+    outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(reasons).toEqual(["outside-press"]);
+
+    select.destroy();
+  });
+
+  it("keeps open while focus moves through trigger and authored portal surfaces", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const positioner = getPositioner();
+    const portal = document.createElement("div");
+    portal.setAttribute("data-sw-select-portal", "");
+    positioner.replaceWith(portal);
+    portal.append(positioner);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange });
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    getTrigger().focus();
+    await waitForMicrotasks();
+
+    positioner.tabIndex = 0;
+    positioner.focus();
+    await waitForMicrotasks();
+
+    portal.tabIndex = 0;
+    portal.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("restores the prior option when callback cancellation follows structural portal focus", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const positioner = getPositioner();
+    const portal = document.createElement("div");
+    portal.setAttribute("data-sw-select-portal", "");
+    positioner.replaceWith(portal);
+    portal.append(positioner);
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (!open && details.reason === "focus-out") details.cancel();
+      },
+    });
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    const activeItem = getItem("system");
+    activeItem.focus();
+    positioner.tabIndex = 0;
+    positioner.focus();
+    portal.tabIndex = 0;
+    portal.focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(activeItem);
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("restores the prior trigger when DOM cancellation follows structural popup focus", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") event.preventDefault();
+    });
+    const select = createSelect(root);
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    getTrigger().focus();
+    getPopup().focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getTrigger());
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("restores the trigger when DOM cancellation rejects settled departure", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    root.addEventListener("starwind:open-change", (event) => {
+      const details = (event as CustomEvent<{ open: boolean; reason: string }>).detail;
+      if (!details.open && details.reason === "focus-out") event.preventDefault();
+    });
+    const select = createSelect(root);
+    const subscriber = vi.fn();
+    select.subscribe("openChange", subscriber);
+
+    select.setOpen(true, { emit: false });
+    getTrigger().focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(getTrigger());
+    expect(subscriber).not.toHaveBeenCalled();
+
+    select.destroy();
+  });
+
+  it("skips restoration when a canceled departure owner disconnects", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const activeItem = getItem("dark");
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (open || details.reason !== "focus-out") return;
+
+        details.cancel();
+        activeItem.remove();
+      },
+    });
+
+    select.setOpen(true, { emit: false });
+    activeItem.focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(outside);
+
+    select.destroy();
+  });
+
+  it("stops canceled settled-departure work when the callback destroys Select", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    let select: ReturnType<typeof createSelect>;
+    select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (open || details.reason !== "focus-out") return;
+
+        details.cancel();
+        select.destroy();
+      },
+    });
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup().hidden).toBe(true);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it("cancels a pending settled departure when Select is destroyed", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange });
+
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    outside.focus();
+    select.destroy();
+    await waitForMicrotasks();
+
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(select.getOpen()).toBe(false);
+    expect(document.activeElement).toBe(outside);
+  });
+
+  it("closes only a nested Select when focus moves to another parent Popover control", async () => {
+    const wrapper = document.createElement("div");
+    wrapper.innerHTML = `
+      <div data-sw-popover>
+        <button data-sw-popover-trigger type="button">Open parent</button>
+        <div data-sw-popover-positioner>
+          <div data-sw-popover-popup hidden>
+            <button id="parent-control" type="button">Parent action</button>
+          </div>
+        </div>
+      </div>
+    `;
+    const popoverRoot = wrapper.firstElementChild as HTMLElement;
+    document.body.append(popoverRoot);
+    const popoverPopup = popoverRoot.querySelector<HTMLElement>("[data-sw-popover-popup]")!;
+    const parentControl = popoverRoot.querySelector<HTMLButtonElement>("#parent-control")!;
+    const selectRoot = renderSelect({ defaultValue: "system" });
+    popoverPopup.append(selectRoot);
+    const popover = createPopover(popoverRoot);
+    const onOpenChange = vi.fn();
+    const select = createSelect(selectRoot, { onOpenChange });
+
+    popover.setOpen(true, { emit: false });
+    select.setOpen(true, { emit: false });
+    getItem("system").focus();
+    parentControl.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(false);
+    expect(popover.getOpen()).toBe(true);
+    expect(popoverPopup.hidden).toBe(false);
+    expect(document.activeElement).toBe(parentControl);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+
+    popover.destroy();
+    select.destroy();
+  });
+
+  it("observes focus departure from a custom portal target", async () => {
+    const portalTarget = document.createElement("div");
+    const portalReference = document.createElement("span");
+    portalTarget.setAttribute("data-floating-root", "");
+    portalTarget.append(portalReference);
+    document.body.append(portalTarget);
+    const root = renderSelect({
+      alignItemWithTrigger: false,
+      defaultValue: "system",
+      modal: false,
+    });
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange, portalReference });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+
+    select.setOpen(true, { emit: false });
+    expect(getPositioner().parentElement).toBe(portalTarget);
+    getItem("system").focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(false);
+    expect(onOpenChange).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+  });
+
+  it("keeps a focus-out close portaled until its animation finishes", async () => {
+    const root = renderSelect({
+      alignItemWithTrigger: false,
+      defaultValue: "system",
+      modal: false,
+    });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const onOpenChange = vi.fn();
+    const select = createSelect(root, { onOpenChange });
+
+    select.setOpen(true, { emit: false });
+    const animationFinished = createDeferred<void>();
+    vi.spyOn(getPopup(), "getAnimations").mockReturnValue([
+      { finished: animationFinished.promise } as unknown as Animation,
+    ]);
+    getItem("system").focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(false);
+    expect(getPopup()).toHaveAttribute("data-state", "closed");
+    expect(getPopup().hidden).toBe(false);
+    expect(getPositioner().parentElement).toBe(document.body);
+    expect(onOpenChange).toHaveBeenCalledWith(
+      false,
+      expect.objectContaining({ reason: "focus-out" }),
+    );
+
+    animationFinished.resolve();
+    await animationFinished.promise;
+    await waitForMicrotasks();
+
+    expect(getPopup().hidden).toBe(true);
+    expect(getPositioner().parentElement).toBe(root);
+  });
+
+  it("skips restoration when a canceled departure owner becomes disabled", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const activeItem = getItem("dark");
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (open || details.reason !== "focus-out") return;
+
+        details.cancel();
+        activeItem.setAttribute("data-disabled", "");
+      },
+    });
+
+    select.setOpen(true, { emit: false });
+    activeItem.focus();
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(document.activeElement).toBe(outside);
+
+    select.destroy();
+  });
+
+  it("expires pointer suppression when pointer default action does not move focus", async () => {
+    const root = renderSelect({ defaultValue: "system" });
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    const reasons: string[] = [];
+    const select = createSelect(root, {
+      onOpenChange: (open, details) => {
+        if (!open) reasons.push(details.reason);
+      },
+      open: true,
+    });
+
+    getItem("system").focus();
+    outside.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    await waitForMacrotask();
+
+    expect(reasons).toEqual(["outside-press"]);
+
+    outside.focus();
+    await waitForMicrotasks();
+
+    expect(select.getOpen()).toBe(true);
+    expect(reasons).toEqual(["outside-press", "focus-out"]);
+
+    select.destroy();
   });
 
   it("registers global dismissal listeners only while select instances are open", () => {

--- a/packages/runtime/tests/internal/focus-boundary.browser.test.ts
+++ b/packages/runtime/tests/internal/focus-boundary.browser.test.ts
@@ -1,0 +1,463 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createFocusBoundary, getNextDocumentTabStop } from "../../src/internal/focus-boundary";
+
+describe("getNextDocumentTabStop", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns the first eligible document target after the logical owner", () => {
+    const before = button("before");
+    const owner = document.createElement("div");
+    const owned = button("owned");
+    const hidden = button("hidden");
+    hidden.hidden = true;
+    const ariaHiddenParent = document.createElement("div");
+    ariaHiddenParent.setAttribute("aria-hidden", "true");
+    const ariaHidden = button("aria-hidden");
+    ariaHiddenParent.append(ariaHidden);
+    const disabled = button("disabled");
+    disabled.disabled = true;
+    const negative = button("negative");
+    negative.tabIndex = -1;
+    const hiddenInput = document.createElement("input");
+    hiddenInput.type = "hidden";
+    const inertParent = document.createElement("div");
+    inertParent.inert = true;
+    const inertControl = button("inert");
+    inertParent.append(inertControl);
+    const next = button("next");
+    owner.append(owned);
+    document.body.append(
+      before,
+      owner,
+      hidden,
+      ariaHiddenParent,
+      disabled,
+      negative,
+      hiddenInput,
+      inertParent,
+      next,
+    );
+
+    expect(getNextDocumentTabStop(owner)).toBe(next);
+  });
+
+  it("skips controls hidden by CSS on themselves or an ancestor", () => {
+    const owner = document.createElement("div");
+    const displayHidden = button("display-hidden");
+    displayHidden.style.display = "none";
+    const displayHiddenParent = document.createElement("div");
+    displayHiddenParent.style.display = "none";
+    displayHiddenParent.append(button("display-hidden-descendant"));
+    const visibilityHidden = button("visibility-hidden");
+    visibilityHidden.style.visibility = "hidden";
+    const visibilityHiddenParent = document.createElement("div");
+    visibilityHiddenParent.style.visibility = "hidden";
+    visibilityHiddenParent.append(button("visibility-hidden-descendant"));
+    const next = button("next");
+    document.body.append(
+      owner,
+      displayHidden,
+      displayHiddenParent,
+      visibilityHidden,
+      visibilityHiddenParent,
+      next,
+    );
+
+    expect(getNextDocumentTabStop(owner)).toBe(next);
+  });
+
+  it("skips hidden content in closed details and keeps its summary eligible", () => {
+    const owner = document.createElement("div");
+    const details = document.createElement("details");
+    const hiddenControl = button("hidden-control");
+    const summary = document.createElement("summary");
+    summary.textContent = "Summary";
+    details.append(hiddenControl, summary);
+    document.body.append(owner, details);
+
+    expect(getNextDocumentTabStop(owner)).toBe(summary);
+  });
+
+  it("routes a checked radio group through its checked member", () => {
+    const owner = document.createElement("div");
+    const first = radio("choice");
+    const checked = radio("choice");
+    checked.checked = true;
+    const next = button("next");
+    document.body.append(owner, first, checked, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(checked);
+  });
+
+  it("routes an unchecked radio group through its first member", () => {
+    const owner = document.createElement("div");
+    const first = radio("choice");
+    const second = radio("choice");
+    const next = button("next");
+    document.body.append(owner, first, second, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(first);
+  });
+
+  it("ignores a disabled checked radio when routing its group", () => {
+    const owner = document.createElement("div");
+    const first = radio("choice");
+    const checked = radio("choice");
+    checked.checked = true;
+    checked.disabled = true;
+    const next = button("next");
+    document.body.append(owner, first, checked, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(first);
+  });
+
+  it.each([
+    ["display", "none"],
+    ["visibility", "hidden"],
+  ])("ignores a checked radio hidden by %s when routing its group", (property, value) => {
+    const owner = document.createElement("div");
+    const first = radio("choice");
+    const checked = radio("choice");
+    checked.checked = true;
+    checked.style.setProperty(property, value);
+    const next = button("next");
+    document.body.append(owner, first, checked, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(first);
+  });
+
+  it("ignores a negative-tab-index checked radio when routing its group", () => {
+    const owner = document.createElement("div");
+    const first = radio("choice");
+    const checked = radio("choice");
+    checked.checked = true;
+    checked.tabIndex = -1;
+    const next = button("next");
+    document.body.append(owner, first, checked, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(first);
+  });
+
+  it("keeps same-name radios with different form owners in separate groups", () => {
+    const owner = document.createElement("div");
+    const firstForm = document.createElement("form");
+    const first = radio("choice");
+    firstForm.append(first);
+    const secondForm = document.createElement("form");
+    const checked = radio("choice");
+    checked.checked = true;
+    secondForm.append(checked);
+    const next = button("next");
+    document.body.append(owner, firstForm, secondForm, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(first);
+  });
+
+  it("uses the logical owner's document for iframe-owned targets", () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const frameDocument = frame.contentDocument!;
+    const owner = frameDocument.createElement("div");
+    const next = frameDocument.createElement("button");
+    frameDocument.body.append(owner, next);
+
+    expect(getNextDocumentTabStop(owner)).toBe(next);
+  });
+
+  it("excludes portaled surfaces and their descendants in document order", () => {
+    const owner = document.createElement("div");
+    const portal = document.createElement("div");
+    const portalControl = button("portal-control");
+    const nestedPortal = document.createElement("div");
+    const nestedControl = button("nested-control");
+    const next = button("next");
+    portal.append(portalControl);
+    nestedPortal.append(nestedControl);
+    document.body.append(owner, portal, nestedPortal, next);
+
+    expect(getNextDocumentTabStop(owner, [portal, nestedPortal])).toBe(next);
+  });
+
+  it("returns null for disconnected owners and when no following target exists", () => {
+    const disconnected = document.createElement("div");
+    expect(getNextDocumentTabStop(disconnected)).toBeNull();
+
+    const before = button("before");
+    const owner = document.createElement("div");
+    document.body.append(before, owner);
+
+    expect(getNextDocumentTabStop(owner)).toBeNull();
+  });
+});
+
+describe("createFocusBoundary", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useRealTimers();
+  });
+
+  it("treats multiple portaled surfaces as one owned focus tree", async () => {
+    const root = document.createElement("div");
+    const trigger = button("trigger");
+    const portal = document.createElement("div");
+    const item = button("item");
+    const submenuPortal = document.createElement("div");
+    const submenuItem = button("submenu-item");
+    const outside = button("outside");
+    root.append(trigger);
+    portal.append(item);
+    submenuPortal.append(submenuItem);
+    document.body.append(root, portal, submenuPortal, outside);
+    const onFocusDeparture = vi.fn();
+    const owned = [root, portal, submenuPortal];
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => owned.some((surface) => surface.contains(target)),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: owned,
+    });
+
+    item.focus();
+    submenuItem.focus();
+    trigger.focus();
+    await settleFocus();
+
+    expect(onFocusDeparture).not.toHaveBeenCalled();
+
+    outside.focus();
+    await settleFocus();
+
+    expect(onFocusDeparture).toHaveBeenCalledTimes(1);
+    expect(onFocusDeparture).toHaveBeenCalledWith({
+      activeElement: outside,
+      lastFocusOwner: trigger,
+    });
+    boundary.destroy();
+  });
+
+  it("coalesces duplicate focusout observations into one settled departure", async () => {
+    const outer = document.createElement("div");
+    const inner = document.createElement("div");
+    const owned = button("owned");
+    const outside = button("outside");
+    inner.append(owned);
+    outer.append(inner);
+    document.body.append(outer, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => outer.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [outer, inner],
+    });
+
+    owned.focus();
+    outside.focus();
+    await settleFocus();
+
+    expect(onFocusDeparture).toHaveBeenCalledTimes(1);
+    expect(onFocusDeparture.mock.calls[0]?.[0].activeElement).toBe(outside);
+    boundary.destroy();
+  });
+
+  it("updates observed surfaces without retaining removed surfaces", async () => {
+    const firstSurface = document.createElement("div");
+    const firstOwner = button("first-owner");
+    const secondSurface = document.createElement("div");
+    const secondOwner = button("second-owner");
+    const outside = button("outside");
+    firstSurface.append(firstOwner);
+    secondSurface.append(secondOwner);
+    document.body.append(firstSurface, secondSurface, outside);
+    const onFocusDeparture = vi.fn();
+    let activeSurface = firstSurface;
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => activeSurface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [firstSurface],
+    });
+
+    activeSurface = secondSurface;
+    boundary.setSurfaces([secondSurface]);
+    firstOwner.focus();
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).not.toHaveBeenCalled();
+
+    secondOwner.focus();
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).toHaveBeenCalledTimes(1);
+    boundary.destroy();
+  });
+
+  it("uses an explicit eligible focus owner and drops it after disconnection", async () => {
+    const surface = document.createElement("div");
+    const item = button("item");
+    const outside = button("outside");
+    surface.append(item);
+    document.body.append(surface, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => surface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [surface],
+    });
+
+    item.focus();
+    boundary.setLastFocusOwner(item);
+    item.remove();
+    outside.focus();
+    surface.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    await settleFocus();
+
+    expect(onFocusDeparture).toHaveBeenCalledWith({
+      activeElement: outside,
+      lastFocusOwner: null,
+    });
+    boundary.destroy();
+  });
+
+  it("rejects hidden-input and inert focus owners from restoration state", async () => {
+    const surface = document.createElement("div");
+    const owned = button("owned");
+    const hiddenInput = document.createElement("input");
+    hiddenInput.type = "hidden";
+    const inertParent = document.createElement("div");
+    inertParent.inert = true;
+    const inertControl = button("inert");
+    const outside = button("outside");
+    inertParent.append(inertControl);
+    surface.append(owned, hiddenInput, inertParent);
+    document.body.append(surface, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => surface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [surface],
+    });
+
+    owned.focus();
+    boundary.setLastFocusOwner(hiddenInput);
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).toHaveBeenLastCalledWith({
+      activeElement: outside,
+      lastFocusOwner: null,
+    });
+
+    owned.focus();
+    boundary.setLastFocusOwner(inertControl);
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).toHaveBeenLastCalledWith({
+      activeElement: outside,
+      lastFocusOwner: null,
+    });
+    expect(onFocusDeparture).toHaveBeenCalledTimes(2);
+    boundary.destroy();
+  });
+
+  it("suppresses one departure during an explicit handoff", async () => {
+    const surface = document.createElement("div");
+    const owned = button("owned");
+    const outside = button("outside");
+    surface.append(owned);
+    document.body.append(surface, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => surface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [surface],
+    });
+
+    owned.focus();
+    boundary.suppressNextDeparture();
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).not.toHaveBeenCalled();
+
+    owned.focus();
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).toHaveBeenCalledTimes(1);
+    boundary.destroy();
+  });
+
+  it("expires unused suppression after the pointer default-action window", async () => {
+    vi.useFakeTimers();
+    const surface = document.createElement("div");
+    const owned = button("owned");
+    const outside = button("outside");
+    surface.append(owned);
+    document.body.append(surface, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => surface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [surface],
+    });
+
+    owned.focus();
+    boundary.suppressNextDeparture();
+    await vi.runAllTimersAsync();
+    outside.focus();
+    await settleFocus();
+
+    expect(onFocusDeparture).toHaveBeenCalledTimes(1);
+    boundary.destroy();
+  });
+
+  it("cancels pending checks and active listeners when destroyed", async () => {
+    const surface = document.createElement("div");
+    const owned = button("owned");
+    const outside = button("outside");
+    surface.append(owned);
+    document.body.append(surface, outside);
+    const onFocusDeparture = vi.fn();
+    const boundary = createFocusBoundary({
+      containsTarget: (target) => surface.contains(target),
+      onFocusDeparture,
+      ownerDocument: document,
+      surfaces: [surface],
+    });
+
+    owned.focus();
+    outside.focus();
+    boundary.suppressNextDeparture();
+    boundary.destroy();
+    boundary.destroy();
+    await settleFocus();
+
+    owned.focus();
+    outside.focus();
+    await settleFocus();
+    expect(onFocusDeparture).not.toHaveBeenCalled();
+  });
+});
+
+function button(label: string): HTMLButtonElement {
+  const element = document.createElement("button");
+  element.textContent = label;
+  return element;
+}
+
+function radio(name: string): HTMLInputElement {
+  const element = document.createElement("input");
+  element.type = "radio";
+  element.name = name;
+  return element;
+}
+
+async function settleFocus(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}


### PR DESCRIPTION
## Summary

- Adds a shared focus boundary for portaled Runtime overlays.
- Closes Menu-backed Dropdown, Context Menu, and Navigation Menu surfaces through ordered `focus-out` transactions with accepted Tab handoff.
- Gives Select the same cancellation-safe Tab and settled focus-departure behavior.

## Issue

Closes #159

Issue 159 references the old demo Dropdown implementation. The maintained Styled Dropdown composes `MenuPrimitive`, and this Runtime change resolves the reported keyboard-open and portaled focus-departure failure on that supported surface. The legacy reference remains unchanged.

## Validation

- Public sync policy: 29 tests passed.
- Focused Runtime browser validation: 5 files and 323 tests passed.
- Review correction validation: Menu browser suite passed 90 tests.
- Portable Runtime generator validation: 56 files and 844 tests passed.
- Complete Runtime checkpoint: 61 files and 1,600 tests passed.
- Runtime build and Runtime, Astro, and React typechecks passed.
- Frozen public install, guarded zero-drift check, and diff checks passed.

## Release impact

Two Runtime minor Changesets cover Menu-backed focus handoff and Select `focus-out` behavior. The configured fixed group will align Runtime, Astro, and React at version 1.1.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved keyboard focus handoff when leaving Menus, Dropdowns, Context Menus, and Select controls with Tab or reverse-Tab.
  * Focus now moves to the next available control or returns to the originating trigger when appropriate.
  * Added a public `focus-out` close reason for Menu and Select events.

* **Bug Fixes**
  * Improved focus restoration, cancellation handling, nested menu behavior, portals, and closing animations.
  * Prevented duplicate focus handling after outside-pointer dismissal.

* **Tests**
  * Added comprehensive coverage for focus movement, restoration, cancellation, accessibility states, and component lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->