### PR TITLE
chore(packages): improve npm discovery metadata

### DIFF
--- a/.changeset/clear-package-discovery.md
+++ b/.changeset/clear-package-discovery.md
@@ -1,0 +1,7 @@
+---
+"@starwind-ui/runtime": patch
+"@starwind-ui/astro": patch
+"@starwind-ui/react": patch
+---
+
+Improve npm metadata and clarify package roles in the public READMEs.

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,12 +1,31 @@
 # `@starwind-ui/astro`
 
-Generated Astro primitive adapters for Starwind UI Runtime. They give Astro projects accessible
-behavior and framework-native markup while leaving the component styling and composition in your
-hands.
+This package contains generated Astro Primitive adapters for Starwind UI. It provides the
+lower-level accessible behavior and framework-native markup layer through the shared
+framework-neutral Runtime.
+
+Starwind UI v3 ships 55 source-owned styled components for Astro and React. Developers install
+these styled components as editable application source with the Starwind CLI. The Astro and React
+Primitive adapters share the Runtime, which can also power raw HTML integrations with
+developer-supplied markup.
 
 The package is source-published and supports Astro 5 or newer.
 
-## Install
+## Start with the CLI
+
+For ready-to-use styled components, initialize the project and add components with the Starwind
+CLI:
+
+```bash
+npx starwind@latest init --framework astro
+npx starwind@latest add button
+```
+
+The CLI installs styled components as source in your application.
+
+## Install the Primitive adapters
+
+Install this package directly when you need to build with the lower-level Primitive parts:
 
 ```bash
 npm install @starwind-ui/astro@latest
@@ -40,22 +59,18 @@ import { ThemeInitScript } from "@starwind-ui/astro/theme";
 </head>
 ```
 
-## Start with the CLI
+## Starwind UI ecosystem
 
