### PR TITLE
fix(release): stabilize post-publish verification

### DIFF
--- a/scripts/portable-runtime/tests/dialog-entry-animation.test.mjs
+++ b/scripts/portable-runtime/tests/dialog-entry-animation.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { assertEntryProgress } from "./smoke/shared/dialog-entry-animation.mjs";
+
+describe("dialog entry animation smoke assertion", () => {
+  it("orders sampled frames by their capture time", () => {
+    const result = {
+      presentationStates: [
+        {
+          backdropHidden: false,
+          backdropState: "open",
+          contentHidden: false,
+          contentState: "open",
+          rootState: "open",
+          triggerExpanded: "true",
+          triggerState: "open",
+        },
+      ],
+      releaseTime: 10,
+      samples: [
+        createSample({
+          animationName: "none",
+          frameTime: 90,
+          opacity: 0,
+          sampledAt: 130,
+          starting: true,
+        }),
+        createSample({
+          animationName: "enter",
+          animationState: "running",
+          frameTime: 140,
+          opacity: 0.5,
+          sampledAt: 145,
+          starting: false,
+        }),
+        createSample({
+          animationName: "enter",
+          frameTime: 350,
+          opacity: 1,
+          sampledAt: 355,
+          starting: false,
+        }),
+      ],
+      showModalReturnedAt: 120,
+    };
+
+    expect(() =>
+      assertEntryProgress({
+        expectedDuration: 100,
+        gesture: "held-release",
+        label: "test dialog",
+        result,
+      }),
+    ).not.toThrow();
+  });
+});
+
+function createSample({
+  animationName,
+  animationState = "finished",
+  frameTime,
+  opacity,
+  sampledAt,
+  starting,
+}) {
+  const animations =
+    animationState === "running" ? [{ currentTime: 25, duration: 200, playState: "running" }] : [];
+  const visual = {
+    animationName,
+    opacity,
+    scale: "none",
+    starting,
+    transform: "none",
+    translate: "none",
+  };
+
+  return {
+    animations,
+    backdrop: visual,
+    content: visual,
+    contentOpen: true,
+    contentState: "open",
+    now: frameTime,
+    sampledAt,
+  };
+}

