### PR TITLE
fix(release): omit absent private package from Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,12 +2,22 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": "./changelog.mjs",
   "commit": true,
-  "fixed": [["@starwind-ui/runtime", "@starwind-ui/astro", "@starwind-ui/react"]],
+  "fixed": [
+    [
+      "@starwind-ui/runtime",
+      "@starwind-ui/astro",
+      "@starwind-ui/react"
+    ]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["demo", "react-demo", "vue-demo", "@starwind-ui/svelte"],
+  "ignore": [
+    "demo",
+    "react-demo",
+    "vue-demo"
+  ],
   "privatePackages": {
     "version": false,
     "tag": false

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -14,7 +14,6 @@ import { join, sep } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { PUBLIC_FRAMEWORK_TARGET_POLICY } from "../../../packages/cli/src/utils/framework-target-policy.js";
-import { CHANGESET_IGNORED_PACKAGES } from "../../runtime-release-policy.mjs";
 
 import {
   createVueContractFixtureFiles,
@@ -173,7 +172,14 @@ const forbiddenPublicVueScriptCommandPatterns = [
   /(?:pack-public-release-artifacts|published-release-acceptance|release-candidate-acceptance|release-packages)\.mjs\b/i,
   /(?:runtime:registry(?::|\b)|generate-cli-registry|packages\/cli\/(?:registry|src\/registry))/i,
 ] as const;
-const approvedChangesetIgnore = [...CHANGESET_IGNORED_PACKAGES];
+const approvedChangesetIgnore = [
+  "demo",
+  "react-demo",
+  "vue-demo",
+  ...(existsSync(join(process.cwd(), "packages/svelte/package.json"))
+    ? ["@starwind-ui/svelte"]
+    : []),
+];
 const approvedProductPositioningVueClaim =
   /Current first-party Primitive adapter packages are Astro, React, and the Vue 3\.5 public beta\.\s+Runtime adapter contract types also allow future targets such as Svelte and Solid\. Claim support\s+only after generated package output, demos, host checks, and release metadata exist\./;
 const approvedVueArchitectureDoc = "docs/adr/0011-use-idiomatic-vue-adapter-semantics.md";

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -14,6 +14,7 @@ import { join, sep } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { PUBLIC_FRAMEWORK_TARGET_POLICY } from "../../../packages/cli/src/utils/framework-target-policy.js";
+import { CHANGESET_IGNORED_PACKAGES } from "../../runtime-release-policy.mjs";
 
 import {
   createVueContractFixtureFiles,
@@ -172,7 +173,7 @@ const forbiddenPublicVueScriptCommandPatterns = [
   /(?:pack-public-release-artifacts|published-release-acceptance|release-candidate-acceptance|release-packages)\.mjs\b/i,
   /(?:runtime:registry(?::|\b)|generate-cli-registry|packages\/cli\/(?:registry|src\/registry))/i,
 ] as const;
-const approvedChangesetIgnore = ["demo", "react-demo", "vue-demo", "@starwind-ui/svelte"];
+const approvedChangesetIgnore = [...CHANGESET_IGNORED_PACKAGES];
 const approvedProductPositioningVueClaim =
   /Current first-party Primitive adapter packages are Astro, React, and the Vue 3\.5 public beta\.\s+Runtime adapter contract types also allow future targets such as Svelte and Solid\. Claim support\s+only after generated package output, demos, host checks, and release metadata exist\./;
 const approvedVueArchitectureDoc = "docs/adr/0011-use-idiomatic-vue-adapter-semantics.md";

--- a/scripts/runtime-release-policy.mjs
+++ b/scripts/runtime-release-policy.mjs
@@ -2,7 +2,6 @@ export const CHANGESET_IGNORED_PACKAGES = Object.freeze([
   "demo",
   "react-demo",
   "vue-demo",
-  "@starwind-ui/svelte",
 ]);
 
 export const CHANGESET_PRIVATE_PACKAGE_POLICY = Object.freeze({

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -131,7 +131,7 @@ describe("release package tooling", () => {
       "demo",
       "react-demo",
       "vue-demo",
-      "@starwind-ui/svelte",
+      ...(hasPrivateSvelte ? ["@starwind-ui/svelte"] : []),
     ]);
     expect(RUNTIME_FIXED_GROUP).toEqual([
       "@starwind-ui/runtime",


### PR DESCRIPTION
Project the Changesets ignore list and release policy to match the public workspace, which excludes private Svelte. Keep private Svelte ignored in the source repository. Update the Vue policy test to check the available workspace. Validation: public release:status now schedules only starwind 3.3.1; 71 release/sync tests, 1,139 generator tests, and generator typecheck passed. No package versions or component code changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated release management so the Svelte package can be included in versioning and publishing workflows when available.
  - Improved release validation for environments where the Svelte package is present or absent.
  - Standardized release configuration formatting without changing existing fixed-package settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->