### PR TITLE
perf(ci): keep verification near three minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,6 @@ jobs:
     needs: scope
     if: needs.scope.outputs.versioned == 'true'
     uses: ./.github/workflows/verify.yml
-    with:
-      private_adapters: false
 
   release:
     name: Release

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,10 +3,6 @@ name: Verify
 on:
   pull_request:
   workflow_call:
-    inputs:
-      private_adapters:
-        type: boolean
-        default: false
   workflow_dispatch:
     inputs:
       base_sha:
@@ -26,75 +22,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  scope:
-    name: Detect verification scope
+  static:
+    name: Static checks
     runs-on: ubuntu-latest
-    outputs:
-      svelte: ${{ steps.changes.outputs.svelte }}
-      vue: ${{ steps.changes.outputs.vue }}
-      windows: ${{ steps.changes.outputs.windows }}
-      node22: ${{ steps.changes.outputs.node22 }}
+    timeout-minutes: 5
     steps:
       - name: Checkout Repo
-        # checkout@6.0.2
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
-
       - name: Verify dispatched head
         if: github.event_name == 'workflow_dispatch'
         env:
           EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
         run: test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"
-
-      - name: Detect adapter-impacting changes
-        id: changes
-        shell: bash
-        env:
-          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha || github.event.before }}
-          VUE_SCOPE_PATTERN: "^(apps/vue-demo/|packages/(runtime|vue)/|packages/cli/(registry/|scripts/|src/|tests/|package[.]json$|tsconfig[.]json$|tsup[.]config[.]ts$|vitest[.]config[.]ts$)|scripts/(check-release-artifacts|pack-public-release-artifacts|published-release-acceptance|release-candidate-acceptance|sync-public-repo|vue-cli-host-acceptance)[.]mjs$|scripts/tests/(check-release-artifacts|pack-public-release-artifacts|published-release-acceptance|public-sync|release-candidate-acceptance|root-verification-scripts|vue-cli-host-acceptance)[.](test[.](mjs|ts)|mjs)$|scripts/portable-runtime/(contracts/(primitive|styled)/|renderers/(framework-adapters/(vue/|[^/]+[.](mjs|ts)$)|generic-adapter-plan/|primitive-output-model/|primitives/|specialized-adapter-spec/|styled-output-model/|[^/]+[.](mjs|ts)$)|generate-(cli-registry|primitive-vendoring-artifacts|vue-wrappers)[.]ts$|format-generated-output[.]ts$|framework-surface-manifest[.](json|mjs)$)|[.]github/workflows/verify[.]yml$|package[.]json$|pnpm-lock[.]yaml$|pnpm-workspace[.]yaml$|turbo[.]json$)"
-        run: |
-          if [[ -z "$BASE_SHA" || "$BASE_SHA" =~ ^0+$ ]] || ! git cat-file -e "$BASE_SHA^{commit}"; then
-            echo "svelte=true" >> "$GITHUB_OUTPUT"
-            echo "vue=true" >> "$GITHUB_OUTPUT"
-            echo "windows=true" >> "$GITHUB_OUTPUT"
-            echo "node22=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          git diff --name-only "$BASE_SHA" "$GITHUB_SHA" > "$RUNNER_TEMP/changed-files.txt"
-          if grep -Eq "$VUE_SCOPE_PATTERN" "$RUNNER_TEMP/changed-files.txt"; then
-            echo "vue=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "vue=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if grep -Eq '^(packages/svelte/|scripts/portable-runtime/(renderers/framework-adapters/svelte/|generate-svelte-wrappers|check-svelte)|scripts/portable-runtime/tests/generate-svelte-proof/)' "$RUNNER_TEMP/changed-files.txt"; then
-            echo "svelte=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "svelte=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if grep -Eq '^(packages/(astro|cli|runtime)/|scripts/(pack-public-release-artifacts|windows-packed-cli-smoke)\.mjs$|scripts/tests/windows-packed-cli-smoke\.test\.ts$|\.github/workflows/verify\.yml$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$)' "$RUNNER_TEMP/changed-files.txt"; then
-            echo "windows=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "windows=false" >> "$GITHUB_OUTPUT"
-          fi
-
-          if grep -Eq '^(packages/(astro|cli|react|runtime)/|scripts/(node22-public-consumer-smoke|pack-public-release-artifacts)\.mjs$|scripts/tests/node22-public-consumer-smoke\.test\.ts$|\.github/workflows/verify\.yml$|package\.json$|pnpm-lock\.yaml$|pnpm-workspace\.yaml$)' "$RUNNER_TEMP/changed-files.txt"; then
-            echo "node22=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "node22=false" >> "$GITHUB_OUTPUT"
-          fi
-
-  static:
-    name: Static checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
       - name: Install pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
         with:
