### PR TITLE
fix(release): wait for git output before publish

### DIFF
--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -283,10 +283,10 @@ function runCommand(command, args, options = {}) {
   });
 }
 
-async function readGitOutput(args) {
+export async function readGitOutput(args, spawnGit = spawn) {
   let output = "";
   await new Promise((resolve, reject) => {
-    const child = spawn("git", args, {
+    const child = spawnGit("git", args, {
       cwd: ROOT_DIR,
       stdio: ["ignore", "pipe", "inherit"],
     });
@@ -294,7 +294,7 @@ async function readGitOutput(args) {
       output += chunk;
     });
     child.on("error", reject);
-    child.on("exit", (code) => {
+    child.on("close", (code) => {
       if (code === 0) resolve();
       else reject(new Error(`git ${args.join(" ")} failed with exit code ${code}.`));
     });

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -17,6 +17,7 @@ import {
   isDirtyGitStatusOutput,
   parseArgs,
   parsePublishOutput,
+  readGitOutput,
   redactCommandArgs,
   validatePublishGitState,
   validatePublishedPrefix,
@@ -926,6 +927,19 @@ describe("release package tooling", () => {
         originUrl: "git@github.com:starwind-ui/starwind-ui.git",
       }).ok,
     ).toBe(true);
+  });
+
+  it("waits for Git stdout to close before validating publish state", async () => {
+    const child = new EventEmitter() as EventEmitter & { stdout: PassThrough };
+    child.stdout = new PassThrough();
+    const outputPromise = readGitOutput(["rev-parse", "HEAD"], () => child);
+
+    child.emit("exit", 0);
+    await Promise.resolve();
+    child.stdout.end("abc123\n");
+    child.emit("close", 0);
+
+    await expect(outputPromise).resolves.toBe("abc123");
   });
 
   it("keeps generated Runtime package requirements publishable", async () => {


### PR DESCRIPTION
## What changed

- wait for Git subprocess stdout to close before validating the publication checkout
- add a deterministic regression test for exit arriving before stdout completion

## Cause

The preflight resolved on the child process exit event. Fast concurrent Git commands could leave the captured origin/main output empty even when the ref existed.

## Validation

- release package tooling: 30 passed
- sync policy: 29 passed
- guarded public sync: zero drift
- formatting and diff checks: passed

## Release impact

Release tooling only. No package contents, versions, or Changesets change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation reliability by ensuring Git command results are evaluated only after all output has been received.
  * Prevented premature validation when a Git process exits before its output stream closes.

* **Tests**
  * Added regression coverage for Git process completion and output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->