### PR TITLE
chore(release): rebaseline stable package sizes

### DIFF
--- a/docs/portable-runtime/package-size-comparison.md
+++ b/docs/portable-runtime/package-size-comparison.md
@@ -1,6 +1,6 @@
 # Package Size Comparison
 
-Generated: 2026-07-23
+Generated: 2026-08-15
 
 ## Method
 
@@ -18,94 +18,88 @@ Regenerate with:
 pnpm runtime:size
 ```
 
-
 ## At A Glance
 
 Use this table for the headline ordering. `Minified + gzip` is the closest column to the advertised browser download size.
 
-| Rank | Scenario | Minified + gzip | Minified | Meaning |
-| ---: | --- | ---: | ---: | --- |
-| 1 | `Zag React adapter + all documented component machines` | 238.5 KiB | 839.0 KiB | React adapter plus every package from Zag's documented component list, bundled once. |
-| 2 | `@starwind-ui/react + runtime` | 166.8 KiB | 673.0 KiB | All Starwind React public root exports with the runtime bundled. |
-| 3 | `@base-ui/react` | 160.1 KiB | 488.6 KiB | All Base UI React public root exports. |
-| 4 | `@starwind-ui/runtime` | 129.4 KiB | 538.7 KiB | Runtime package alone, without the React adapter. |
-| 5 | `@starwind-ui/react (adapter only)` | 34.7 KiB | 141.4 KiB | React adapter overhead with runtime externalized. |
-| 6 | `@zag-js/react` | 4.0 KiB | 9.9 KiB | Zag React framework adapter only, without any machines. |
-
+| Rank | Scenario                                                | Minified + gzip |  Minified | Meaning                                                                              |
+| ---: | ------------------------------------------------------- | --------------: | --------: | ------------------------------------------------------------------------------------ |
+|    1 | `Zag React adapter + all documented component machines` |       240.0 KiB | 843.1 KiB | React adapter plus every package from Zag's documented component list, bundled once. |
+|    2 | `@starwind-ui/react + runtime`                          |       175.1 KiB | 705.7 KiB | All Starwind React public root exports with the runtime bundled.                     |
+|    3 | `@base-ui/react`                                        |       156.2 KiB | 468.1 KiB | All Base UI React public root exports.                                               |
+|    4 | `@starwind-ui/runtime`                                  |       136.7 KiB | 568.1 KiB | Runtime package alone, without the React adapter.                                    |
+|    5 | `@starwind-ui/react (adapter only)`                     |        35.6 KiB | 144.7 KiB | React adapter overhead with runtime externalized.                                    |
+|    6 | `@zag-js/react`                                         |         4.1 KiB |  10.3 KiB | Zag React framework adapter only, without any machines.                              |
 
 ## Starwind-Matched Support
 
 These rows compare only the Starwind React components that have a comparable primitive in the other package. This is the better table for apples-to-apples sizing.
 
-| Comparison set | Starwind components | Starwind min+gzip | Zag React min+gzip | Base UI min+gzip | Notes |
-| --- | ---: | ---: | ---: | ---: | --- |
-| All-three overlap | 26 | 107.0 KiB | 97.5 KiB | 139.8 KiB | Only Starwind components with both a Zag and Base UI equivalent. |
-| Starwind/Zag overlap | 28 | 118.8 KiB | 109.7 KiB | N/A | Only Starwind components with a Zag equivalent. |
-| Starwind/Base UI overlap | 29 | 114.7 KiB | N/A | 143.4 KiB | Only Starwind components with a Base UI equivalent. |
-
+| Comparison set           | Starwind components | Starwind min+gzip | Zag React min+gzip | Base UI min+gzip | Notes                                                            |
+| ------------------------ | ------------------: | ----------------: | -----------------: | ---------------: | ---------------------------------------------------------------- |
+| All-three overlap        |                  26 |         114.4 KiB |           98.0 KiB |        136.5 KiB | Only Starwind components with both a Zag and Base UI equivalent. |
+| Starwind/Zag overlap     |                  28 |         126.3 KiB |          110.1 KiB |              N/A | Only Starwind components with a Zag equivalent.                  |
+| Starwind/Base UI overlap |                  29 |         122.3 KiB |                N/A |        140.1 KiB | Only Starwind components with a Base UI equivalent.              |
 
 ## Isolated vs Combined Support Costs
 
 This table explains why isolated component rows can look very different from matched-support aggregate rows. `Isolated per-component sum` adds each one-component measurement together, so shared runtime, adapter, and infrastructure code is counted repeatedly. `One combined bundle` imports the same support set once and lets esbuild dedupe shared code, which is closer to a real app using many primitives.
 
-| Comparison set | Library | Components | Isolated per-component sum | One combined bundle | Shared-code savings | Combined avg/component |
-| --- | --- | ---: | ---: | ---: | ---: | ---: |
-| All-three overlap | Starwind | 26 | 251.8 KiB | 107.0 KiB | 144.8 KiB (57.5%) | 4.1 KiB |
-| All-three overlap | Zag React | 26 | 371.8 KiB | 97.5 KiB | 274.3 KiB (73.8%) | 3.8 KiB |
-| All-three overlap | Base UI | 26 | 517.5 KiB | 139.8 KiB | 377.7 KiB (73.0%) | 5.4 KiB |
-| Starwind/Zag overlap | Starwind | 28 | 266.8 KiB | 118.8 KiB | 148.0 KiB (55.5%) | 4.2 KiB |
-| Starwind/Zag overlap | Zag React | 28 | 395.9 KiB | 109.7 KiB | 286.3 KiB (72.3%) | 3.9 KiB |
-| Starwind/Base UI overlap | Starwind | 29 | 264.8 KiB | 114.7 KiB | 150.1 KiB (56.7%) | 4.0 KiB |
-| Starwind/Base UI overlap | Base UI | 29 | 538.8 KiB | 143.4 KiB | 395.4 KiB (73.4%) | 4.9 KiB |
-
+| Comparison set           | Library   | Components | Isolated per-component sum | One combined bundle | Shared-code savings | Combined avg/component |
+| ------------------------ | --------- | ---------: | -------------------------: | ------------------: | ------------------: | ---------------------: |
+| All-three overlap        | Starwind  |         26 |                  266.0 KiB |           114.4 KiB |   151.6 KiB (57.0%) |                4.4 KiB |
+| All-three overlap        | Zag React |         26 |                  377.0 KiB |            98.0 KiB |   279.0 KiB (74.0%) |                3.8 KiB |
+| All-three overlap        | Base UI   |         26 |                  515.7 KiB |           136.5 KiB |   379.2 KiB (73.5%) |                5.3 KiB |
+| Starwind/Zag overlap     | Starwind  |         28 |                  281.1 KiB |           126.3 KiB |   154.8 KiB (55.1%) |                4.5 KiB |
+| Starwind/Zag overlap     | Zag React |         28 |                  401.3 KiB |           110.1 KiB |   291.3 KiB (72.6%) |                3.9 KiB |
+| Starwind/Base UI overlap | Starwind  |         29 |                  279.0 KiB |           122.3 KiB |   156.7 KiB (56.2%) |                4.2 KiB |
+| Starwind/Base UI overlap | Base UI   |         29 |                  536.9 KiB |           140.1 KiB |   396.8 KiB (73.9%) |                4.8 KiB |
 
 ## Starwind Component Matches
 
-| Starwind component | Zag equivalent | Base UI equivalent | Starwind min+gzip | Zag min+gzip | Base UI min+gzip | Notes |
-| --- | --- | --- | ---: | ---: | ---: | --- |
-| `accordion` | `@zag-js/accordion` | `@base-ui/react/accordion` | 3.9 KiB | 6.5 KiB | 8.9 KiB |  |
-| `alert-dialog` | `@zag-js/dialog` | `@base-ui/react/alert-dialog` | 7.7 KiB | 16.1 KiB | 22.4 KiB | Zag reuses its dialog machine for alert-dialog behavior. |
-| `avatar` | `@zag-js/avatar` | `@base-ui/react/avatar` | 2.2 KiB | 5.6 KiB | 4.0 KiB |  |
-| `button` | N/A | `@base-ui/react/button` | 1.3 KiB | N/A | 3.0 KiB | Base UI has a button primitive; Zag has no button machine. |
-| `carousel` | `@zag-js/carousel` | N/A | 9.4 KiB | 12.6 KiB | N/A | No Base UI carousel export. |
-| `checkbox` | `@zag-js/checkbox` | `@base-ui/react/checkbox` | 7.1 KiB | 8.2 KiB | 7.9 KiB |  |
-| `checkbox-group` | `@zag-js/checkbox` | `@base-ui/react/checkbox-group` | 7.9 KiB | 8.2 KiB | 4.0 KiB | Starwind and Base UI expose a group wrapper; Zag uses the checkbox machine. |
-| `collapsible` | `@zag-js/collapsible` | `@base-ui/react/collapsible` | 4.2 KiB | 7.5 KiB | 7.1 KiB |  |
-| `combobox` | `@zag-js/combobox` | `@base-ui/react/combobox` | 25.3 KiB | 29.3 KiB | 49.0 KiB |  |
-| `context-menu` | `@zag-js/menu` | `@base-ui/react/context-menu` | 21.6 KiB | 28.3 KiB | 50.7 KiB | Zag models context-menu through the menu package. |
-| `dialog` | `@zag-js/dialog` | `@base-ui/react/dialog` | 7.2 KiB | 16.1 KiB | 22.5 KiB |  |
-| `drawer` | `@zag-js/drawer` | `@base-ui/react/drawer` | 7.7 KiB | 25.5 KiB | 37.2 KiB |  |
-| `dropzone` | `@zag-js/file-upload` | N/A | 5.7 KiB | 11.5 KiB | N/A | Maps to Zag file-upload; no Base UI file upload/dropzone export. |
-| `field` | N/A | `@base-ui/react/field` | 9.6 KiB | N/A | 9.2 KiB | Base UI has field primitives; Zag has no field machine. |
-| `input` | N/A | `@base-ui/react/input` | 2.1 KiB | N/A | 9.2 KiB | Base UI has input primitives; Zag has no input machine. |
-| `input-otp` | `@zag-js/pin-input` | `@base-ui/react/otp-field` | 6.9 KiB | 9.0 KiB | 8.5 KiB | Equivalent naming differs: Zag pin-input, Base UI otp-field. |
-| `menu` | `@zag-js/menu` | `@base-ui/react/menu` | 21.1 KiB | 28.3 KiB | 50.0 KiB |  |
-| `popover` | `@zag-js/popover` | `@base-ui/react/popover` | 16.9 KiB | 26.4 KiB | 39.8 KiB |  |
-| `preview-card` | `@zag-js/hover-card` | `@base-ui/react/preview-card` | 15.4 KiB | 20.2 KiB | 32.3 KiB | Equivalent naming differs: Zag hover-card. |
-| `progress` | `@zag-js/progress` | `@base-ui/react/progress` | 2.8 KiB | 6.4 KiB | 3.3 KiB |  |
-| `radio` | `@zag-js/radio-group` | `@base-ui/react/radio` | 6.3 KiB | 8.9 KiB | 7.8 KiB | Zag's radio support is represented through radio-group. |
-| `radio-group` | `@zag-js/radio-group` | `@base-ui/react/radio-group` | 8.6 KiB | 8.9 KiB | 7.0 KiB |  |
-| `scroll-area` | `@zag-js/scroll-area` | `@base-ui/react/scroll-area` | 4.6 KiB | 10.4 KiB | 8.0 KiB |  |
-| `select` | `@zag-js/select` | `@base-ui/react/select` | 25.4 KiB | 28.6 KiB | 43.9 KiB |  |
-| `slider` | `@zag-js/slider` | `@base-ui/react/slider` | 8.9 KiB | 12.7 KiB | 14.6 KiB |  |
-| `switch` | `@zag-js/switch` | `@base-ui/react/switch` | 6.2 KiB | 8.2 KiB | 6.1 KiB |  |
-| `tabs` | `@zag-js/tabs` | `@base-ui/react/tabs` | 4.8 KiB | 9.4 KiB | 12.8 KiB |  |
-| `toast` | `@zag-js/toast` | `@base-ui/react/toast` | 5.6 KiB | 12.2 KiB | 26.1 KiB |  |
-| `toggle` | `@zag-js/toggle` | `@base-ui/react/toggle` | 2.9 KiB | 4.9 KiB | 4.8 KiB |  |
-| `toggle-group` | `@zag-js/toggle-group` | `@base-ui/react/toggle-group` | 4.7 KiB | 7.4 KiB | 5.7 KiB |  |
-| `tooltip` | `@zag-js/tooltip` | `@base-ui/react/tooltip` | 15.8 KiB | 18.5 KiB | 33.4 KiB |  |
-
+| Starwind component | Zag equivalent         | Base UI equivalent              | Starwind min+gzip | Zag min+gzip | Base UI min+gzip | Notes                                                                       |
+| ------------------ | ---------------------- | ------------------------------- | ----------------: | -----------: | ---------------: | --------------------------------------------------------------------------- |
+| `accordion`        | `@zag-js/accordion`    | `@base-ui/react/accordion`      |           4.1 KiB |      6.6 KiB |          9.1 KiB |                                                                             |
+| `alert-dialog`     | `@zag-js/dialog`       | `@base-ui/react/alert-dialog`   |           7.9 KiB |     16.6 KiB |         22.5 KiB | Zag reuses its dialog machine for alert-dialog behavior.                    |
+| `avatar`           | `@zag-js/avatar`       | `@base-ui/react/avatar`         |           2.2 KiB |      5.7 KiB |          3.9 KiB |                                                                             |
+| `button`           | N/A                    | `@base-ui/react/button`         |           1.3 KiB |          N/A |          3.1 KiB | Base UI has a button primitive; Zag has no button machine.                  |
+| `carousel`         | `@zag-js/carousel`     | N/A                             |           9.4 KiB |     12.7 KiB |              N/A | No Base UI carousel export.                                                 |
+| `checkbox`         | `@zag-js/checkbox`     | `@base-ui/react/checkbox`       |           7.6 KiB |      8.3 KiB |          7.7 KiB |                                                                             |
+| `checkbox-group`   | `@zag-js/checkbox`     | `@base-ui/react/checkbox-group` |           8.7 KiB |      8.3 KiB |          3.9 KiB | Starwind and Base UI expose a group wrapper; Zag uses the checkbox machine. |
+| `collapsible`      | `@zag-js/collapsible`  | `@base-ui/react/collapsible`    |           4.4 KiB |      7.6 KiB |          7.2 KiB |                                                                             |
+| `combobox`         | `@zag-js/combobox`     | `@base-ui/react/combobox`       |          25.8 KiB |     29.5 KiB |         49.0 KiB |                                                                             |
+| `context-menu`     | `@zag-js/menu`         | `@base-ui/react/context-menu`   |          23.4 KiB |     28.5 KiB |         51.2 KiB | Zag models context-menu through the menu package.                           |
+| `dialog`           | `@zag-js/dialog`       | `@base-ui/react/dialog`         |           7.4 KiB |     16.6 KiB |         22.6 KiB |                                                                             |
+| `drawer`           | `@zag-js/drawer`       | `@base-ui/react/drawer`         |           7.9 KiB |     26.0 KiB |         36.9 KiB |                                                                             |
+| `dropzone`         | `@zag-js/file-upload`  | N/A                             |           5.7 KiB |     11.6 KiB |              N/A | Maps to Zag file-upload; no Base UI file upload/dropzone export.            |
+| `field`            | N/A                    | `@base-ui/react/field`          |           9.6 KiB |          N/A |          9.0 KiB | Base UI has field primitives; Zag has no field machine.                     |
+| `input`            | N/A                    | `@base-ui/react/input`          |           2.1 KiB |          N/A |          9.0 KiB | Base UI has input primitives; Zag has no input machine.                     |
+| `input-otp`        | `@zag-js/pin-input`    | `@base-ui/react/otp-field`      |           7.2 KiB |      9.2 KiB |          8.6 KiB | Equivalent naming differs: Zag pin-input, Base UI otp-field.                |
+| `menu`             | `@zag-js/menu`         | `@base-ui/react/menu`           |          22.8 KiB |     28.5 KiB |         50.5 KiB |                                                                             |
+| `popover`          | `@zag-js/popover`      | `@base-ui/react/popover`        |          17.3 KiB |     26.9 KiB |         39.8 KiB |                                                                             |
+| `preview-card`     | `@zag-js/hover-card`   | `@base-ui/react/preview-card`   |          15.7 KiB |     20.4 KiB |         32.2 KiB | Equivalent naming differs: Zag hover-card.                                  |
+| `progress`         | `@zag-js/progress`     | `@base-ui/react/progress`       |           2.8 KiB |      6.5 KiB |          3.2 KiB |                                                                             |
+| `radio`            | `@zag-js/radio-group`  | `@base-ui/react/radio`          |           7.2 KiB |      9.1 KiB |          7.5 KiB | Zag's radio support is represented through radio-group.                     |
+| `radio-group`      | `@zag-js/radio-group`  | `@base-ui/react/radio-group`    |          10.5 KiB |      9.1 KiB |          7.2 KiB |                                                                             |
+| `scroll-area`      | `@zag-js/scroll-area`  | `@base-ui/react/scroll-area`    |           4.6 KiB |     10.6 KiB |          7.6 KiB |                                                                             |
+| `select`           | `@zag-js/select`       | `@base-ui/react/select`         |          27.3 KiB |     28.8 KiB |         43.4 KiB |                                                                             |
+| `slider`           | `@zag-js/slider`       | `@base-ui/react/slider`         |           9.5 KiB |     12.8 KiB |         14.0 KiB |                                                                             |
+| `switch`           | `@zag-js/switch`       | `@base-ui/react/switch`         |           6.6 KiB |      8.3 KiB |          6.0 KiB |                                                                             |
+| `tabs`             | `@zag-js/tabs`         | `@base-ui/react/tabs`           |           5.0 KiB |      9.6 KiB |         12.3 KiB |                                                                             |
+| `toast`            | `@zag-js/toast`        | `@base-ui/react/toast`          |           5.8 KiB |     12.3 KiB |         25.6 KiB |                                                                             |
+| `toggle`           | `@zag-js/toggle`       | `@base-ui/react/toggle`         |           3.1 KiB |      5.0 KiB |          4.8 KiB |                                                                             |
+| `toggle-group`     | `@zag-js/toggle-group` | `@base-ui/react/toggle-group`   |           5.1 KiB |      7.5 KiB |          5.8 KiB |                                                                             |
+| `tooltip`          | `@zag-js/tooltip`      | `@base-ui/react/tooltip`        |          16.1 KiB |     18.7 KiB |         33.2 KiB |                                                                             |
 
 ## Starwind Published Source Payloads
 
 These rows measure the published package's own runtime-bearing source files after minification. They are useful for `@starwind-ui/astro`, whose package ships `.astro` source files rather than a JS bundle entry.
 
-| Package | Version | Minified source payload | Minified + gzip | npm tarball gzip | npm unpacked | Notes |
-| --- | ---: | ---: | ---: | ---: | ---: | --- |
-| `@starwind-ui/astro` | 0.1.0-beta.3 | 195.7 KiB | 20.7 KiB | 31.7 KiB | 235.2 KiB | Source-published Astro package; measured published .astro/.ts source payload, not compiled Astro output. |
-| `@starwind-ui/runtime` | 0.1.0-beta.3 | 535.9 KiB | 124.3 KiB | 185.8 KiB | 1022.0 KiB |  |
-| `@starwind-ui/react` | 0.1.0-beta.3 | 181.7 KiB | 42.8 KiB | 70.7 KiB | 542.7 KiB |  |
-
+| Package                | Version | Minified source payload | Minified + gzip | npm tarball gzip | npm unpacked | Notes                                                                                                    |
+| ---------------------- | ------: | ----------------------: | --------------: | ---------------: | -----------: | -------------------------------------------------------------------------------------------------------- |
+| `@starwind-ui/astro`   |   1.1.0 |               195.7 KiB |        20.7 KiB |         32.1 KiB |    236.4 KiB | Source-published Astro package; measured published .astro/.ts source payload, not compiled Astro output. |
+| `@starwind-ui/runtime` |   1.1.0 |               566.9 KiB |       132.0 KiB |        196.5 KiB |   1078.1 KiB |                                                                                                          |
+| `@starwind-ui/react`   |   1.1.0 |               185.7 KiB |        43.8 KiB |         70.8 KiB |    553.6 KiB |                                                                                                          |
 
 ## Reading The Numbers
 

--- a/scripts/portable-runtime/measure-package-sizes.mjs
+++ b/scripts/portable-runtime/measure-package-sizes.mjs
@@ -6,7 +6,10 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { gzipSync } from "node:zlib";
 
-import { evaluatePackageSizeBudgets } from "./package-size-budget-checks.mjs";
+import {
+  aggregateBaselineProvenance,
+  evaluatePackageSizeBudgets,
+} from "./package-size-budget-checks.mjs";
 import {
   buildRawGzipDiagnostics,
   formatRawGzipDiagnosticsMarkdown,
@@ -1125,6 +1128,7 @@ export function formatDiagnosticPackageSizeReport({
     "## Budget Checks",
     "",
     "`pnpm runtime:size` treats aggregate package and support-set sizes as regression guards: they fail only after more than 10% or 15 KiB of gzip growth from the committed baseline, whichever comes first. Targeted cold imports retain strict absolute budgets. Competitor comparisons are informational.",
+    `The aggregate baselines were refreshed from public commit \`${aggregateBaselineProvenance.publicCommit}\` on ${aggregateBaselineProvenance.date} for Runtime ${aggregateBaselineProvenance.release.runtime}, Astro ${aggregateBaselineProvenance.release.astro}, React ${aggregateBaselineProvenance.release.react}, and CLI ${aggregateBaselineProvenance.release.cli}. Targeted cold-import budgets were not rebaselined.`,
     "",
     ...formatColorPickerRebaselineMarkdown(),
     "",