@@ -107,7 +48,7 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Check source and test ownership
-        run: pnpm check && pnpm test:homes
+        run: pnpm check && pnpm test:homes && pnpm runtime:generate:typecheck
       - name: Check release metadata
         run: pnpm styled:versions:check && pnpm primitive:versions:check && pnpm runtime:docs:metadata:check
       - name: Verify Styled Component Version Intent
@@ -119,6 +60,7 @@ jobs:
   node-tests:
     name: Node tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -134,33 +76,14 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
       - name: Run Node suites
-        run: pnpm test:node && pnpm runtime:test:unit && pnpm react:test:ssr
-
-  generator-tests:
-    name: Generator tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          cache: true
-      - name: Setup Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Run portable Runtime generator tests
-        run: pnpm runtime:generate:test && pnpm runtime:generate:typecheck
+        run: pnpm test:node && pnpm runtime:test:unit && pnpm react:test:ssr && pnpm --filter=@starwind-ui/vue test:run
+      - name: Check adapter contracts and registry
+        run: pnpm runtime:generate:test:ci
 
   browser-adapter-tests:
     name: Browser adapter tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -178,61 +101,12 @@ jobs:
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
       - name: Run browser suites
-        run: pnpm runtime:test:browser && pnpm react:test:browser
-
-  vue-tests:
-    name: Vue verification
-    needs: scope
-    if: github.head_ref != 'changeset-release/main' && needs.scope.outputs.vue == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          cache: true
-      - name: Setup Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Run Vue public-beta verification
-        run: pnpm vue:verify
-      - name: Run Vue public-beta CLI host acceptance
-        run: pnpm test:vue-cli-host-acceptance
-
-  svelte-tests:
-    name: Svelte verification
-    needs: scope
-    if: github.event.repository.private && (github.event_name == 'pull_request' || inputs.private_adapters) && github.head_ref != 'changeset-release/main' && needs.scope.outputs.svelte == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          cache: true
-      - name: Setup Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Run quarantined Svelte verification
-        run: pnpm svelte:verify
+        run: pnpm runtime:test:browser && pnpm react:test:browser && pnpm vue:test:browser:ci
 
   build-drift:
     name: Build and generated drift
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -249,129 +123,26 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Regenerate Runtime adapters and CLI registries
         run: pnpm runtime:generate:all && pnpm runtime:registry:generate
-      - name: Build repository
-        run: pnpm build
+      - name: Build shipping packages
+        run: pnpm exec turbo build --filter=@starwind-ui/runtime --filter=@starwind-ui/react --filter=@starwind-ui/vue --filter=starwind
       - name: Reject Generated Drift
         run: git diff --exit-code
       - name: Check CLI package size
         run: pnpm --filter=starwind package:check
-      - name: Check prepared Astro demo bundles
-        run: node scripts/portable-runtime/assert-astro-demo-bundles.mjs
-      - name: Validate saved Vue performance evidence
-        if: github.event.repository.private
-        run: pnpm runtime:perf:vue:evidence:check
-      - name: Check prepared package sizes
-        env:
-          STARWIND_MEASUREMENT_TMP_ROOT: ${{ runner.temp }}/starwind-measurements
-        run: pnpm runtime:size:check:prepared
-      - name: Upload package-size failure diagnostics
-        if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
-        with:
-          name: package-size-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            ${{ runner.temp }}/starwind-measurements/starwind-package-size-comparison/run-*/raw-evidence
-            docs/portable-runtime/diagnostics/astro-demo-bundle-report.md
-          if-no-files-found: ignore
-          retention-days: 7
-
-  node22-public-consumer:
-    name: Node 22.12 public consumer
-    needs: scope
-    if: needs.scope.outputs.node22 == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          cache: true
-      - name: Setup Node.js 24 for public package builds
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Build public packages
-        run: pnpm runtime:build && pnpm react:build && pnpm cli:build && pnpm --filter=@starwind-ui/astro typecheck
-      - name: Pack public artifacts
-        run: pnpm release:pack:public-artifacts
-      - name: Setup exact public Node floor
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 22.12.0
-      - name: Verify packed Astro and React consumers
-        run: npm run release:consumer:node22
-
-  windows-packed-cli:
-    name: Windows packed CLI
-    needs: scope
-    if: needs.scope.outputs.windows == 'true'
-    runs-on: windows-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Install pnpm
-        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
-        with:
-          cache: true
-      - name: Setup Node.js 24
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Verify packed Windows CLI lifecycle
-        run: pnpm test:windows-packed-cli
 
   verify:
     name: Verify
     if: always()
     needs:
