### PR TITLE
test(tooltip): align smoke with positioner override

### DIFF
--- a/scripts/portable-runtime/tests/smoke/shared/tooltip.mjs
+++ b/scripts/portable-runtime/tests/smoke/shared/tooltip.mjs
@@ -348,7 +348,6 @@ function assertTooltipBaseState(state) {
     state.styleLeft === "" ||
     state.styleTop === "" ||
     state.rootContains !== false ||
-    state.parentClassName?.includes("isolate") !== true ||
     state.parentClassName?.includes("z-50") !== true ||
     state.dataSlot !== "tooltip-content"
   ) {


### PR DESCRIPTION
## Summary
- remove the stale Tooltip smoke requirement for the intentionally removed isolation utility
- preserve fixed Positioner geometry and the overridable default z-50 stack level

## Verification
- 85 focused portable-runtime tests passed
- layered docs metadata check passed
- guarded public sync contains one modified file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tooltip validation to allow positioner wrappers without the `isolate` class.
  * Existing tooltip placement and structural checks remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->