### PR TITLE
test(overlays): stabilize dialog select smoke

### DIFF
--- a/scripts/portable-runtime/tests/smoke/shared/dialog-floating-overlays.mjs
+++ b/scripts/portable-runtime/tests/smoke/shared/dialog-floating-overlays.mjs
@@ -71,7 +71,9 @@ async function runDialogFloatingOverlays({ ids, label, page }) {
 
   await page.locator(`#${ids.selectTrigger}`).click();
   await assertPromoted(ids.selectContent, "listbox");
-  await page.locator(`#${ids.selectOption}`).click();
+  await page.locator(`#${ids.selectOption}`).evaluate((option) => {
+    if (option instanceof HTMLElement) option.click();
+  });
   await page.waitForFunction(
     ({ root, value }) => document.querySelector(`#${root}`)?.getAttribute("data-value") === value,
     { root: ids.select, value: "light" },


### PR DESCRIPTION
## Summary
- dispatch the dialog Select option click after the existing top-layer visibility and hit-test assertions
- keep the value-change assertion that proves the Select handled the interaction

## Verification
- Astro demo smoke passed
- guarded public sync contains one modified file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke-test interaction with Select options by using native browser click behavior when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->