### PR TITLE
test(release): verify public Vue package and candidate CLI versions

### DIFF
--- a/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
+++ b/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
@@ -396,9 +396,8 @@ describe("Vue package foundation", () => {
     expect(changesetConfig.fixed).toEqual([
       ["@starwind-ui/runtime", "@starwind-ui/astro", "@starwind-ui/react"],
     ]);
-    expect(changesetConfig.ignore).toEqual(
-      expect.arrayContaining(["vue-demo", "@starwind-ui/svelte"]),
-    );
+    expect(changesetConfig.ignore).toContain("vue-demo");
+    expect(changesetConfig.ignore.includes("@starwind-ui/svelte")).toBe(hasPrivateSvelte);
     expect(changesetConfig.ignore).not.toContain("@starwind-ui/vue");
 
     const vueDemoPackage = JSON.parse(await readFile("apps/vue-demo/package.json", "utf8"));

--- a/scripts/tests/vue-cli-host-acceptance.test.ts
+++ b/scripts/tests/vue-cli-host-acceptance.test.ts
@@ -22,6 +22,7 @@ import {
   getAstroVueFixture,
   getViteVueFixture,
   getVueFixture,
+  getVueBetaPackVersion,
   isPreviewTreeAlive,
   isNuxtComponentCollisionWarning,
   isVueHydrationMismatchWarning,
@@ -42,6 +43,12 @@ const packages = {
 };
 
 describe("production Vue CLI host acceptance", () => {
+  it("keeps the candidate CLI version when packing Vue beta hosts", () => {
+    expect(getVueBetaPackVersion("cli", "3.3.1")).toBe("3.3.1");
+    expect(getVueBetaPackVersion("runtime", "1.2.0")).toBe("1.2.0");
+    expect(getVueBetaPackVersion("vue", "0.1.0")).toBe("0.1.0");
+  });
+
   it("plans exact beta packages and includes Vue in public candidate acceptance", () => {
     const betaPlan = createVueBetaPackPlan({ outputDirectory: path.join(root, "packs") });
     const publicPlan = createPackPlan({ outputDirectory: path.join(root, "public-packs") });

--- a/scripts/vue-cli-host-acceptance.mjs
+++ b/scripts/vue-cli-host-acceptance.mjs
@@ -34,7 +34,6 @@ const NUXT_3_VERSION = "3.21.0";
 const NUXT_4_VERSION = "4.2.0";
 const QUASAR_APP_VERSION = "3.0.0";
 const VUE_BETA_REGISTRY_VERSION = "0.1.0";
-const VUE_BETA_CLI_VERSION = "3.3.0";
 const HOST = "127.0.0.1";
 const PRIVATE_PACKAGES = [
   {
@@ -676,6 +675,10 @@ export async function runVueLocalLinkAcceptance({ root, runCommand = runLoggedCo
   console.log("[vue-cli-host] isolated Runtime, Vue, and CLI local-link acceptance passed");
 }
 
+export function getVueBetaPackVersion(key, version) {
+  return key === "vue" ? VUE_BETA_REGISTRY_VERSION : version;
+}
+
 async function packVueBetaPackages(outputDirectory, logsDirectory) {
   const plan = createVueBetaPackPlan({ outputDirectory });
   await mkdir(outputDirectory, { recursive: true });
@@ -686,12 +689,7 @@ async function packVueBetaPackages(outputDirectory, logsDirectory) {
     const manifest = JSON.parse(
       await readFile(path.join(packageDirectory, "package.json"), "utf8"),
     );
-    const plannedVersion =
-      entry.key === "vue"
-        ? VUE_BETA_REGISTRY_VERSION
-        : entry.key === "cli"
-          ? VUE_BETA_CLI_VERSION
-          : manifest.version;
+    const plannedVersion = getVueBetaPackVersion(entry.key, manifest.version);
     if (plannedVersion !== manifest.version) {
       packageDirectory = path.join(outputDirectory, "staged", entry.key);
       await cp(entry.directory, packageDirectory, {


### PR DESCRIPTION
Align the Vue package-foundation assertion with the public workspace, which excludes private Svelte. Preserve the candidate CLI version when packing Vue host fixtures instead of relabeling every candidate 3.3.0. Validation: full public vue:verify, generator typecheck, and 16 host-acceptance helper tests passed. Package versions and component source are unchanged. This prerequisite lets the Version Packages PR verify CLI 3.3.1 accurately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Vue beta package version handling so the CLI uses its intended package version while the Vue package continues using the beta registry version.
  * Improved package configuration validation for Vue projects with or without private Svelte support.

* **Tests**
  * Added coverage to verify that beta package versions are preserved correctly across supported Vue CLI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->