--- a/scripts/portable-runtime/package-size-budget-checks.mjs
+++ b/scripts/portable-runtime/package-size-budget-checks.mjs
@@ -3,24 +3,35 @@ const aggregateGrowthPolicy = Object.freeze({
   maxGrowthPercent: 10,
 });
 
+export const aggregateBaselineProvenance = Object.freeze({
+  date: "2026-08-15",
+  publicCommit: "6d497055479ca56bad8463f3fc38bedc231d0174",
+  release: Object.freeze({
+    astro: "1.1.0",
+    cli: "3.1.0",
+    react: "1.1.0",
+    runtime: "1.1.0",
+  }),
+});
+
 const headlinePackageBudgets = [
   createAggregateBudget(
     {
-      baselineGzipBytes: 126_295,
+      baselineGzipBytes: 139_964,
       label: "@starwind-ui/runtime",
     },
     "maxGzipBytes",
   ),
   createAggregateBudget(
     {
-      baselineGzipBytes: 35_194,
+      baselineGzipBytes: 36_486,
       label: "@starwind-ui/react (adapter only)",
     },
     "maxGzipBytes",
   ),
   createAggregateBudget(
     {
-      baselineGzipBytes: 164_250,
+      baselineGzipBytes: 179_332,
       label: "@starwind-ui/react + runtime",
     },
     "maxGzipBytes",
@@ -30,7 +41,7 @@ const headlinePackageBudgets = [
 const matchedSupportBudgets = [
   createAggregateBudget(
     {
-      baselineGzipBytes: 107_231,
+      baselineGzipBytes: 117_191,
       comparisonSet: "all-three-overlap",
       compareProviders: ["zag", "base"],
       label: "All-three overlap",
@@ -39,7 +50,7 @@ const matchedSupportBudgets = [
   ),
   createAggregateBudget(
     {
-      baselineGzipBytes: 118_786,
+      baselineGzipBytes: 129_328,
       comparisonSet: "starwind-zag-overlap",
       compareProviders: ["zag"],
       label: "Starwind/Zag overlap",
@@ -48,9 +59,7 @@ const matchedSupportBudgets = [
   ),
   createAggregateBudget(
     {
-      // This set predated exact raw-gzip diagnostics. Its former committed ceiling
-      // is the retained baseline until the next explicit size-report refresh.
-      baselineGzipBytes: 115 * 1024,
+      baselineGzipBytes: 125_239,
       comparisonSet: "starwind-base-overlap",
       compareProviders: ["base"],
       label: "Starwind/Base UI overlap",

--- a/scripts/portable-runtime/tests/package-size-budget-checks.test.mjs
+++ b/scripts/portable-runtime/tests/package-size-budget-checks.test.mjs
@@ -1,8 +1,26 @@
 import { describe, expect, it } from "vitest";
 
-import { evaluatePackageSizeBudgets } from "../package-size-budget-checks.mjs";
+import {
+  aggregateBaselineProvenance,
+  evaluatePackageSizeBudgets,
+} from "../package-size-budget-checks.mjs";
 
 describe("package size budget checks", () => {
+  it("records the stable release candidate used for the aggregate rebaseline", () => {
+    expect(aggregateBaselineProvenance).toEqual({
+      date: "2026-08-15",
+      publicCommit: "6d497055479ca56bad8463f3fc38bedc231d0174",
+      release: {
+        astro: "1.1.0",
+        cli: "3.1.0",
+        react: "1.1.0",
+        runtime: "1.1.0",
+      },
+    });
+    expect(Object.isFrozen(aggregateBaselineProvenance)).toBe(true);
+    expect(Object.isFrozen(aggregateBaselineProvenance.release)).toBe(true);
+  });
+
   it("allows normal aggregate feature growth while reporting the real Zag advisory", () => {
     const result = evaluatePackageSizeBudgets({
       bundleResults: passingBundleResults(),
@@ -17,19 +35,19 @@ describe("package size budget checks", () => {
     expect(result.headlineChecks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          baselineGzipBytes: 126_295,
+          baselineGzipBytes: 139_964,
           label: "@starwind-ui/runtime",
-          maxGzipBytes: 138_924,
+          maxGzipBytes: 153_960,
         }),
         expect.objectContaining({
-          baselineGzipBytes: 35_194,
+          baselineGzipBytes: 36_486,
           label: "@starwind-ui/react (adapter only)",
-          maxGzipBytes: 38_713,
+          maxGzipBytes: 40_134,
         }),
         expect.objectContaining({
-          baselineGzipBytes: 164_250,
+          baselineGzipBytes: 179_332,
           label: "@starwind-ui/react + runtime",
-          maxGzipBytes: 179_610,
+          maxGzipBytes: 194_692,
         }),
       ]),
     );
@@ -56,8 +74,8 @@ describe("package size budget checks", () => {
       ),
     ).toEqual(
       expect.objectContaining({
-        baselineGzipBytes: 118_786,
-        maxStarwindGzipBytes: 130_664,
+        baselineGzipBytes: 129_328,
+        maxStarwindGzipBytes: 142_260,
         comparatorGzipBytes: 112_282,
         comparisonStatus: "Above comparator",
         starwindGzipBytes: 121_678,
@@ -128,18 +146,18 @@ describe("package size budget checks", () => {
   it("passes each aggregate headline guard exactly and fails one byte above it", () => {
     const atCeiling = evaluatePackageSizeBudgets({
       bundleResults: [
-        { label: "@starwind-ui/runtime", gzipBytes: 138_924 },
-        { label: "@starwind-ui/react (adapter only)", gzipBytes: 38_713 },
-        { label: "@starwind-ui/react + runtime", gzipBytes: 179_610 },
+        { label: "@starwind-ui/runtime", gzipBytes: 153_960 },
+        { label: "@starwind-ui/react (adapter only)", gzipBytes: 40_134 },
+        { label: "@starwind-ui/react + runtime", gzipBytes: 194_692 },
         { label: "@starwind-ui/runtime/color-picker", gzipBytes: 13 * 1024 },
       ],
       supportResults: passingSupportResults(),
     });
     const oneByteAbove = evaluatePackageSizeBudgets({
       bundleResults: [
-        { label: "@starwind-ui/runtime", gzipBytes: 138_925 },
-        { label: "@starwind-ui/react (adapter only)", gzipBytes: 38_714 },
-        { label: "@starwind-ui/react + runtime", gzipBytes: 179_611 },
+        { label: "@starwind-ui/runtime", gzipBytes: 153_961 },
+        { label: "@starwind-ui/react (adapter only)", gzipBytes: 40_135 },
+        { label: "@starwind-ui/react + runtime", gzipBytes: 194_693 },
         { label: "@starwind-ui/runtime/color-picker", gzipBytes: 13 * 1024 },
       ],
       supportResults: passingSupportResults(),
@@ -161,7 +179,7 @@ describe("package size budget checks", () => {
     const result = evaluatePackageSizeBudgets({
       bundleResults: passingBundleResults(),
       supportResults: [
-        supportRow("all-three-overlap", "starwind", 117_955),
+        supportRow("all-three-overlap", "starwind", 128_911),
         supportRow("all-three-overlap", "zag", 120 * 1024),
         supportRow("all-three-overlap", "base", 140 * 1024),
         supportRow("starwind-zag-overlap", "starwind", 106 * 1024),
@@ -190,7 +208,7 @@ describe("package size budget checks", () => {
       supportRow("all-three-overlap", "starwind", 94 * 1024),
       supportRow("all-three-overlap", "zag", 97 * 1024),
       supportRow("all-three-overlap", "base", 139 * 1024),
-      supportRow("starwind-zag-overlap", "starwind", 130_664),
+      supportRow("starwind-zag-overlap", "starwind", 142_260),
       supportRow("starwind-zag-overlap", "zag", 112_282),
       supportRow("starwind-base-overlap", "starwind", 102 * 1024),
       supportRow("starwind-base-overlap", "base", 143 * 1024),
@@ -204,7 +222,7 @@ describe("package size budget checks", () => {
       bundleResults: passingBundleResults(),
       supportResults: supportResults.map((row) =>
         row.comparisonSet === "starwind-zag-overlap" && row.provider === "starwind"
-          ? { ...row, gzipBytes: 130_665 }
+          ? { ...row, gzipBytes: 142_261 }
           : row,
       ),
     });
@@ -213,7 +231,7 @@ describe("package size budget checks", () => {
       atCeiling.matchedSupportChecks.find(
         (check) => check.label === "Starwind/Zag overlap vs Zag React",
       ),
-    ).toEqual(expect.objectContaining({ maxStarwindGzipBytes: 130_664, status: "Pass" }));
+    ).toEqual(expect.objectContaining({ maxStarwindGzipBytes: 142_260, status: "Pass" }));
     expect(oneByteAbove.failures.join("\n")).toContain(
       "Starwind/Zag overlap set-wide Starwind matched-support regression guard exceeded",
     );
@@ -221,7 +239,7 @@ describe("package size budget checks", () => {
       oneByteAbove.matchedSupportChecks.find(
         (check) => check.label === "Starwind/Zag overlap vs Zag React",
       ),
-    ).toEqual(expect.objectContaining({ maxStarwindGzipBytes: 130_664, status: "Fail" }));
+    ).toEqual(expect.objectContaining({ maxStarwindGzipBytes: 142_260, status: "Fail" }));
   });
 
   it("keeps targeted Color Picker cold-import growth as a strict absolute gate", () => {

--- a/scripts/portable-runtime/tests/source-contribution-report.test.mjs
+++ b/scripts/portable-runtime/tests/source-contribution-report.test.mjs
@@ -270,12 +270,12 @@ describe("source contribution report", () => {
 
     expect(historicalHeadlineCeilings).not.toEqual(ceilings.headline);
     expect(ceilings.headline).toEqual({
-      "@starwind-ui/react (adapter only)": 38_713,
-      "@starwind-ui/react + runtime": 179_610,
-      "@starwind-ui/runtime": 138_924,
+      "@starwind-ui/react (adapter only)": 40_134,
+      "@starwind-ui/react + runtime": 194_692,
+      "@starwind-ui/runtime": 153_960,
     });
     expect(summary.overlapBudgetRow.newCeilingBytes).toBe(120_020);
-    expect(ceilings.matchedSupport["starwind-zag-overlap"]).toBe(130_664);
+    expect(ceilings.matchedSupport["starwind-zag-overlap"]).toBe(142_260);
     expect(Object.isFrozen(ceilings)).toBe(true);
     expect(Object.isFrozen(ceilings.headline)).toBe(true);
     expect(Object.isFrozen(ceilings.matchedSupport)).toBe(true);


### PR DESCRIPTION
## What changed

- refresh the six aggregate package-size baselines from the stable 1.1.0/3.1.0 release candidate
- record the public commit and release versions used as baseline provenance
- regenerate the public package-size comparison report
- preserve the existing aggregate growth policy and strict Color Picker and Field budgets

## Validation

- focused package-size tests: 19 passed, 3 private-only checks skipped
- guarded public sync: zero drift
- frozen install: up to date
- diff and formatting checks: passed

## Release impact

This changes internal release regression guards and documentation only. It adds no Changeset and changes no package contents or versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the portable runtime package-size comparison report with refreshed measurements, package versions, and aggregate calculations dated August 15, 2026.

* **Chores**
  * Refreshed package-size budget baselines and added provenance details for the source commit, date, and package releases.
  * Updated budget thresholds and validation coverage, including exact-limit and over-limit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->