### PR TITLE
test(cli): remove registry generation from docs test setup

### DIFF
--- a/packages/cli/tests/commands/docs.test.ts
+++ b/packages/cli/tests/commands/docs.test.ts
@@ -1,18 +1,10 @@
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
 
 import * as clackPrompts from "@clack/prompts";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-
-import {
-  buildRuntimeRegistry,
-  createCliRegistryBuildPolicy,
-} from "../../../../scripts/portable-runtime/generate-cli-registry.js";
-import { vueFrameworkAdapterTarget } from "../../../../scripts/portable-runtime/renderers/framework-adapters/vue/index.js";
-
-import * as registry from "../../src/utils/registry.js";
 import { docs } from "../../src/commands/docs.js";
 import { PRIVATE_VUE_FRAMEWORK_TARGET_POLICY } from "../../src/utils/framework-target-policy.js";
+import * as registry from "../../src/utils/registry.js";
 
 vi.mock("@clack/prompts");
 vi.mock("../../src/utils/registry.js");
@@ -37,13 +29,12 @@ const mockParseRegistrySource = vi.mocked(registry.parseRegistrySource);
 describe("docs command", () => {
   let mockExit: ReturnType<typeof vi.spyOn>;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
-  let vueRegistry: Awaited<ReturnType<typeof buildRuntimeRegistry>>;
+  let vueRegistry: Awaited<ReturnType<typeof registry.loadRegistry>>;
 
-  beforeAll(async () => {
-    vueRegistry = await buildRuntimeRegistry({
-      repoRoot: fileURLToPath(new URL("../../../..", import.meta.url)),
-      targetPolicy: createCliRegistryBuildPolicy([vueFrameworkAdapterTarget]),
-    });
+  beforeAll(() => {
+    vueRegistry = JSON.parse(
+      readFileSync(new URL("../../src/registry/bundled-registry.json", import.meta.url), "utf8"),
+    );
   });
 
   beforeEach(() => {


### PR DESCRIPTION
The docs test setup regenerated the full Vue registry and exceeded the ten-second CI hook budget after merge. Read the shipped registry fixture, as the other CLI command tests do. Generator tests retain regeneration coverage. Six focused tests pass in 167ms locally, compared with 4.05s before this change. No timeout, package version, component source, or release plan changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated documentation command tests to load the Vue registry from the bundled registry file.
  * Improved test setup consistency by using the registry’s loaded representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->