-      - scope
       - static
       - node-tests
-      - generator-tests
       - browser-adapter-tests
-      - vue-tests
-      - svelte-tests
       - build-drift
-      - node22-public-consumer
-      - windows-packed-cli
     runs-on: ubuntu-latest
+    timeout-minutes: 1
     steps:
       - name: Require every verification gate
-        shell: bash
-        run: |
-          if [[ "${{ needs.scope.result }}" != "success" ||
-                "${{ needs.static.result }}" != "success" ||
-                "${{ needs.node-tests.result }}" != "success" ||
-                "${{ needs.generator-tests.result }}" != "success" ||
-                "${{ needs.browser-adapter-tests.result }}" != "success" ||
-                "${{ needs.build-drift.result }}" != "success" ]]; then
-            exit 1
-          fi
-
-          if [[ "${{ needs.node22-public-consumer.result }}" != "success" &&
-                "${{ needs.node22-public-consumer.result }}" != "skipped" ]]; then
-            exit 1
-          fi
-
-          if [[ "${{ needs.windows-packed-cli.result }}" != "success" &&
-                "${{ needs.windows-packed-cli.result }}" != "skipped" ]]; then
-            exit 1
-          fi
-
-          if [[ "${{ needs.vue-tests.result }}" != "success" &&
-                "${{ needs.vue-tests.result }}" != "skipped" ]]; then
-            exit 1
-          fi
-
-          if [[ "${{ needs.svelte-tests.result }}" != "success" &&
-                "${{ needs.svelte-tests.result }}" != "skipped" ]]; then
-            exit 1
-          fi
+        env:
+          CHECK_RESULTS: ${{ join(needs.*.result, ',') }}
+        run: >-
+          node -e "process.exit(process.env.CHECK_RESULTS === 'success,success,success,success' ? 0 : 1)"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,10 +125,36 @@ https://www.conventionalcommits.org/ or check out the
 
 3. Make and commit your changes following the
    [commit convention](https://github.com/starwind-ui/starwind-ui/blob/main/CONTRIBUTING.md#commit-convention).
-   Before opening a pull request, run `pnpm check`, `pnpm test:all`, and `pnpm build`. Run
-   `pnpm verify` for the complete local CI-equivalent gate.
+   Before opening a pull request, run the checks for the areas you changed. Use `pnpm verify`
+   for the full local test and build suite. PR CI targets about three minutes, excluding queue
+   time, with static checks, core tests, generated-file checks, and shipping package builds.
 
 4. Please note that you might have to run `git fetch origin main:master` (where
    origin will be your fork on GitHub).
 
 5. After making your changes, add a changeset by running `pnpm changeset`. This will open an interactive prompt where you can add a changeset.
+
+### Local verification
+
+CI runs Runtime and React browser tests, Vue source SSR, and Vue Checkbox, Dialog, and Select
+browser tests. Contract and registry tests cover adapter interfaces and installed source. CI also
+regenerates adapters and registries to detect stale files. Run the broader checks locally when the
+changed area needs them:
+
+| Changed area                                | Local command                                                        |
+| ------------------------------------------- | -------------------------------------------------------------------- |
+| Shared contracts, generators, or registry   | `pnpm runtime:generate:test`                                         |
+| Vue adapters or Vue generator               | `pnpm vue:verify`                                                    |
+| Vue CLI installation or project integration | `pnpm test:vue-cli-host-acceptance`                                  |
+| Astro or React CLI installation             | `pnpm test:cli-host-acceptance`                                      |
+| Demo interaction                            | `pnpm demo:smoke`, `pnpm react-demo:smoke`, or `pnpm vue-demo:smoke` |
+| Bundle size                                 | `pnpm runtime:bundle:test` and `pnpm runtime:size:check`             |
+| Windows CLI behavior                        | `pnpm test:windows-packed-cli` on Windows                            |
+
+For Node 22.12 consumer validation, build and pack the public packages with Node 24 using
+`pnpm runtime:build && pnpm react:build && pnpm cli:build && pnpm release:pack:public-artifacts`.
+Switch to Node 22.12.0, then run `npm run release:consumer:node22`.
+
+Before publication, run `pnpm release:gate` on the final versioned public commit. It includes the
+full test and build suite, Vue generator and host acceptance, demo smoke tests, size checks, and
+packed consumer acceptance. Publication remains a separate action.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "release:version": "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
     "local:release": "pnpm build && pnpm release:version && changeset publish",
     "release:prepare": "pnpm runtime:generate:all && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
-    "release:gate": "pnpm verify:public && pnpm --filter=starwind package:check && pnpm audit:prod && pnpm demo:smoke && pnpm react-demo:smoke && pnpm vue-demo:smoke && pnpm runtime:size:check:prepared && pnpm release:candidate:acceptance",
+    "release:gate": "pnpm verify:public && pnpm runtime:generate:vue:test && pnpm test:vue-cli-host-acceptance && pnpm --filter=starwind package:check && pnpm audit:prod && pnpm demo:smoke && pnpm react-demo:smoke && pnpm vue-demo:smoke && pnpm runtime:size:check:prepared && pnpm release:candidate:acceptance",
     "release:candidate:acceptance": "node scripts/release-candidate-acceptance.mjs",
     "release:artifacts": "node scripts/check-release-artifacts.mjs",
     "publish:release:dry-run": "pnpm release:artifacts && node scripts/release-packages.mjs --dry-run",
@@ -147,7 +147,9 @@
     "vue:link": "pnpm --dir packages/vue add --global . --ignore-scripts",
     "vue:unlink": "pnpm unlink:global @starwind-ui/vue",
     "unlink:global": "node -e \"const { spawnSync } = require(\\\"node:child_process\\\"); const command = process.platform === \\\"win32\\\" ? \\\"pnpm.cmd\\\" : \\\"pnpm\\\"; const name = process.argv[1]; const listed = spawnSync(command, [\\\"list\\\", \\\"--global\\\", \\\"--depth\\\", \\\"-1\\\", \\\"--json\\\"], { encoding: \\\"utf8\\\" }); if (listed.status !== 0) { process.stderr.write(listed.stderr); process.exitCode = listed.status ?? 1; } else { const dependencies = JSON.parse(listed.stdout)[0]?.dependencies ?? {}; if (dependencies[name]) { const removed = spawnSync(command, [\\\"rm\\\", \\\"--global\\\", name], { stdio: \\\"inherit\\\" }); process.exitCode = removed.status ?? 1; } }\"",
-    "test:vue-cli-local-link": "pnpm exec tsx --tsconfig packages/cli/tsconfig.json scripts/vue-cli-host-acceptance.mjs --local-link-only"
+    "test:vue-cli-local-link": "pnpm exec tsx --tsconfig packages/cli/tsconfig.json scripts/vue-cli-host-acceptance.mjs --local-link-only",
+    "runtime:generate:test:ci": "pnpm exec vitest run --project=portable-runtime scripts/portable-runtime/tests/runtime-adapter-contract.test.ts scripts/portable-runtime/tests/styled-adapter-contract.test.ts scripts/portable-runtime/tests/framework-surface-manifest.test.mjs scripts/portable-runtime/tests/primitive-generator-registry.test.ts scripts/portable-runtime/tests/generate-cli-registry.test.ts scripts/portable-runtime/tests/framework-adapters.test.ts",
+    "vue:test:browser:ci": "pnpm exec vitest run --config packages/vue/tests/checkbox/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/dialog/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/select/vitest.config.ts --project=browser"
   },
   "dependencies": {
     "turbo": "^2.5.4"

--- a/scripts/tests/node22-public-consumer-smoke.test.ts
+++ b/scripts/tests/node22-public-consumer-smoke.test.ts
@@ -1,11 +1,10 @@
-import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import {
-  assertPackedPackageProvenance,
   assertExactNodeVersion,
+  assertPackedPackageProvenance,
   createNodeFloorPlan,
   getJavaScriptTypecheckConfig,
   getPackedProjectDependencies,
@@ -177,18 +176,5 @@ describe("Node 22 public consumer smoke", () => {
       compilerOptions: { allowJs: true, checkJs: true, noEmit: true },
       include: expect.arrayContaining(["src/**/*.jsx", "src/**/*.tsx"]),
     });
-  });
-
-  it("runs as one focused exact-Node workflow without the full candidate matrix", async () => {
-    const workflow = await readFile(".github/workflows/verify.yml", "utf8");
-    const jobStart = workflow.indexOf("  node22-public-consumer:");
-    const nextJob = workflow.indexOf("\n  windows-packed-cli:", jobStart);
-    const job = workflow.slice(jobStart, nextJob);
-
-    expect(job).toContain("node-version: 22.12.0");
-    expect(job).toContain("pnpm release:pack:public-artifacts");
-    expect(job).toContain("npm run release:consumer:node22");
-    expect(job.slice(job.indexOf("Setup exact public Node floor"))).not.toContain("cache: pnpm");
-    expect(job).not.toContain("release:candidate:acceptance");
   });
 });

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -357,6 +357,8 @@ describe("release package tooling", () => {
     expect(root.scripts?.["publish:beta"]).toBe("pnpm publish:release");
     expect(commandPhases(root.scripts?.["release:gate"])).toEqual([
       "pnpm verify:public",
+      "pnpm runtime:generate:vue:test",
+      "pnpm test:vue-cli-host-acceptance",
       "pnpm --filter=starwind package:check",
       "pnpm audit:prod",
       "pnpm demo:smoke",

--- a/scripts/tests/root-verification-scripts.test.ts
+++ b/scripts/tests/root-verification-scripts.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -154,6 +155,8 @@ describe("root verification scripts", () => {
 
     expect(commandPhases(pkg.scripts?.["release:gate"])).toEqual([
       "pnpm verify:public",
+      "pnpm runtime:generate:vue:test",
+      "pnpm test:vue-cli-host-acceptance",
       "pnpm --filter=starwind package:check",
       "pnpm audit:prod",
       "pnpm demo:smoke",
@@ -171,20 +174,16 @@ describe("root verification scripts", () => {
     expect(pkg.scripts?.["publish:release"]).toBe("node scripts/release-packages.mjs --publish");
   });
 
-  it("runs public Vue and private Svelte checks in their intended scopes", async () => {
-    const [verifyWorkflowSource, releaseWorkflowSource] = await Promise.all([
-      readFile(".github/workflows/verify.yml", "utf8"),
-      readFile(".github/workflows/release.yml", "utf8"),
-    ]);
-    const verifyWorkflow = parse(verifyWorkflowSource) as Workflow;
-    const releaseWorkflow = parse(releaseWorkflowSource) as Workflow;
-    const verifyRuns = Object.values(verifyWorkflow.jobs).flatMap(
-      ({ steps = [] }) => steps.map(({ run }) => run).filter(Boolean) as string[],
-    );
+  it("keeps CI focused and checks every shipping adapter", async () => {
+    const source = await readFile(".github/workflows/verify.yml", "utf8");
+    const workflow = parse(source) as Workflow;
+    const pkg = await readRootPackage();
+    const jobs = Object.values(workflow.jobs);
+    const runs = jobs.flatMap(({ steps = [] }) => steps.flatMap(({ run }) => (run ? [run] : [])));
 
-    expect(verifyWorkflow.on).toMatchObject({
+    expect(workflow.on).toMatchObject({
       pull_request: null,
-      workflow_call: { inputs: { private_adapters: { default: false, type: "boolean" } } },
+      workflow_call: null,
       workflow_dispatch: {
         inputs: {
           base_sha: { required: true, type: "string" },
@@ -192,226 +191,102 @@ describe("root verification scripts", () => {
         },
       },
     });
-    expect(verifyWorkflow.permissions).toEqual({ contents: "read" });
-    expect(Object.keys(verifyWorkflow.jobs)).toEqual(
-      expect.arrayContaining([
-        "scope",
-        "static",
-        "node-tests",
-        "generator-tests",
-        "browser-adapter-tests",
-        "svelte-tests",
-        "vue-tests",
-        "build-drift",
-        "verify",
-      ]),
-    );
-    expect(verifyWorkflow.jobs["vue-tests"]).toMatchObject({
-      if: expect.not.stringContaining("inputs.private_adapters"),
-      needs: "scope",
-    });
-    expect(verifyWorkflow.jobs["vue-tests"].if).toContain("needs.scope.outputs.vue == 'true'");
-    expect(verifyWorkflow.jobs["vue-tests"].steps).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ run: "pnpm vue:verify" }),
-        expect.objectContaining({ run: "pnpm test:vue-cli-host-acceptance" }),
-      ]),
-    );
-    const scopeStep = verifyWorkflow.jobs.scope.steps?.find((step) => step.id === "changes");
-    const vueScopePattern = scopeStep?.env?.VUE_SCOPE_PATTERN;
-    expect(vueScopePattern).toBeDefined();
-    const matchesVueScope = (file: string): boolean => new RegExp(vueScopePattern!).test(file);
-    for (const file of [
-      "apps/vue-demo/src/App.vue",
-      "packages/vue/src/index.ts",
-      "packages/runtime/src/index.ts",
-      "packages/cli/registry/styled-components.json",
-      "packages/cli/src/registry/bundled-registry.json",
-      "packages/cli/src/commands/init.ts",
-      "packages/cli/tests/commands/init.test.ts",
-      "packages/cli/package.json",
-      "packages/cli/tsup.config.ts",
-      "scripts/portable-runtime/contracts/primitive/components/dialog.ts",
-      "scripts/portable-runtime/contracts/styled/components/dialog.ts",
-      "scripts/portable-runtime/renderers/shared.ts",
-      "scripts/portable-runtime/renderers/generic-adapter-plan/index.ts",
-      "scripts/portable-runtime/renderers/framework-adapters/vue/renderer.ts",
-      "scripts/portable-runtime/renderers/framework-adapters/target-definition.ts",
-      "scripts/portable-runtime/generate-cli-registry.ts",
-      "scripts/release-candidate-acceptance.mjs",
-      "scripts/tests/root-verification-scripts.test.ts",
-      ".github/workflows/verify.yml",
-      "package.json",
-      "turbo.json",
-    ]) {
-      expect(matchesVueScope(file), file).toBe(true);
-    }
-    expect(matchesVueScope("docs/product/positioning.md")).toBe(false);
-    expect(
-      matchesVueScope("scripts/portable-runtime/renderers/framework-adapters/svelte/renderer.ts"),
-    ).toBe(false);
-    expect(verifyWorkflow.jobs["svelte-tests"]).toMatchObject({
-      if: expect.stringContaining("inputs.private_adapters"),
-      needs: "scope",
-    });
-    expect(verifyWorkflow.jobs["svelte-tests"].if).toContain(
-      "needs.scope.outputs.svelte == 'true'",
-    );
-    const shouldRunSvelte = new Function(
-      "github",
-      "inputs",
-      "needs",
-      `return (${verifyWorkflow.jobs["svelte-tests"].if});`,
-    );
-    for (const isPrivate of [false, true]) {
-      expect(
-        shouldRunSvelte(
-          {
-            event: { repository: { private: isPrivate } },
-            event_name: "pull_request",
-            head_ref: "runtime",
-          },
-          { private_adapters: false },
-          { scope: { outputs: { svelte: "true" } } },
-        ),
-      ).toBe(isPrivate);
-    }
-    expect(verifyWorkflowSource).not.toMatch(/packages\/\(runtime\|svelte\)/u);
-    expect(verifyWorkflowSource).toContain("packages/svelte/");
-    expect(verifyWorkflow.jobs["windows-packed-cli"]).toMatchObject({
-      if: "needs.scope.outputs.windows == 'true'",
-      needs: "scope",
-    });
-    expect(verifyWorkflow.jobs["node22-public-consumer"]).toMatchObject({
-      if: "needs.scope.outputs.node22 == 'true'",
-      needs: "scope",
-    });
-    expect(verifyWorkflow.jobs["generator-tests"].steps).toEqual(
+    expect(workflow.permissions).toEqual({ contents: "read" });
+    expect(workflow.jobs.static.steps).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: "Install Playwright Chromium",
-          run: "pnpm exec playwright install --with-deps chromium",
+          if: "github.event_name == 'workflow_dispatch'",
+          env: { EXPECTED_HEAD_SHA: "${{ inputs.expected_head_sha }}" },
+          run: 'test "$GITHUB_SHA" = "$EXPECTED_HEAD_SHA"',
         }),
       ]),
     );
-    for (const job of Object.values(verifyWorkflow.jobs)) {
+    expect(runs).toEqual(
+      expect.arrayContaining([
+        "pnpm check && pnpm test:homes && pnpm runtime:generate:typecheck",
+        "pnpm test:node && pnpm runtime:test:unit && pnpm react:test:ssr && pnpm --filter=@starwind-ui/vue test:run",
+        "pnpm runtime:generate:test:ci",
+        "pnpm runtime:test:browser && pnpm react:test:browser && pnpm vue:test:browser:ci",
+        "pnpm runtime:generate:all && pnpm runtime:registry:generate",
+        "pnpm exec turbo build --filter=@starwind-ui/runtime --filter=@starwind-ui/react --filter=@starwind-ui/vue --filter=starwind",
+        "git diff --exit-code",
+        "pnpm --filter=starwind package:check",
+        'pnpm styled:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
+        'pnpm primitive:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
+      ]),
+    );
+    expect(runs.join("\n")).not.toMatch(
+      /pnpm (?:vue:verify|vue:test(?:\s|$)|svelte:verify|build(?:\s|$)|runtime:size:|runtime:perf:|test:vue-cli-host-acceptance|test:windows-packed-cli|release:consumer:node22)/,
+    );
+    expect(pkg.scripts?.["runtime:generate:test:ci"]).toContain("generate-cli-registry.test.ts");
+    expect(pkg.scripts?.["runtime:generate:test:ci"]).toContain("runtime-adapter-contract.test.ts");
+    expect(pkg.scripts?.["runtime:generate:test"]).toBe("vitest run --project=portable-runtime");
+    for (const component of ["checkbox", "dialog", "select"]) {
+      expect(pkg.scripts?.["vue:test:browser:ci"]).toContain(
+        `packages/vue/tests/${component}/vitest.config.ts --project=browser`,
+      );
+    }
+    for (const job of jobs) {
       for (const value of Object.values(job.env ?? {})) {
         expect(value).not.toMatch(/\$\{\{[^}]*\brunner\./);
       }
     }
-    expect(verifyWorkflow.jobs["build-drift"]).toMatchObject({
-      steps: expect.arrayContaining([
-        expect.objectContaining({
-          name: "Check CLI package size",
-          run: "pnpm --filter=starwind package:check",
-        }),
-        expect.objectContaining({
-          name: "Check prepared Astro demo bundles",
-          run: "node scripts/portable-runtime/assert-astro-demo-bundles.mjs",
-        }),
-        expect.objectContaining({
-          if: "github.event.repository.private",
-          name: "Validate saved Vue performance evidence",
-          run: "pnpm runtime:perf:vue:evidence:check",
-        }),
-        expect.objectContaining({
-          name: "Check prepared package sizes",
-          env: {
-            STARWIND_MEASUREMENT_TMP_ROOT: "${{ runner.temp }}/starwind-measurements",
-          },
-          run: "pnpm runtime:size:check:prepared",
-        }),
-        expect.objectContaining({
-          if: "failure()",
-          name: "Upload package-size failure diagnostics",
-          uses: "actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f",
-          with: expect.objectContaining({
-            "if-no-files-found": "ignore",
-            path: expect.stringContaining("starwind-package-size-comparison/run-*/raw-evidence"),
-          }),
-        }),
-      ]),
-    });
-    const browserInstallSteps = Object.values(verifyWorkflow.jobs).flatMap(({ steps = [] }) =>
-      steps.filter(({ name }) => name === "Install Playwright Chromium"),
-    );
-    expect(browserInstallSteps).toHaveLength(4);
-    for (const step of browserInstallSteps) {
-      expect(step.run).toBe("pnpm exec playwright install --with-deps chromium");
-    }
-    expect(verifyWorkflow.jobs.verify).toMatchObject({
-      name: "Verify",
-      needs: expect.arrayContaining([
-        "static",
-        "node-tests",
-        "generator-tests",
-        "browser-adapter-tests",
-        "svelte-tests",
-        "vue-tests",
-        "build-drift",
-      ]),
-    });
-    expect(verifyRuns).toEqual(
-      expect.arrayContaining([
-        "pnpm test:node && pnpm runtime:test:unit && pnpm react:test:ssr",
-        "pnpm runtime:generate:test && pnpm runtime:generate:typecheck",
-        "pnpm runtime:test:browser && pnpm react:test:browser",
-        "pnpm svelte:verify",
-        "pnpm runtime:generate:all && pnpm runtime:registry:generate",
-        "git diff --exit-code",
-      ]),
-    );
-    expect(verifyRuns).toContain(
-      'pnpm styled:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
-    );
-    expect(verifyRuns).toContain(
-      'pnpm primitive:versions:check --base "${{ inputs.base_sha || github.event.pull_request.base.sha }}"',
-    );
-    expect(
-      verifyRuns.filter((command) => command.includes("pnpm runtime:generate:test")),
-    ).toHaveLength(1);
-    expect(
-      verifyRuns.filter((command) => /(?:^|[\s;&])pnpm\s+audit(?::prod)?(?:\s|$)/u.test(command)),
-    ).toEqual([]);
-    expect(verifyWorkflowSource).toContain(`needs.windows-packed-cli.result }}" != "skipped"`);
-    expect(verifyWorkflowSource).toContain(`needs.node22-public-consumer.result }}" != "skipped"`);
-
-    expect(verifyWorkflow.concurrency).toMatchObject({
+    expect(workflow.concurrency).toMatchObject({
       "cancel-in-progress": "${{ github.event_name == 'pull_request' }}",
     });
-    expect(releaseWorkflow.concurrency).toMatchObject({ "cancel-in-progress": true });
-    expect(releaseWorkflow.jobs.verify).toMatchObject({
+  });
+
+  it("fails Verify when any required job fails, skips, or is cancelled", async () => {
+    const workflow = parse(await readFile(".github/workflows/verify.yml", "utf8")) as Workflow;
+    const gate = workflow.jobs.verify;
+    const requiredJobs = Object.keys(workflow.jobs).filter((name) => name !== "verify");
+    expect(gate.name).toBe("Verify");
+    expect(gate.if).toBe("always()");
+    expect(gate.needs).toEqual(requiredJobs);
+    const step = gate.steps?.find(({ name }) => name === "Require every verification gate");
+    expect(step?.env).toEqual({ CHECK_RESULTS: "${{ join(needs.*.result, ',') }}" });
+    const gateScript = step?.run?.match(/^node -e "(.*)"$/)?.[1];
+    expect(gateScript).toBeDefined();
+    const check = (results: string[]) =>
+      spawnSync(process.execPath, ["-e", gateScript!], {
+        env: { ...process.env, CHECK_RESULTS: results.join(",") },
+      }).status;
+    const success = requiredJobs.map(() => "success");
+    expect(check(success)).toBe(0);
+    for (let index = 0; index < requiredJobs.length; index += 1) {
+      for (const result of ["failure", "cancelled", "skipped"]) {
+        const results = [...success];
+        results[index] = result;
+        expect(check(results)).not.toBe(0);
+      }
+    }
+  });
+
+  it("preserves exact-head release verification and the publication boundary", async () => {
+    const source = await readFile(".github/workflows/release.yml", "utf8");
+    const workflow = parse(source) as Workflow;
+    expect(workflow.concurrency).toMatchObject({ "cancel-in-progress": true });
+    expect(workflow.jobs.verify).toMatchObject({
       if: "needs.scope.outputs.versioned == 'true'",
       needs: "scope",
       uses: "./.github/workflows/verify.yml",
-      with: { private_adapters: false },
     });
-    expect(releaseWorkflow.jobs.release).toMatchObject({
-      name: "Release",
-      needs: ["scope", "verify"],
-    });
-    expect(releaseWorkflow.jobs.release.steps).toEqual(
+    expect(workflow.jobs.release.needs).toEqual(["scope", "verify"]);
+    expect(workflow.jobs.release.steps).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           run: "pnpm styled:versions:stage && pnpm primitive:versions:stage",
         }),
-        expect.objectContaining({
-          id: "changesets",
-          name: "Create Release Pull Request",
-        }),
+        expect.objectContaining({ id: "changesets", name: "Create Release Pull Request" }),
         expect.objectContaining({
           if: "steps.changesets.outputs.pullRequestNumber != ''",
           name: "Verify Release Pull Request",
-          run: expect.stringContaining("gh workflow run verify.yml"),
+          run: expect.stringContaining('--field expected_head_sha="$HEAD_SHA"'),
         }),
       ]),
     );
-    expect(releaseWorkflowSource).toContain("commitMode: github-api");
-    expect(releaseWorkflow.jobs.release.permissions).toEqual({
-      actions: "write",
-      contents: "write",
-      "pull-requests": "write",
-    });
-    expect(releaseWorkflowSource).toContain("version: pnpm release:version");
+    expect(source).toContain("commitMode: github-api");
+    expect(source).toContain("version: pnpm release:version");
+    expect(source).not.toMatch(/pnpm (?:publish|release:gate)/);
   });
 });


### PR DESCRIPTION
Routine CI spent 7m33s on Vue verification in the previous run, including 3m03s installing and testing consumer projects. This change targets about three minutes, excluding GitHub queue time, with four concurrent jobs and the final Verify gate.

CI keeps static and release-intent checks, repository and CLI tests, Runtime unit/browser tests, React SSR/browser tests, all Vue source SSR, and focused Vue Checkbox/Dialog/Select browser tests. Six contract and registry suites cover generator interfaces. Full adapter/registry regeneration still rejects stale output, and shipping packages still build.

Full generator proofs, the complete Vue browser and hydration matrix, demo builds and smoke tests, size comparisons, consumer installation matrices, and platform checks remain local commands. The local release gate now also includes the full Vue generator suite and Vue host acceptance. CONTRIBUTING maps these commands to changed areas.

Exact-head release dispatch remains checked. Verify fails if any of its four jobs fails, is cancelled, or is skipped. Work jobs have five-minute timeouts to stop stalled runs.

Validation:

- Repository-script suite: 215 passed, 2 skipped.
- Focused Vue source SSR: 97 tests passed across 46 files.
- Focused Vue browser suites: 22 tests passed.
- Contract and registry suites: 155 tests passed across six files.
- Shipping package build: all four packages passed.
- Workflow/sync tests, focused public policy tests, Prettier, Biome, locked installation, and Git whitespace checks passed.
- Guarded public sync reports zero drift.
- [The first focused CI run](https://github.com/starwind-ui/starwind-ui/actions/runs/34043725894) passed in 2m43s, compared with 7m47s for the preceding full run. Total job time fell from 24m00s to 7m55s. These durations run from the first job start through the final Verify completion.

This changes verification policy and contributor guidance. Package behavior, versions, and pending release intent stay unchanged.