--- a/scripts/portable-runtime/tests/smoke/shared/dialog-entry-animation.mjs
+++ b/scripts/portable-runtime/tests/smoke/shared/dialog-entry-animation.mjs
@@ -84,6 +84,9 @@ export async function verifyDialogEntryAnimationGestures({
           };
         };
         const sample = (now) => {
+          // The rAF timestamp marks the frame start and can predate synchronous input work in the
+          // same frame. Use the capture time when ordering samples against event timestamps.
+          const sampledAt = performance.now();
           const animations = [
             ...element.getAnimations(),
             ...(backdrop instanceof HTMLElement ? backdrop.getAnimations() : []),
@@ -105,6 +108,7 @@ export async function verifyDialogEntryAnimationGestures({
             contentOpen: element instanceof HTMLDialogElement ? element.open : null,
             contentState: element.getAttribute("data-state"),
             now,
+            sampledAt,
           });
 
           if (finishedFrames >= 2 || now - record.startedAt > 4000) {
@@ -142,10 +146,10 @@ export async function verifyDialogEntryAnimationGestures({
   }
 }
 
-function assertEntryProgress({ expectedDuration, gesture, label, result }) {
-  const afterRelease = result.samples.filter((sample) => sample.now >= result.releaseTime);
+export function assertEntryProgress({ expectedDuration, gesture, label, result }) {
+  const afterRelease = result.samples.filter((sample) => sample.sampledAt >= result.releaseTime);
   const afterPresentation = afterRelease.filter(
-    (sample) => sample.now >= result.showModalReturnedAt,
+    (sample) => sample.sampledAt >= result.showModalReturnedAt,
   );
   const running = afterRelease.filter((sample) =>
     sample.animations.some((animation) => animation.playState === "running"),

--- a/scripts/release-finalization.mjs
+++ b/scripts/release-finalization.mjs
@@ -112,6 +112,13 @@ function isRetryableRegistryFailure(result) {
   );
 }
 
+function createRegistryPropagationError(subject, attempt) {
+  return new Error(
+    `${subject} did not become visible on npm after ${attempt} registry ${attempt === 1 ? "check" : "checks"}. ` +
+      "The package publication may have succeeded. Wait for npm propagation, then run pnpm release:finalize.",
+  );
+}
+
 export async function verifyPublishedPackages(release, system, options = {}) {
   const attempts = options.attempts ?? DEFAULT_REGISTRY_VERIFICATION_ATTEMPTS;
   const retryDelayMs = options.retryDelayMs ?? DEFAULT_REGISTRY_RETRY_DELAY_MS;
@@ -140,10 +147,7 @@ export async function verifyPublishedPackages(release, system, options = {}) {
           await waitForRetry(retryDelayMs);
           continue;
         }
-        throw new Error(
-          `${spec} did not become visible on npm after ${attempt} registry ${attempt === 1 ? "check" : "checks"}. ` +
-            "The package publication may have succeeded. Wait for npm propagation, then run pnpm release:finalize.",
-        );
+        throw createRegistryPropagationError(spec, attempt);
       }
       const publishedVersion = parseJsonOutput(versionResult, `${spec} version`);
       if (publishedVersion !== entry.version) {
@@ -158,6 +162,9 @@ export async function verifyPublishedPackages(release, system, options = {}) {
           onRetry(spec, attempt);
           await waitForRetry(retryDelayMs);
           continue;
+        }
+        if (isRetryableRegistryFailure(tagsResult)) {
+          throw createRegistryPropagationError(`${spec} dist-tag ${release.npmTag}`, attempt);
         }
         parseJsonOutput(tagsResult, `${spec} dist-tags`);
       }

--- a/scripts/release-finalization.mjs
+++ b/scripts/release-finalization.mjs
@@ -142,12 +142,14 @@ export async function verifyPublishedPackages(release, system, options = {}) {
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
       const versionResult = await system.capture("npm", ["view", spec, "version", "--json"]);
       if (versionResult.code !== 0) {
-        if (attempt < attempts && isRetryableRegistryFailure(versionResult)) {
+        const retryable = isRetryableRegistryFailure(versionResult);
+        if (attempt < attempts && retryable) {
           onRetry(spec, attempt);
           await waitForRetry(retryDelayMs);
           continue;
         }
-        throw createRegistryPropagationError(spec, attempt);
+        if (retryable) throw createRegistryPropagationError(spec, attempt);
+        parseJsonOutput(versionResult, `${spec} version`);
       }
       const publishedVersion = parseJsonOutput(versionResult, `${spec} version`);
       if (publishedVersion !== entry.version) {

--- a/scripts/release-finalization.mjs
+++ b/scripts/release-finalization.mjs
@@ -9,6 +9,8 @@ import { assertPublicMainForPublish, assertReleaseMetadata } from "./release-pac
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const PUBLIC_REPOSITORY = "starwind-ui/starwind-ui";
+const DEFAULT_REGISTRY_VERIFICATION_ATTEMPTS = 12;
+const DEFAULT_REGISTRY_RETRY_DELAY_MS = 5_000;
 
 export function createCommandSystem({ cwd = ROOT_DIR, spawnProcess = spawn } = {}) {
   async function capture(command, args) {
@@ -99,26 +101,78 @@ function parseJsonOutput(result, description) {
   }
 }
 
-export async function verifyPublishedPackages(release, system) {
+function wait(delayMs) {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function isRetryableRegistryFailure(result) {
+  const detail = `${result.stderr}\n${result.stdout}`;
+  return /(?:E404|404 Not Found|EAI_AGAIN|ECONNRESET|ETIMEDOUT|ENETUNREACH|EHOSTUNREACH|HTTP 5\d\d)/i.test(
+    detail,
+  );
+}
+
+export async function verifyPublishedPackages(release, system, options = {}) {
+  const attempts = options.attempts ?? DEFAULT_REGISTRY_VERIFICATION_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_REGISTRY_RETRY_DELAY_MS;
+  const waitForRetry = options.wait ?? wait;
+  const onRetry =
+    options.onRetry ??
+    ((spec, attempt) => {
+      console.log(
+        `[finalize] Waiting for ${spec} to become visible on npm (${attempt}/${attempts})...`,
+      );
+    });
+  if (!Number.isInteger(attempts) || attempts < 1) {
+    throw new Error("Registry verification attempts must be a positive integer.");
+  }
+  if (!Number.isFinite(retryDelayMs) || retryDelayMs < 0) {
+    throw new Error("Registry retry delay must be a non-negative number.");
+  }
+
   for (const entry of release.packages) {
     const spec = `${entry.name}@${entry.version}`;
-    const versionResult = await system.capture("npm", ["view", spec, "version", "--json"]);
-    if (versionResult.code !== 0) {
-      throw new Error(`${spec} is not published and release finalization cannot continue.`);
-    }
-    const publishedVersion = parseJsonOutput(versionResult, `${spec} version`);
-    if (publishedVersion !== entry.version) {
-      throw new Error(
-        `${spec} resolved to unexpected version ${JSON.stringify(publishedVersion)}.`,
-      );
-    }
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      const versionResult = await system.capture("npm", ["view", spec, "version", "--json"]);
+      if (versionResult.code !== 0) {
+        if (attempt < attempts && isRetryableRegistryFailure(versionResult)) {
+          onRetry(spec, attempt);
+          await waitForRetry(retryDelayMs);
+          continue;
+        }
+        throw new Error(
+          `${spec} did not become visible on npm after ${attempt} registry ${attempt === 1 ? "check" : "checks"}. ` +
+            "The package publication may have succeeded. Wait for npm propagation, then run pnpm release:finalize.",
+        );
+      }
+      const publishedVersion = parseJsonOutput(versionResult, `${spec} version`);
+      if (publishedVersion !== entry.version) {
+        throw new Error(
+          `${spec} resolved to unexpected version ${JSON.stringify(publishedVersion)}.`,
+        );
+      }
 
-    const tagsResult = await system.capture("npm", ["view", spec, "dist-tags", "--json"]);
-    const tags = parseJsonOutput(tagsResult, `${spec} dist-tags`);
-    if (tags?.[release.npmTag] !== entry.version) {
-      throw new Error(
-        `${entry.name} dist-tag ${release.npmTag} must point to ${entry.version}, found ${tags?.[release.npmTag] ?? "nothing"}.`,
-      );
+      const tagsResult = await system.capture("npm", ["view", spec, "dist-tags", "--json"]);
+      if (tagsResult.code !== 0) {
+        if (attempt < attempts && isRetryableRegistryFailure(tagsResult)) {
+          onRetry(spec, attempt);
+          await waitForRetry(retryDelayMs);
+          continue;
+        }
+        parseJsonOutput(tagsResult, `${spec} dist-tags`);
+      }
+      const tags = parseJsonOutput(tagsResult, `${spec} dist-tags`);
+      if (tags?.[release.npmTag] !== entry.version) {
+        if (attempt < attempts) {
+          onRetry(spec, attempt);
+          await waitForRetry(retryDelayMs);
+          continue;
+        }
+        throw new Error(
+          `${entry.name} dist-tag ${release.npmTag} must point to ${entry.version}, found ${tags?.[release.npmTag] ?? "nothing"}.`,
+        );
+      }
+      break;
     }
   }
 }
@@ -247,12 +301,13 @@ export async function finalizeVerifiedRelease(release, system) {
 export async function runReleaseFinalization({
   gitStateLoader = assertPublicMainForPublish,
   metadataLoader = assertReleaseMetadata,
+  registryVerificationOptions,
   system = createCommandSystem(),
 } = {}) {
   const { packageManifests, tag } = await metadataLoader();
   const { head } = await gitStateLoader();
   const release = deriveReleaseIdentity(packageManifests, tag, head);
-  await verifyPublishedPackages(release, system);
+  await verifyPublishedPackages(release, system, registryVerificationOptions);
   await finalizeVerifiedRelease(release, system);
   return release;
 }

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -417,6 +417,45 @@ describe("release package tooling", () => {
     expect(calls).toHaveLength(8);
   });
 
+  it("retries a package version while npm publication propagates", async () => {
+    const expected = deriveReleaseIdentity(manifests({ cli: "3.0.0", runtime: "1.0.0" }), "latest");
+    const calls: string[] = [];
+    const waits: number[] = [];
+    let runtimeVersionAttempts = 0;
+
+    await verifyPublishedPackages(
+      expected,
+      {
+        capture: async (command: string, args: string[]) => {
+          calls.push([command, ...args].join(" "));
+          const packageName = args[1].slice(0, args[1].lastIndexOf("@"));
+          const item = expected.packages.find((entry) => entry.name === packageName)!;
+          if (packageName === "@starwind-ui/runtime" && args[2] === "version") {
+            runtimeVersionAttempts += 1;
+            if (runtimeVersionAttempts === 1) {
+              return { code: 1, stderr: "npm error E404", stdout: "" };
+            }
+          }
+          return args[2] === "version"
+            ? { code: 0, stderr: "", stdout: JSON.stringify(item.version) }
+            : { code: 0, stderr: "", stdout: JSON.stringify({ latest: item.version }) };
+        },
+        run: async () => undefined,
+      },
+      {
+        attempts: 3,
+        retryDelayMs: 5_000,
+        wait: async (delayMs: number) => {
+          waits.push(delayMs);
+        },
+      },
+    );
+
+    expect(runtimeVersionAttempts).toBe(2);
+    expect(waits).toEqual([5_000]);
+    expect(calls).toHaveLength(9);
+  });
+
   it("stops before Git changes when any package version is missing", async () => {
     const expected = deriveReleaseIdentity(
       manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }),
@@ -432,7 +471,9 @@ describe("release package tooling", () => {
         commands.push([command, ...args].join(" "));
       },
     };
-    await expect(verifyPublishedPackages(expected, system)).rejects.toThrow(/not published/);
+    await expect(verifyPublishedPackages(expected, system, { attempts: 1 })).rejects.toThrow(
+      /did not become visible/,
+    );
     expect(commands.every((command) => command.startsWith("npm view"))).toBe(true);
   });
 
@@ -445,6 +486,7 @@ describe("release package tooling", () => {
           packageManifests: manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }),
           tag: "beta",
         }),
+        registryVerificationOptions: { attempts: 1 },
         system: {
           capture: async (command: string, args: string[]) => {
             commands.push([command, ...args].join(" "));
@@ -455,7 +497,7 @@ describe("release package tooling", () => {
           },
         },
       }),
-    ).rejects.toThrow(/not published/);
+    ).rejects.toThrow(/did not become visible/);
     expect(commands).toEqual(["npm view @starwind-ui/runtime@0.1.0-beta.8 version --json"]);
   });
 

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -489,6 +489,40 @@ describe("release package tooling", () => {
     expect(waits).toEqual([5_000, 5_000]);
   });
 
+  it("preserves non-retryable version lookup errors", async () => {
+    const expected = deriveReleaseIdentity(manifests({ cli: "3.0.0", runtime: "1.0.0" }), "latest");
+    const waits: number[] = [];
+    let attempts = 0;
+
+    const error = await verifyPublishedPackages(
+      expected,
+      {
+        capture: async () => {
+          attempts += 1;
+          return { code: 1, stderr: "npm error E401", stdout: "" };
+        },
+        run: async () => undefined,
+      },
+      {
+        attempts: 3,
+        onRetry: () => undefined,
+        retryDelayMs: 5_000,
+        wait: async (delayMs: number) => {
+          waits.push(delayMs);
+        },
+      },
+    ).then(
+      () => undefined,
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toContain("version could not be verified: npm error E401");
+    expect((error as Error).message).not.toContain("pnpm release:finalize");
+    expect(attempts).toBe(1);
+    expect(waits).toEqual([]);
+  });
+
   it("stops before Git changes when any package version is missing", async () => {
     const expected = deriveReleaseIdentity(
       manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }),

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -456,6 +456,39 @@ describe("release package tooling", () => {
     expect(calls).toHaveLength(9);
   });
 
+  it("reports safe recovery after dist-tag propagation retries are exhausted", async () => {
+    const expected = deriveReleaseIdentity(manifests({ cli: "3.0.0", runtime: "1.0.0" }), "latest");
+    const waits: number[] = [];
+    let runtimeTagAttempts = 0;
+
+    await expect(
+      verifyPublishedPackages(
+        expected,
+        {
+          capture: async (_command: string, args: string[]) => {
+            if (args[2] === "version") {
+              return { code: 0, stderr: "", stdout: JSON.stringify("1.0.0") };
+            }
+            runtimeTagAttempts += 1;
+            return { code: 1, stderr: "npm error E404", stdout: "" };
+          },
+          run: async () => undefined,
+        },
+        {
+          attempts: 3,
+          onRetry: () => undefined,
+          retryDelayMs: 5_000,
+          wait: async (delayMs: number) => {
+            waits.push(delayMs);
+          },
+        },
+      ),
+    ).rejects.toThrow(/dist-tag latest.*pnpm release:finalize/);
+
+    expect(runtimeTagAttempts).toBe(3);
+    expect(waits).toEqual([5_000, 5_000]);
+  });
+
   it("stops before Git changes when any package version is missing", async () => {
     const expected = deriveReleaseIdentity(
       manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }),


### PR DESCRIPTION
## What changed

- Retry transient npm registry misses before release finalization stops.
- Report the safe `pnpm release:finalize` recovery command when propagation exceeds the retry window.
- Compare dialog animation samples by capture time instead of the frame-start timestamp.
- Add deterministic regressions for both timing failures.

## Verification

- 39 focused release and animation tests passed on the public candidate.
- Prettier and `git diff --check` passed.
- Published CLI 3.2.0 acceptance passed in Astro and React, including production builds and Chromium behavior.

## Release impact

Tooling and test fixes only. No package Changeset is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release verification now retries transient registry failures with configurable attempts and delays.
  * Improved error reporting when package versions or distribution tags remain unavailable.
  * Registry verification now completes before release finalization proceeds, reducing premature release completion.

* **Tests**
  * Added coverage for exhausted and non-retryable registry verification failures.
  * Added validation for dialog entry-animation timing when samples arrive out of frame order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->