-For ready-to-use styled Starwind components, initialize the project and add components with the
-Starwind CLI:
+- [Website](https://starwind.dev/)
+- [Installation](https://starwind.dev/docs/getting-started/installation/)
+- [Styled components](https://starwind.dev/docs/components/)
+- [Migration guide](https://starwind.dev/docs/getting-started/migration/)
+- [GitHub repository](https://github.com/starwind-ui/starwind-ui)
+- [Issue tracker](https://github.com/starwind-ui/starwind-ui/issues)
 
-```bash
-npx starwind@latest init --framework astro
-npx starwind@latest add button
-```
-
-The adapter package brings in the compatible Runtime version for normal application use.
-
-## Documentation
-
-Read the [Astro installation guide](https://starwind.dev/docs/getting-started/installation/)
-and [component documentation](https://starwind.dev/docs/components/).
+Coding agents can use [Starwind Skills](https://starwind.dev/docs/getting-started/skills/) and the
+optional [MCP server](https://starwind.dev/docs/getting-started/mcp/) for framework-aware
+installation, documentation, and migration guidance.
 
 ## Contributing
 

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@starwind-ui/astro",
   "version": "1.0.0",
-  "description": "Astro primitive adapters for Starwind UI Runtime components",
+  "description": "Accessible Astro primitives for Starwind UI, powered by the shared framework-neutral Runtime.",
   "license": "MIT",
+  "homepage": "https://starwind.dev/",
   "author": {
     "name": "boston343",
     "url": "https://x.com/boston343builds"
@@ -12,6 +13,24 @@
     "url": "https://github.com/starwind-ui/starwind-ui.git",
     "directory": "packages/astro"
   },
+  "bugs": {
+    "url": "https://github.com/starwind-ui/starwind-ui/issues"
+  },
+  "keywords": [
+    "starwind",
+    "starwind-ui",
+    "ui",
+    "components",
+    "accessibility",
+    "accessible",
+    "astro",
+    "astro-components",
+    "primitives",
+    "runtime",
+    "tailwindcss",
+    "design-system",
+    "typescript"
+  ],
   "type": "module",
   "exports": {
     ".": {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,11 +1,30 @@
 # `@starwind-ui/react`
 
-Generated React primitive adapters for Starwind UI Runtime. They give React projects accessible
-behavior and framework-native components while leaving styling and composition in your hands.
+This package contains generated React Primitive adapters for Starwind UI. It provides the
+lower-level accessible behavior layer through the shared framework-neutral Runtime.
+
+Starwind UI v3 ships 55 source-owned styled components for Astro and React. Developers install
+these styled components as editable application source with the Starwind CLI. The Astro and React
+Primitive adapters share the Runtime, which can also power raw HTML integrations with
+developer-supplied markup.
 
 The package supports React and React DOM 18 or newer.
 
-## Install
+## Start with the CLI
+
+For ready-to-use styled components, initialize the project and add components with the Starwind
+CLI:
+
+```bash
+npx starwind@latest init --framework react
+npx starwind@latest add button
+```
+
+The CLI installs styled components as source in your application.
+
+## Install the Primitive adapters
+
+Install this package directly when you need to build with the lower-level Primitive parts:
 
 ```bash
 npm install @starwind-ui/react@latest
@@ -30,22 +49,18 @@ Use `ThemeInitScript` in a server-rendered document head, or use `getThemeInitSc
 integration, to apply the stored theme before the first paint. The Starwind CLI configures this for
 supported Vite React, Next.js, TanStack Start, and React Router projects.
 
-## Start with the CLI
+## Starwind UI ecosystem
 
-For ready-to-use styled Starwind components, initialize the project and add components with the
-Starwind CLI:
+- [Website](https://starwind.dev/)
+- [Installation](https://starwind.dev/docs/getting-started/installation/)
+- [Styled components](https://starwind.dev/docs/components/)
+- [Migration guide](https://starwind.dev/docs/getting-started/migration/)
+- [GitHub repository](https://github.com/starwind-ui/starwind-ui)
+- [Issue tracker](https://github.com/starwind-ui/starwind-ui/issues)
 
-```bash
-npx starwind@latest init --framework react
-npx starwind@latest add button
-```
-
-The adapter package brings in the compatible Runtime version for normal application use.
-
-## Documentation
-
-Read the [React installation guide](https://starwind.dev/docs/getting-started/installation/)
-and [component documentation](https://starwind.dev/docs/components/).
+Coding agents can use [Starwind Skills](https://starwind.dev/docs/getting-started/skills/) and the
+optional [MCP server](https://starwind.dev/docs/getting-started/mcp/) for framework-aware
+installation, documentation, and migration guidance.
 
 ## Contributing
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@starwind-ui/react",
   "version": "1.0.0",
-  "description": "React primitive adapters for Starwind UI Runtime components",
+  "description": "Accessible React primitives for Starwind UI, powered by the shared framework-neutral Runtime.",
   "license": "MIT",
+  "homepage": "https://starwind.dev/",
   "author": {
     "name": "boston343",
     "url": "https://x.com/boston343builds"
@@ -12,6 +13,24 @@
     "url": "https://github.com/starwind-ui/starwind-ui.git",
     "directory": "packages/react"
   },
+  "bugs": {
+    "url": "https://github.com/starwind-ui/starwind-ui/issues"
+  },
+  "keywords": [
+    "starwind",
+    "starwind-ui",
+    "ui",
+    "components",
+    "accessibility",
+    "accessible",
+    "react",
+    "react-components",
+    "primitives",
+    "runtime",
+    "tailwindcss",
+    "design-system",
+    "typescript"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -4,10 +4,23 @@ Framework-neutral DOM controllers for Starwind UI behavior. Runtime owns state, 
 forms, overlays, timers, and cleanup while framework adapters render normal HTML and connect it to
 that behavior.
 
+Starwind UI v3 ships 55 source-owned styled components for Astro and React. Its lower-level Astro
+and React Primitive adapters share this Runtime. The Runtime can also power raw HTML integrations
+when the developer supplies the markup.
+
 ## For application projects
 
-Install a first-party adapter for Astro or React. The adapter brings in the compatible Runtime
-version:
+Most Astro and React application developers should start with the CLI to install styled components
+as editable source:
+
+```bash
+npx starwind@latest init --framework astro
+# or
+npx starwind@latest init --framework react
+```
+
+Install a first-party Primitive adapter when you need the lower-level component layer. Each adapter
+brings in the compatible Runtime version:
 
 ```bash
 npm install @starwind-ui/astro@latest
@@ -53,17 +66,24 @@ cleanup.destroy();
 - Component subpath exports such as `select`, `dialog`, `form`, and `theme`.
 - A foundation shared by the generated Astro and React adapters.
 
-Runtime does not provide framework markup, Tailwind styles, or custom elements. Use
-`@starwind-ui/astro` or `@starwind-ui/react` when you need framework components.
+Use `@starwind-ui/astro` or `@starwind-ui/react` when you need framework Primitive components.
 
 ## Compatibility
 
 The package requires Node 22.12 or newer.
 
-## Documentation
+## Starwind UI ecosystem
 
-Read the [installation guide](https://starwind.dev/docs/getting-started/installation/) and
-[component documentation](https://starwind.dev/docs/components/).
+- [Website](https://starwind.dev/)
+- [Installation](https://starwind.dev/docs/getting-started/installation/)
+- [Styled components](https://starwind.dev/docs/components/)
+- [Migration guide](https://starwind.dev/docs/getting-started/migration/)
+- [GitHub repository](https://github.com/starwind-ui/starwind-ui)
+- [Issue tracker](https://github.com/starwind-ui/starwind-ui/issues)
+
+Coding agents can use [Starwind Skills](https://starwind.dev/docs/getting-started/skills/) and the
+optional [MCP server](https://starwind.dev/docs/getting-started/mcp/) for framework-aware
+installation, documentation, and migration guidance.
 
 ## Contributing
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@starwind-ui/runtime",
   "version": "1.0.0",
-  "description": "Framework-agnostic Runtime controllers for Starwind UI primitives",
+  "description": "Framework-neutral accessible DOM behavior for Starwind UI components across Astro, React, and plain HTML.",
   "license": "MIT",
+  "homepage": "https://starwind.dev/",
   "author": {
     "name": "boston343",
     "url": "https://x.com/boston343builds"
@@ -12,6 +13,24 @@
     "url": "https://github.com/starwind-ui/starwind-ui.git",
     "directory": "packages/runtime"
   },
+  "bugs": {
+    "url": "https://github.com/starwind-ui/starwind-ui/issues"
+  },
+  "keywords": [
+    "starwind",
+    "starwind-ui",
+    "ui",
+    "components",
+    "accessibility",
+    "accessible",
+    "runtime",
+    "dom",
+    "headless-ui",
+    "tailwindcss",
+    "astro",
+    "react",
+    "typescript"
+  ],
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Changes

- add searchable npm descriptions, keywords, homepage, and issue metadata for Runtime, Astro, and React
- clarify the styled component, Primitive adapter, and Runtime package roles in public READMEs
- add verified ecosystem documentation links
- add a patch Changeset for the three fixed-group packages

## Validation

- `pnpm exec vitest run scripts/tests/public-sync.test.mjs scripts/tests/runtime-release-skills.test.ts`
- `pnpm release:status`
- package format checks for Runtime, Astro, and React
- package typechecks for Runtime, Astro, and React
- `pnpm publish:release:dry-run`
- direct packed-artifact inspection
- guarded public sync dry-run, apply, and zero-drift check
- public `pnpm install --frozen-lockfile`
- `git diff --check`

## Release impact

Patch intent for `@starwind-ui/runtime`, `@starwind-ui/astro`, and `@starwind-ui/react`. Existing pending minor Changesets make the current fixed-group release plan `1.1.0`. This PR does not version or publish packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified installation and setup guidance for Astro, React, and Runtime packages.
  * Added guidance for generated Primitive adapters, styled components, shared runtime behavior, and CLI workflows.
  * Expanded links to ecosystem resources, coding-agent tools, Skills, and the optional MCP server.

* **Chores**
  * Improved package descriptions, discoverability keywords, homepage links, and issue-tracker metadata.
  * Added patch release declarations for the Astro, React, and Runtime packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->