### PR TITLE
fix(release): keep recurring Vue updates on beta

### DIFF
--- a/docs/portable-runtime/beta-release.md
+++ b/docs/portable-runtime/beta-release.md
@@ -1,10 +1,11 @@
-# Runtime Prerelease Guide
+# Runtime Release Guide
 
-This release path covers the public package set:
+This release path plans the public package manifests:
 
 - `@starwind-ui/runtime`
 - `@starwind-ui/astro`
 - `@starwind-ui/react`
+- `@starwind-ui/vue`
 - `starwind`
 
 ## Versioning And Channels
@@ -17,7 +18,9 @@ Use numbered SemVer prereleases and publish them with the matching npm dist-tag.
 prerelease state is the source for the active channel: `beta`, `rc`, or another prerelease tag.
 Stable package versions publish with `latest` only after prerelease state has been fully consumed.
 
-Runtime, Astro, and React are versioned in lockstep. Release the CLI alongside them so generated
+Runtime, Astro, and React are versioned in lockstep. Vue has its own beta channel and always
+publishes on `beta`, including versions without a SemVer prerelease suffix. The saved plan preserves
+Vue `latest` until an approved promotion changes it. Release the CLI alongside Runtime changes so generated
 styled components and vendored Primitive sources request compatible package versions. Use
 `pnpm release:version` to consolidate deferred styled component intent, regenerate registry
 artifacts, and advance package versions; do not hand-edit prerelease versions. Before a release,
@@ -43,8 +46,10 @@ Release metadata validation rejects a stable Runtime adapter version below `1.0.
 ## Prepare, Gate, And Dry Run
 
 Start from a clean checkout of public `main`, fetch `origin/main`, and confirm that local `HEAD`
-matches the fetched branch. Record the four intended package versions, verify that each version is
-unused on npm, and inspect the existing dist-tags before publication.
+matches the fetched branch. Preview the manifest-derived selection, verify the intended versions
+against npm, and inspect existing dist-tags before publication. The normal dry-run omits exact
+versions already published. The user-run publication saves an immutable plan for prefix recovery and
+finalization before its first npm publication.
 
 Prepare the package set:
 
@@ -58,8 +63,8 @@ Run the complete release gate once against those prepared files:
 pnpm release:gate
 ```
 
-This command runs repository verification, the production dependency audit, both demo smoke tests,
-the prepared package-size check, and the ten-project candidate matrix. If the prepared files change,
+This command runs repository verification, the production dependency audit, demo smoke tests, the
+prepared package-size check, and the candidate matrix. If the prepared files change,
 prepare them again and restart the gate.
 
 After the gate passes, run the package dry-run:
@@ -68,9 +73,9 @@ After the gate passes, run the package dry-run:
 pnpm publish:release:dry-run
 ```
 
-The dry-run validates the release artifacts and runs the publisher in dry-run mode. It does not
-prepare the packages or repeat the release gate. Inspect the packed file lists, package metadata,
-dependency ranges, derived channel, and release summary before continuing.
+The dry-run validates release artifacts and runs the publisher in dry-run mode. It does not prepare
+packages or repeat the release gate. Inspect the packed file lists, package metadata, dependency
+ranges, package tags, and Vue `latest` baseline before continuing.
 
 ## Release Gate And Publication
 
@@ -122,17 +127,19 @@ run:
 pnpm publish:release
 ```
 
-The publisher derives the npm tag from Changesets state and uses `latest` only for stable versions.
-It publishes with public access in dependency order: Runtime, Astro, React, then the `starwind` CLI.
-A real publish refuses to run unless the checkout belongs to `starwind-ui/starwind-ui`, the working
-tree is clean, the current branch is `main`, and `HEAD` exactly matches the locally fetched
-`origin/main`.
+The publisher derives the normal plan from final manifests. It includes changed Runtime, Astro,
+React, Vue, and CLI packages, then omits exact versions already on npm. Before its first npm
+publication, the user-run command saves this immutable plan under
+`node_modules/.cache/starwind-release/publication-plans/<head>.json`. Vue uses `beta` and preserves
+its saved `latest` baseline. Other tags derive from the release state. A real publish refuses to run unless the checkout belongs to
+`starwind-ui/starwind-ui`, the working tree is clean, the current branch is `main`, and `HEAD`
+exactly matches the locally fetched `origin/main`.
 
-After all four exact versions and their npm dist-tags are visible, the publisher finalizes the
-release. It creates and pushes one annotated product tag from the CLI version, such as
-`v3.0.0-beta.8`. It pushes only that explicit tag ref. It then creates a GitHub Release with
-generated notes. Any SemVer prerelease becomes a GitHub prerelease and does not become the latest
-release. A stable version becomes the latest GitHub release.
+After all planned exact versions and their npm dist-tags are visible, the publisher automatically
+finalizes from the saved plan. It creates and pushes one annotated product tag, then creates a
+GitHub Release with generated notes. A plan with CLI uses `v<cli-version>`. A plan with Runtime and no CLI uses
+`runtime-v<runtime-version>`. A Vue-only plan uses `vue-v<vue-version>`, creates a GitHub
+prerelease, and sets `latest=false`. A SemVer prerelease also creates a GitHub prerelease.
 
 Finalization checks local and remote tag targets plus existing GitHub Release metadata before it
 writes anything. A retry succeeds when the tag target and release classification already match.
@@ -141,10 +148,10 @@ differs.
 
 ## Published Acceptance
 
-After publishing, query npm for all four exact versions and verify:
+After publishing, query npm for every exact version in the saved plan and verify:
 
-- the expected dist-tag points to the intended versions
-- `latest` was unchanged for a prerelease
+- the expected dist-tag points to each intended version
+- Vue `latest` matches its captured baseline
 - repository metadata and packed file lists are correct
 - Astro and React declare the intended Runtime version
 - the CLI declares compatible adapter and Runtime requirements
@@ -170,9 +177,9 @@ builds, and browser behavior checks all pass.
 
 ## Partial Publish Recovery
 
-If publishing fails, stop and query all four exact versions on npm. Continue only when the packages
-already present form a valid prefix of the intended publish order. Re-run the prepare and release
-gates, then resume from the first missing package:
+If publishing fails, stop and query every saved plan entry on npm. Continue only when packages
+already present form a valid prefix of the immutable plan. Re-run the prepare and release gates,
+then resume from the first missing package:
 
 ```bash
 node scripts/release-packages.mjs --publish --resume-from <first-missing-package>
@@ -182,13 +189,16 @@ Do not republish an existing version, unpublish a package, increment versions, o
 during recovery. If registry state is not a valid prefix, investigate and reconcile the registry
 state before making further changes.
 
-The publisher creates no tag after a partial package publish. When all four versions are present
-but tag or GitHub Release creation failed, use the idempotent recovery command:
+The legacy `--vue-beta` option is only for recovery of the frozen first `0.1.0` Vue publication. It
+does not apply to ordinary Vue beta releases or ordinary plan resume.
+
+When all planned versions are present but tag or GitHub Release creation failed, use the idempotent
+recovery command:
 
 ```bash
 pnpm release:finalize
 ```
 
-This command revalidates public `main`, all four exact npm versions, the derived dist-tag, local and
-remote tag targets, and GitHub Release metadata. It completes the missing finalization steps without
+This command revalidates public `main`, every planned exact npm version, the planned tags, local and
+remote tag targets, and GitHub Release metadata. It completes missing finalization without
 publishing an npm package again. Never force or move a release tag during recovery.

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -60,12 +60,34 @@ shared version advance even when their files stay unchanged. Their adapter npm p
 release solely because Vue changed. Changes to shared Runtime behavior still follow the fixed-group
 rules below.
 
-Vue's npm package has a separate beta version history, starting at `0.1.0` on the `beta` tag while
-preserving `latest` after the initial release. The release owner approved `latest=0.1.0` when the
-first publication had no previous `latest`; the initial release may have both tags. This exception
-does not permit later beta releases to move an existing `latest`. Component versions do not determine package beta status. Stable graduation and
-package alignment require a separate approved decision. The initial Vue release keeps all existing
-component versions and publishes CLI `3.3.0` with Vue `0.1.0`.
+Vue's npm package has a separate beta version history outside the Runtime, Astro, and React fixed
+group. A normal `pnpm publish:release:dry-run` previews a manifest-derived selection for Runtime,
+Astro, React, Vue, and CLI. A user-run `pnpm publish:release` saves that selection as an immutable
+plan before its first npm publication. A new selection omits an exact version that already exists on
+npm. Recovery reads the original saved plan and resumes only its remaining suffix.
+
+Vue entries in a normal plan always publish on `beta`, even when the Vue version has no SemVer
+prerelease suffix. Vue `latest` stays at its captured baseline until an approved promotion changes
+it. Component versions do not set the Vue package channel. Stable graduation and fixed-group
+membership require a separate approved decision. The legacy `--vue-beta` mode exists only to
+recover the frozen first `0.1.0` release; it is not an ordinary Vue release path.
+
+The first Vue publication is historical: it published Vue `0.1.0` on `beta` and set `latest` to
+`0.1.0` because no prior `latest` existed. It also published CLI `3.3.0`. Later beta publications
+must preserve the existing `latest` value.
+
+## Publication plans and GitHub releases
+
+The saved plan records package order, exact versions, tags, and the Vue `latest` baseline before the
+first npm publication. It is stored under
+`node_modules/.cache/starwind-release/publication-plans/<head>.json`. A plan can contain any changed
+subset of Runtime, Astro, React, Vue, and CLI. Svelte is private and never appears in the plan.
+
+Finalization creates one GitHub release from the same plan. A plan with a CLI package uses
+`v<cli-version>`. A plan with Runtime and no CLI uses `runtime-v<runtime-version>`. A Vue-only plan uses
+`vue-v<vue-version>`, marks the GitHub release as a prerelease, and sets `latest` to `false`.
+The publisher finalizes automatically after all plan entries publish. Use standalone
+`pnpm release:finalize` only when npm publication completed but finalization failed.
 
 Each existing Styled or vendorable Primitive has two values. `version` is the SemVer of delivered
 public behavior. `sourceVersion` is the component version from the most recent release that changed

--- a/scripts/check-release-artifacts.mjs
+++ b/scripts/check-release-artifacts.mjs
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 import { createHash } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const RELEASE_PACKAGE_DIRS = ["packages/runtime", "packages/react", "packages/cli"];
+const RELEASE_PACKAGE_DIRS = ["packages/runtime", "packages/react", "packages/vue", "packages/cli"];
 const VUE_BETA_PACKAGE_DIRS = ["packages/vue", "packages/cli"];
 const VUE_BETA_INPUTS = [
   "tsconfig.json",

--- a/scripts/release-candidate-acceptance.mjs
+++ b/scripts/release-candidate-acceptance.mjs
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { copyFile, cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import os from "node:os";
@@ -22,7 +22,6 @@ const NEXT_SCAFFOLD_VERSION = "16.3.0";
 const REACT_ROUTER_SCAFFOLD_VERSION = "8.3.0";
 const TANSTACK_CLI_VERSION = "0.70.1";
 const VITE_SCAFFOLD_VERSION = "9.1.1";
-const VUE_BETA_VERSION = "0.1.0";
 
 function fileSpecifier(file) {
   return `file:${file.replaceAll("\\", "/")}`;
@@ -126,11 +125,7 @@ export async function startCandidateRegistry(packageEntries) {
   };
 }
 
-export function getCandidateRegistryVersion(packageName, manifestVersion) {
-  return packageName === "@starwind-ui/vue" ? VUE_BETA_VERSION : manifestVersion;
-}
-
-export function getCandidateMatrix() {
+export function getCandidateMatrix({ vueAdapterVersion } = {}) {
   return [
     {
       framework: "astro",
@@ -161,7 +156,7 @@ export function getCandidateMatrix() {
       packageManager: "pnpm",
     },
     {
-      adapterVersion: VUE_BETA_VERSION,
+      ...(vueAdapterVersion ? { adapterVersion: vueAdapterVersion } : {}),
       framework: "vue",
       frameworkVersion: "3.5.39",
       host: "vite",
@@ -313,9 +308,13 @@ function getScaffoldArgs(entry) {
   ];
 }
 
-export function createCandidatePlan({ packages, projectIds, root }) {
+export function createCandidatePlan({ packages, projectIds, root, vueAdapterVersion }) {
+  assert.ok(
+    typeof vueAdapterVersion === "string" && vueAdapterVersion.trim().length > 0,
+    "The Vue candidate adapter version is required.",
+  );
   const cliEntrypoint = path.join(root, "node_modules", "starwind", "dist", "index.js");
-  const matrix = getCandidateMatrix();
+  const matrix = getCandidateMatrix({ vueAdapterVersion });
   const selectedIds = projectIds ? new Set(projectIds) : undefined;
   if (selectedIds) {
     for (const id of selectedIds) {
@@ -616,27 +615,6 @@ async function packWorkspacePackages(packDirectory) {
   };
 
   for (const name of ["runtime", "astro", "react", "vue", "cli"]) {
-    if (name === "vue") {
-      const sourceDirectory = path.join(REPO_ROOT, packageDirectories.vue);
-      const stageDirectory = path.join(packDirectory, "vue-package");
-      const manifest = JSON.parse(await readFile(path.join(sourceDirectory, "package.json")));
-      manifest.version = VUE_BETA_VERSION;
-      await mkdir(stageDirectory, { recursive: true });
-      await cp(path.join(sourceDirectory, "dist"), path.join(stageDirectory, "dist"), {
-        recursive: true,
-      });
-      await copyFile(path.join(REPO_ROOT, "LICENSE"), path.join(stageDirectory, "LICENSE"));
-      await copyFile(
-        path.join(sourceDirectory, "README.md"),
-        path.join(stageDirectory, "README.md"),
-      );
-      await writeFile(
-        path.join(stageDirectory, "package.json"),
-        `${JSON.stringify(manifest, null, 2)}\n`,
-      );
-      await runCommand({ args: ["pack", "--out", packages.vue], cwd: stageDirectory });
-      continue;
-    }
     await runCommand({
       args: ["pack", "--out", packages[name]],
       cwd: path.join(REPO_ROOT, packageDirectories[name]),
@@ -662,7 +640,7 @@ async function getCandidateRegistryPackages(packages) {
       file: packages[name],
       manifest,
       name: manifest.name,
-      version: getCandidateRegistryVersion(manifest.name, manifest.version),
+      version: manifest.version,
     };
   }
   return entries;
@@ -766,7 +744,13 @@ export async function runReleaseCandidateAcceptance({
     ? path.resolve(artifactsOption)
     : await mkdtemp(path.join(os.tmpdir(), "starwind-release-candidate-artifacts-"));
   const packages = await packWorkspacePackages(path.join(root, "packs"));
-  const plan = createCandidatePlan({ packages, projectIds, root });
+  const registryPackages = await getCandidateRegistryPackages(packages);
+  const plan = createCandidatePlan({
+    packages,
+    projectIds,
+    root,
+    vueAdapterVersion: registryPackages.vue.version,
+  });
   let browser;
   let registry;
 
@@ -781,7 +765,7 @@ export async function runReleaseCandidateAcceptance({
   console.log(`[candidate] diagnostic artifacts: ${artifacts}`);
 
   try {
-    registry = await startCandidateRegistry(await getCandidateRegistryPackages(packages));
+    registry = await startCandidateRegistry(registryPackages);
     for (const project of plan.projects) {
       await runCommand(project.scaffold);
       await prepareProjectManifest(project);

--- a/scripts/release-finalization.mjs
+++ b/scripts/release-finalization.mjs
@@ -6,10 +6,11 @@ import { fileURLToPath } from "node:url";
 import { createSpawnCommand } from "./command-process.mjs";
 import {
   assertPublicMainForPublish,
-  assertReleaseMetadata,
+  assertRoutineReleaseMetadata,
   assertVueBetaReleaseMetadata,
   loadVueBetaRegistryBaseline,
 } from "./release-packages.mjs";
+import { loadPublicationPlan } from "./release-publication-plan.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
@@ -68,14 +69,18 @@ export function deriveReleaseIdentity(packageManifests, npmTag, head) {
     tag: entry.tag ?? npmTag,
     version: manifest.version,
   }));
-  const cli = packages.find((entry) => entry.name === "starwind");
-  if (!cli?.version) throw new Error("The starwind package must have an exact version.");
+  const anchor =
+    packages.find((entry) => entry.name === "starwind") ??
+    packages.find((entry) => entry.name === "@starwind-ui/runtime") ??
+    packages[0];
+  if (!anchor?.version) throw new Error("Release finalization requires a versioned package.");
+  const prefix = anchor.name === "starwind" ? "" : `${anchor.name.replace("@starwind-ui/", "")}-`;
   return {
     head,
     npmTag,
     packages,
-    prerelease: cli.version.includes("-"),
-    tagName: `v${cli.version}`,
+    prerelease: anchor.tag !== "latest" || anchor.version.includes("-"),
+    tagName: `${prefix}v${anchor.version}`,
   };
 }
 
@@ -237,7 +242,7 @@ function isMissingRelease(result) {
   return result.code === 1 && /(?:not found|release not found|HTTP 404)/i.test(result.stderr);
 }
 
-export async function finalizeVerifiedRelease(release, system) {
+export async function assertReleaseIdentityAvailable(release, system) {
   if (!release.head) throw new Error("Release finalization requires the validated release commit.");
   const tagRef = `refs/tags/${release.tagName}`;
   const peeledTagRef = `${tagRef}^{}`;
@@ -311,6 +316,15 @@ export async function finalizeVerifiedRelease(release, system) {
     }
   }
 
+  return { githubRelease, localSha, remoteSha, repairLatest };
+}
+
+export async function finalizeVerifiedRelease(release, system) {
+  const { githubRelease, localSha, remoteSha, repairLatest } = await assertReleaseIdentityAvailable(
+    release,
+    system,
+  );
+  const tagRef = `refs/tags/${release.tagName}`;
   if (!localSha) {
     await system.run("git", [
       "tag",
@@ -340,7 +354,8 @@ export async function finalizeVerifiedRelease(release, system) {
 
 export async function runReleaseFinalization({
   gitStateLoader = assertPublicMainForPublish,
-  metadataLoader = assertReleaseMetadata,
+  metadataLoader = assertRoutineReleaseMetadata,
+  publicationPlanLoader = loadPublicationPlan,
   registryVerificationOptions,
   system = createCommandSystem(),
   vueBeta = false,
@@ -350,10 +365,23 @@ export async function runReleaseFinalization({
   const loadedMetadata = vueBeta ? await vueBetaMetadataLoader() : await metadataLoader();
   const { packageManifests, tag } = loadedMetadata;
   const { head } = await gitStateLoader();
-  const release = deriveReleaseIdentity(packageManifests, tag, head);
+  let selectedManifests = packageManifests;
+  let baseline;
   if (vueBeta) {
-    const baseline = await vueLatestBaselineLoader({ head });
+    baseline = await vueLatestBaselineLoader({ head });
+  } else {
+    baseline = await publicationPlanLoader({ head, packageManifests, tag });
+    selectedManifests = baseline.packages.map((selected) => {
+      const item = packageManifests.find(({ entry }) => entry.name === selected.name);
+      return { ...item, entry: { ...item.entry, tag: selected.tag } };
+    });
+    if (selectedManifests.length === 0) return undefined;
+  }
+  const release = deriveReleaseIdentity(selectedManifests, tag, head);
+  if (vueBeta) {
     release.finalizeCommand = "pnpm release:vue-beta:finalize";
+  }
+  if (release.packages.some((entry) => entry.name === "@starwind-ui/vue" && entry.tag === "beta")) {
     release.preservedDistTags = {
       "@starwind-ui/vue": { latest: baseline.vueLatest },
     };
@@ -369,7 +397,9 @@ async function main() {
     throw new Error("release:finalize accepts only the optional --vue-beta plan selector.");
   }
   const release = await runReleaseFinalization({ vueBeta: args[0] === "--vue-beta" });
-  console.log(`Release ${release.tagName} is finalized.`);
+  console.log(
+    release ? `Release ${release.tagName} is finalized.` : "No packages need finalization.",
+  );
 }
 
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -3,11 +3,14 @@ import { spawn } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { valid as validSemver } from "semver";
 
 import { createSpawnCommand } from "./command-process.mjs";
+import { preparePublicationPlan } from "./release-publication-plan.mjs";
 import {
   CHANGESET_IGNORED_PACKAGES,
   CHANGESET_PRIVATE_PACKAGE_POLICY,
+  ROUTINE_RELEASE_PACKAGE_SET,
   RUNTIME_FIXED_GROUP,
   RUNTIME_RELEASE_PACKAGE_SET,
 } from "./runtime-release-policy.mjs";
@@ -423,6 +426,56 @@ export async function assertReleaseMetadata() {
   return { packageManifests, tag: results[0].tag };
 }
 
+export function validateRoutineReleaseMetadata({ packageManifests, preState, config }) {
+  const baseManifests = packageManifests.filter(({ entry }) =>
+    RELEASE_PACKAGE_SET.some(({ name }) => name === entry.name),
+  );
+  const baseResult = validateReleasePackageManifests(baseManifests, preState);
+  const errors = [...baseResult.errors, ...validateReleaseChangesetConfig(config).errors];
+  if (
+    JSON.stringify(packageManifests.map(({ entry }) => entry.name)) !==
+    JSON.stringify(ROUTINE_RELEASE_PACKAGE_SET.map(({ name }) => name))
+  ) {
+    errors.push("Routine releases must include the complete ordered public package inventory.");
+  }
+  if (JSON.stringify(config?.fixed) !== JSON.stringify([RUNTIME_FIXED_GROUP])) {
+    errors.push("Vue must remain outside the Runtime, Astro, and React Changesets fixed group.");
+  }
+  const vue = packageManifests.find(({ entry }) => entry.name === "@starwind-ui/vue");
+  const runtime = baseManifests.find(({ entry }) => entry.name === "@starwind-ui/runtime");
+  if (vue?.manifest.name !== "@starwind-ui/vue" || vue?.manifest.private === true) {
+    errors.push("@starwind-ui/vue must be a public package for routine publication.");
+  }
+  if (
+    !parseVersion(vue?.manifest.version) ||
+    validSemver(vue?.manifest.version) !== vue?.manifest.version
+  ) {
+    errors.push("@starwind-ui/vue must use an exact SemVer version.");
+  }
+  if (
+    vue?.entry.tag !==
+    ROUTINE_RELEASE_PACKAGE_SET.find(({ name }) => name === "@starwind-ui/vue").tag
+  ) {
+    errors.push("@starwind-ui/vue must use its explicit release-policy tag.");
+  }
+  if (vue?.manifest.dependencies?.["@starwind-ui/runtime"] !== runtime?.manifest.version) {
+    errors.push("@starwind-ui/vue must depend on the exact current @starwind-ui/runtime version.");
+  }
+  return { errors, ok: errors.length === 0, tag: baseResult.tag };
+}
+
+export async function assertRoutineReleaseMetadata() {
+  const [packageManifests, preState, config] = await Promise.all([
+    Promise.all(ROUTINE_RELEASE_PACKAGE_SET.map(readPackageManifest)),
+    readPrereleaseState(),
+    readFile(path.join(ROOT_DIR, ".changeset", "config.json"), "utf8").then(JSON.parse),
+  ]);
+  const result = validateRoutineReleaseMetadata({ packageManifests, preState, config });
+  if (!result.ok)
+    throw new Error(`Routine release metadata is not ready:\n${result.errors.join("\n")}`);
+  return { packageManifests, tag: result.tag };
+}
+
 export function parseArgs(argv) {
   let dryRun = false;
   let publish = false;
@@ -455,7 +508,7 @@ export function parseArgs(argv) {
 
   if (dryRun === publish) throw new Error("Pass exactly one mode: --dry-run or --publish.");
   if (dryRun && resumeFrom) throw new Error("--resume-from is available only with --publish.");
-  getResumeIndex(resumeFrom, vueBeta ? VUE_BETA_RELEASE_PLAN : RELEASE_PACKAGE_SET);
+  getResumeIndex(resumeFrom, vueBeta ? VUE_BETA_RELEASE_PLAN : ROUTINE_RELEASE_PACKAGE_SET);
   return { dryRun, otp, resumeFrom, vueBeta };
 }
 
@@ -551,31 +604,68 @@ export async function executeReleasePublication({
       packageName: publishCommand.packageName,
     });
   }
-  if (!dryRun) await finalize();
+  if (!dryRun && publishCommands.length > 0) await finalize();
 }
 
 async function main() {
   const { dryRun, otp, resumeFrom, vueBeta } = parseArgs(process.argv.slice(2));
-  const metadata = vueBeta ? await assertVueBetaReleaseMetadata() : await assertReleaseMetadata();
+  const metadata = vueBeta
+    ? await assertVueBetaReleaseMetadata()
+    : await assertRoutineReleaseMetadata();
   const gitState = !dryRun ? await assertPublicMainForPublish() : undefined;
+  const {
+    assertReleaseIdentityAvailable,
+    createCommandSystem,
+    deriveReleaseIdentity,
+    runReleaseFinalization,
+  } = await import("./release-finalization.mjs");
+  let releasePlan = VUE_BETA_RELEASE_PLAN;
   if (vueBeta && gitState) {
     await captureVueBetaRegistryBaseline({ head: gitState.head, resumeFrom });
   }
-  if (vueBeta) {
+  if (!vueBeta) {
+    const head = gitState?.head ?? (await readGitOutput(["rev-parse", "HEAD"]));
+    const system = createCommandSystem();
+    const plan = await preparePublicationPlan({
+      head,
+      packageManifests: metadata.packageManifests,
+      tag: metadata.tag,
+      registry: system,
+      dryRun,
+      resumeFrom,
+    });
+    if (plan.packages.length === 0) {
+      console.log(
+        "[publish-plan] All current package versions already exist on npm; nothing to publish.",
+      );
+      return;
+    }
+    const selected = metadata.packageManifests
+      .filter(({ entry }) => plan.packages.some(({ name }) => name === entry.name))
+      .map(({ entry, manifest }) => ({
+        entry: { ...entry, tag: plan.packages.find(({ name }) => name === entry.name).tag },
+        manifest,
+      }));
+    if (!dryRun) {
+      await assertReleaseIdentityAvailable(
+        deriveReleaseIdentity(selected, metadata.tag, head),
+        system,
+      );
+    }
+    releasePlan = selected.map(({ entry }) => entry);
+    console.log("[publish-plan] Routine release order:");
+    for (const target of formatPublishPlan(selected)) console.log(`- ${target}`);
+  } else {
     console.log("[publish-plan] Approved Vue beta release order:");
     for (const target of formatPublishPlan(metadata.packageManifests)) console.log(`- ${target}`);
   }
-  const finalize = async () => {
-    const { runReleaseFinalization } = await import("./release-finalization.mjs");
-    await runReleaseFinalization({ vueBeta });
-  };
   await executeReleasePublication({
     dryRun,
-    finalize,
+    finalize: () => runReleaseFinalization({ vueBeta }),
     publishCommands: createPublishCommands({
       dryRun,
       otp,
-      releasePlan: vueBeta ? VUE_BETA_RELEASE_PLAN : RELEASE_PACKAGE_SET,
+      releasePlan,
       resumeFrom,
       tag: metadata.tag,
     }),

--- a/scripts/release-publication-plan.mjs
+++ b/scripts/release-publication-plan.mjs
@@ -1,0 +1,171 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = fileURLToPath(new URL("..", import.meta.url));
+const PLAN_DIRECTORY = "node_modules/.cache/starwind-release/publication-plans";
+const VUE_PACKAGE = "@starwind-ui/vue";
+
+function planFile(repoRoot, head) {
+  if (typeof head !== "string" || !head || head === "." || head === "..") {
+    throw new Error("Publication planning requires an exact release commit.");
+  }
+  return path.join(repoRoot, PLAN_DIRECTORY, `${encodeURIComponent(head)}.json`);
+}
+
+function createSnapshot(packageManifests, tag) {
+  return packageManifests.map(({ entry, manifest }) => ({
+    name: entry.name,
+    version: manifest.version,
+    tag: entry.tag ?? tag,
+  }));
+}
+
+function validatePlan(plan, head, snapshot) {
+  if (plan?.head !== head || JSON.stringify(plan.snapshot) !== JSON.stringify(snapshot)) {
+    throw new Error("The publication plan does not match this release commit and snapshot.");
+  }
+  if (plan.vueLatest !== null && typeof plan.vueLatest !== "string") {
+    throw new Error("The publication plan contains an invalid Vue latest baseline.");
+  }
+  let previousIndex = -1;
+  if (!Array.isArray(plan.packages)) {
+    throw new Error("The publication plan packages must be an ordered subset of its snapshot.");
+  }
+  for (const entry of plan.packages) {
+    const index = snapshot.findIndex(
+      (candidate) => JSON.stringify(candidate) === JSON.stringify(entry),
+    );
+    if (index <= previousIndex) {
+      throw new Error("The publication plan packages must be an ordered subset of its snapshot.");
+    }
+    previousIndex = index;
+  }
+  return plan;
+}
+
+export async function loadPublicationPlan({ head, packageManifests, tag, repoRoot = ROOT_DIR }) {
+  let plan;
+  try {
+    plan = JSON.parse(await readFile(planFile(repoRoot, head), "utf8"));
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      throw new Error("The original publication plan is missing.", { cause: error });
+    }
+    throw new Error("The original publication plan is invalid.", { cause: error });
+  }
+  return validatePlan(plan, head, createSnapshot(packageManifests, tag));
+}
+
+function isMissing(result) {
+  return /(?:\bE404\b|404 Not Found)/i.test(`${result.stderr}\n${result.stdout}`);
+}
+
+async function exactVersionExists(entry, registry) {
+  const spec = `${entry.name}@${entry.version}`;
+  const result = await registry.capture("npm", ["view", spec, "version", "--json"]);
+  if (result.code !== 0) {
+    if (isMissing(result)) return false;
+    throw new Error(`${spec} could not be checked on npm: ${result.stderr || result.stdout}`);
+  }
+  let version;
+  try {
+    version = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`${spec} returned invalid version JSON.`);
+  }
+  if (version !== entry.version) {
+    throw new Error(`${spec} resolved to unexpected version ${JSON.stringify(version)}.`);
+  }
+  return true;
+}
+
+async function readVueLatest(registry) {
+  const result = await registry.capture("npm", ["view", VUE_PACKAGE, "dist-tags", "--json"]);
+  if (result.code !== 0) {
+    if (isMissing(result)) return null;
+    throw new Error(`Vue latest could not be checked on npm: ${result.stderr || result.stdout}`);
+  }
+  let tags;
+  try {
+    tags = JSON.parse(result.stdout);
+  } catch {
+    throw new Error("Vue dist-tags returned invalid JSON.");
+  }
+  if (
+    !tags ||
+    typeof tags !== "object" ||
+    Array.isArray(tags) ||
+    (tags.latest !== undefined && typeof tags.latest !== "string")
+  ) {
+    throw new Error("Vue dist-tags returned an invalid latest baseline.");
+  }
+  return tags.latest ?? null;
+}
+
+async function validateRecovery(plan, registry, resumeFrom) {
+  let firstMissingIndex = plan.packages.length;
+  for (const [index, entry] of plan.packages.entries()) {
+    const exists = await exactVersionExists(entry, registry);
+    if (!exists && firstMissingIndex === plan.packages.length) firstMissingIndex = index;
+    if (exists && firstMissingIndex < index) {
+      throw new Error(
+        "Published packages do not form an exact prefix of the original publication plan.",
+      );
+    }
+  }
+  if (plan.packages.length && firstMissingIndex === plan.packages.length) {
+    throw new Error("All planned versions are already published. Run pnpm release:finalize.");
+  }
+  const firstMissing = plan.packages[firstMissingIndex]?.name;
+  if (resumeFrom && resumeFrom !== firstMissing) {
+    throw new Error(
+      `--resume-from must name the first missing package: ${firstMissing ?? "none"}.`,
+    );
+  }
+  if (!resumeFrom && firstMissingIndex > 0) {
+    throw new Error(`Resume the original publication with --resume-from ${firstMissing}.`);
+  }
+}
+
+export async function preparePublicationPlan({
+  head,
+  packageManifests,
+  tag,
+  registry,
+  repoRoot = ROOT_DIR,
+  dryRun = false,
+  resumeFrom,
+}) {
+  if (dryRun && resumeFrom) throw new Error("--resume-from is available only for a real publish.");
+  if (!registry?.capture)
+    throw new Error("Publication planning requires a read-only npm registry client.");
+  const file = planFile(repoRoot, head);
+  const snapshot = createSnapshot(packageManifests, tag);
+  if (!dryRun) {
+    let saved;
+    try {
+      saved = await loadPublicationPlan({ head, packageManifests, tag, repoRoot });
+    } catch (error) {
+      if (resumeFrom || error.cause?.code !== "ENOENT") throw error;
+    }
+    if (saved) {
+      await validateRecovery(saved, registry, resumeFrom);
+      return saved;
+    }
+  }
+
+  const packages = [];
+  for (const entry of snapshot) {
+    if (!(await exactVersionExists(entry, registry))) packages.push(entry);
+  }
+  const vueLatest = packages.some(({ name }) => name === VUE_PACKAGE)
+    ? await readVueLatest(registry)
+    : null;
+  const plan = { head, snapshot, packages, vueLatest };
+  if (!dryRun) {
+    await mkdir(path.dirname(file), { recursive: true });
+    await writeFile(file, `${JSON.stringify(plan, null, 2)}\n`, { encoding: "utf8", flag: "wx" });
+  }
+  return plan;
+}

--- a/scripts/runtime-release-policy.mjs
+++ b/scripts/runtime-release-policy.mjs
@@ -21,3 +21,16 @@ export const RUNTIME_RELEASE_PACKAGE_SET = Object.freeze([
   Object.freeze({ directory: "packages/react", name: "@starwind-ui/react" }),
   Object.freeze({ directory: "packages/cli", name: "starwind" }),
 ]);
+
+// Graduation requires an explicit policy change, independent of the package's SemVer.
+export const VUE_RELEASE_POLICY = Object.freeze({
+  directory: "packages/vue",
+  name: "@starwind-ui/vue",
+  tag: "beta",
+});
+
+export const ROUTINE_RELEASE_PACKAGE_SET = Object.freeze([
+  ...RUNTIME_RELEASE_PACKAGE_SET.slice(0, 3),
+  VUE_RELEASE_POLICY,
+  RUNTIME_RELEASE_PACKAGE_SET[3],
+]);

--- a/scripts/tests/check-release-artifacts.test.ts
+++ b/scripts/tests/check-release-artifacts.test.ts
@@ -23,7 +23,7 @@ describe("release artifact check", () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "starwind-release-artifacts-"));
     tempRoots.push(root);
 
-    for (const packageName of ["runtime", "react", "cli"]) {
+    for (const packageName of ["runtime", "react", "vue", "cli"]) {
       const packageRoot = path.join(root, "packages", packageName);
       await mkdir(packageRoot, { recursive: true });
       await writeFile(
@@ -41,6 +41,8 @@ describe("release artifact check", () => {
       "packages/cli/dist/index.js",
       "packages/react/dist/index.d.ts",
       "packages/react/dist/index.js",
+      "packages/vue/dist/index.d.ts",
+      "packages/vue/dist/index.js",
     ]);
   });
 

--- a/scripts/tests/release-candidate-acceptance.test.ts
+++ b/scripts/tests/release-candidate-acceptance.test.ts
@@ -7,14 +7,13 @@ import { describe, expect, it } from "vitest";
 import {
   createCandidatePlan,
   createCandidateVerificationPlan,
-  getCandidateManifestScriptCommand,
-  getCandidateRegistryVersion,
   getCandidateFixtureFiles,
+  getCandidateManifestScriptCommand,
   getCandidateMatrix,
-  startCandidateRegistry,
   getCandidateWorkspacePackage,
   getCandidateWorkspacePolicy,
   parseArgs,
+  startCandidateRegistry,
 } from "../release-candidate-acceptance.mjs";
 
 const root = path.resolve("candidate-root");
@@ -25,6 +24,7 @@ const packages = {
   runtime: path.join(root, "packs", "runtime.tgz"),
   vue: path.join(root, "packs", "vue.tgz"),
 };
+const vueAdapterVersion = "0.2.0";
 
 describe("release candidate acceptance", () => {
   it("covers supported Astro, React, and Vue versions plus each supported React host", () => {
@@ -49,7 +49,6 @@ describe("release candidate acceptance", () => {
         host: "vite",
         id: "vue-35",
         packageManager: "pnpm",
-        adapterVersion: "0.1.0",
       }),
       expect.objectContaining({
         framework: "react",
@@ -84,7 +83,7 @@ describe("release candidate acceptance", () => {
 
     expect(manifest.devDependencies.starwind).toBe(`file:${packages.cli.replaceAll("\\", "/")}`);
     const workspace = getCandidateWorkspacePolicy(
-      createCandidatePlan({ packages, root }).projects,
+      createCandidatePlan({ packages, root, vueAdapterVersion }).projects,
       packages,
     );
     expect(workspace).toContain(
@@ -104,8 +103,10 @@ describe("release candidate acceptance", () => {
     const directory = await mkdtemp(path.join(os.tmpdir(), "starwind-candidate-registry-"));
     const tarball = path.join(directory, "runtime.tgz");
     const adapterTarball = path.join(directory, "astro.tgz");
+    const vueTarball = path.join(directory, "vue.tgz");
     await writeFile(tarball, "packed runtime");
     await writeFile(adapterTarball, "packed astro adapter");
+    await writeFile(vueTarball, "packed vue adapter");
     const registry = await startCandidateRegistry({
       astro: {
         file: adapterTarball,
@@ -117,6 +118,11 @@ describe("release candidate acceptance", () => {
         file: tarball,
         name: "@starwind-ui/runtime",
         version: "0.1.0-beta.7",
+      },
+      vue: {
+        file: vueTarball,
+        name: "@starwind-ui/vue",
+        version: "0.2.0",
       },
     });
 
@@ -135,19 +141,29 @@ describe("release candidate acceptance", () => {
 
       const tarballResponse = await fetch(metadata.versions["0.1.0-beta.7"].dist.tarball);
       expect(await tarballResponse.text()).toBe("packed runtime");
+
+      const vueMetadata = await (await fetch(`${registry.url}/@starwind-ui%2Fvue`)).json();
+      expect(vueMetadata["dist-tags"].beta).toBe("0.2.0");
+      expect(vueMetadata.versions["0.2.0"].version).toBe("0.2.0");
     } finally {
       await registry.close();
       await rm(directory, { force: true, recursive: true });
     }
   });
 
-  it("advertises the approved beta version without materializing the packed Vue manifest", () => {
-    expect(getCandidateRegistryVersion("@starwind-ui/vue", "0.0.0")).toBe("0.1.0");
-    expect(getCandidateRegistryVersion("@starwind-ui/runtime", "1.2.0")).toBe("1.2.0");
+  it("uses current manifest versions in candidate registry metadata and validation", () => {
+    expect(
+      createCandidatePlan({ packages, root, vueAdapterVersion }).projects.find(
+        ({ framework }) => framework === "vue",
+      ),
+    ).toMatchObject({ adapterVersion: vueAdapterVersion });
+    expect(() => createCandidatePlan({ packages, root })).toThrow(
+      "The Vue candidate adapter version is required.",
+    );
   });
 
   it("runs auto-detect, all-component install, lifecycle, checks, builds, SSR, and browser work", () => {
-    const plan = createCandidatePlan({ packages, root });
+    const plan = createCandidatePlan({ packages, root, vueAdapterVersion });
 
     for (const project of plan.projects.filter((project) => project.packageManager === "pnpm")) {
       expect(project.init.args).toEqual([plan.cliEntrypoint, "init", "--defaults"]);
@@ -175,7 +191,7 @@ describe("release candidate acceptance", () => {
   });
 
   it("uses each host's official noninteractive scaffold and production server", () => {
-    const projects = createCandidatePlan({ packages, root }).projects;
+    const projects = createCandidatePlan({ packages, root, vueAdapterVersion }).projects;
     const getProject = (id: string) => projects.find((project) => project.id === id)!;
 
     expect(getProject("next-app").scaffold.args).toEqual(
@@ -258,7 +274,7 @@ describe("release candidate acceptance", () => {
   });
 
   it("writes framework-native fixtures that render the critical interactive cohort", () => {
-    const projects = createCandidatePlan({ packages, root }).projects;
+    const projects = createCandidatePlan({ packages, root, vueAdapterVersion }).projects;
     const fixturePaths = Object.fromEntries(
       projects.map((project) => [
         project.id,
@@ -291,13 +307,16 @@ describe("release candidate acceptance", () => {
       "react-router",
     ]);
     expect(
-      createCandidatePlan({ packages, projectIds: ["next-pages"], root }).projects.map(
-        (project) => project.id,
-      ),
+      createCandidatePlan({
+        packages,
+        projectIds: ["next-pages"],
+        root,
+        vueAdapterVersion,
+      }).projects.map((project) => project.id),
     ).toEqual(["next-pages"]);
-    expect(() => createCandidatePlan({ packages, projectIds: ["missing"], root })).toThrow(
-      /Unknown candidate project: missing/,
-    );
+    expect(() =>
+      createCandidatePlan({ packages, projectIds: ["missing"], root, vueAdapterVersion }),
+    ).toThrow(/Unknown candidate project: missing/);
   });
 
   it("runs once in the release gate and stays out of the public sync and publish commands", async () => {

--- a/scripts/tests/release-finalization.test.ts
+++ b/scripts/tests/release-finalization.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertReleaseIdentityAvailable,
+  createGitHubReleaseArgs,
+  deriveReleaseIdentity,
+  runReleaseFinalization,
+  verifyPublishedPackages,
+} from "../release-finalization.mjs";
+import { VUE_BETA_RELEASE_PLAN } from "../release-packages.mjs";
+
+describe("Vue beta release finalization", () => {
+  it.each(["0.1.1", "0.2.0", "1.0.0"])(
+    "gives a Vue-only beta %s its own GitHub prerelease identity",
+    (version) => {
+      expect(
+        deriveReleaseIdentity(
+          [{ entry: { name: "@starwind-ui/vue", tag: "beta" }, manifest: { version } }],
+          "latest",
+          "abc123",
+        ),
+      ).toMatchObject({ prerelease: true, tagName: `vue-v${version}` });
+    },
+  );
+
+  it("gives a Runtime update its own identity when the CLI is unchanged", () => {
+    expect(
+      deriveReleaseIdentity(
+        [
+          {
+            entry: { name: "@starwind-ui/runtime", tag: "latest" },
+            manifest: { version: "1.2.1" },
+          },
+        ],
+        "latest",
+        "abc123",
+      ),
+    ).toMatchObject({ prerelease: false, tagName: "runtime-v1.2.1" });
+  });
+
+  it.each([
+    ["@starwind-ui/vue", "0.1.0", "beta", null, "0.1.0", true],
+    ["@starwind-ui/vue", "0.1.0", "beta", null, null, true],
+    ["@starwind-ui/vue", "0.1.0", "beta", "0.0.8", "0.1.0", false],
+    ["@starwind-ui/vue", "0.1.0", "beta", null, "0.2.0", false],
+    ["@starwind-ui/vue", "0.1.1", "beta", null, "0.1.1", false],
+    ["@starwind-ui/react", "0.1.0", "beta", null, "0.1.0", false],
+    ["@starwind-ui/vue", "0.1.0", "next", null, "0.1.0", false],
+  ])(
+    "checks initial latest exception for %s@%s on %s (%s -> %s)",
+    async (name, version, tag, before, after, accepted) => {
+      const result = verifyPublishedPackages(
+        {
+          packages: [{ name, version, tag }],
+          preservedDistTags: { [name]: { latest: before } },
+        },
+        {
+          capture: async (_command: string, args: string[]) => ({
+            code: 0,
+            stderr: "",
+            stdout: JSON.stringify(
+              args[2] === "version"
+                ? version
+                : { [tag]: version, ...(after === null ? {} : { latest: after }) },
+            ),
+          }),
+        },
+        { attempts: 1 },
+      );
+      if (accepted) await expect(result).resolves.toBeUndefined();
+      else await expect(result).rejects.toThrow(/dist-tag latest changed/);
+    },
+  );
+
+  it("verifies each package against its own dist-tag", async () => {
+    const packageManifests = VUE_BETA_RELEASE_PLAN.map((entry) => ({
+      entry,
+      manifest: { name: entry.name, version: entry.version },
+    }));
+    const release = deriveReleaseIdentity(packageManifests, undefined, "abc123");
+    expect(release).toMatchObject({
+      packages: [
+        { name: "@starwind-ui/vue", tag: "beta", version: "0.1.0" },
+        { name: "starwind", tag: "latest", version: "3.3.0" },
+      ],
+      prerelease: false,
+      tagName: "v3.3.0",
+    });
+
+    const calls: string[] = [];
+    await verifyPublishedPackages(release, {
+      capture: async (command: string, args: string[]) => {
+        calls.push([command, ...args].join(" "));
+        const packageName = args[1].slice(0, args[1].lastIndexOf("@"));
+        const entry = release.packages.find((candidate) => candidate.name === packageName)!;
+        return args[2] === "version"
+          ? { code: 0, stderr: "", stdout: JSON.stringify(entry.version) }
+          : { code: 0, stderr: "", stdout: JSON.stringify({ [entry.tag]: entry.version }) };
+      },
+      run: async () => undefined,
+    });
+    expect(calls).toHaveLength(4);
+  });
+
+  it("uses the Vue-beta recovery command when registry propagation is incomplete", async () => {
+    const release = {
+      finalizeCommand: "pnpm release:vue-beta:finalize",
+      packages: [{ name: "@starwind-ui/vue", tag: "beta", version: "0.1.0" }],
+    };
+    await expect(
+      verifyPublishedPackages(
+        release,
+        {
+          capture: async () => ({ code: 1, stderr: "npm error E404", stdout: "" }),
+          run: async () => undefined,
+        },
+        { attempts: 1 },
+      ),
+    ).rejects.toThrow(/pnpm release:vue-beta:finalize/);
+  });
+
+  it("verifies Vue beta and CLI latest before finalization mutates Git or GitHub", async () => {
+    const packageManifests = VUE_BETA_RELEASE_PLAN.map((entry) => ({
+      entry,
+      manifest: { name: entry.name, version: entry.version },
+    }));
+    const events: string[] = [];
+    await runReleaseFinalization({
+      gitStateLoader: async () => ({ head: "abc123" }),
+      system: {
+        capture: async (command: string, args: string[]) => {
+          const invocation = [command, ...args].join(" ");
+          events.push(`read ${invocation}`);
+          if (command === "npm") {
+            const packageName = args[1].slice(0, args[1].lastIndexOf("@"));
+            const entry = VUE_BETA_RELEASE_PLAN.find(
+              (candidate) => candidate.name === packageName,
+            )!;
+            return args[2] === "version"
+              ? { code: 0, stderr: "", stdout: JSON.stringify(entry.version) }
+              : {
+                  code: 0,
+                  stderr: "",
+                  stdout: JSON.stringify({
+                    [entry.tag]: entry.version,
+                    ...(entry.name === "@starwind-ui/vue" ? { latest: "0.0.8" } : {}),
+                  }),
+                };
+          }
+          if (command === "git" && args[0] === "ls-remote") {
+            return { code: 0, stderr: "", stdout: "" };
+          }
+          return { code: 1, stderr: command === "gh" ? "release not found" : "", stdout: "" };
+        },
+        run: async (command: string, args: string[]) => {
+          events.push(`mutate ${[command, ...args].join(" ")}`);
+        },
+      },
+      vueBeta: true,
+      vueBetaMetadataLoader: async () => ({ packageManifests }),
+      vueLatestBaselineLoader: async () => ({ vueLatest: "0.0.8" }),
+    });
+
+    expect(events.slice(0, 4)).toEqual([
+      "read npm view @starwind-ui/vue@0.1.0 version --json",
+      "read npm view @starwind-ui/vue@0.1.0 dist-tags --json",
+      "read npm view starwind@3.3.0 version --json",
+      "read npm view starwind@3.3.0 dist-tags --json",
+    ]);
+    expect(events.findIndex((event) => event.startsWith("mutate "))).toBeGreaterThan(3);
+  });
+
+  it("stops standalone beta finalization before mutation when CLI latest is wrong", async () => {
+    const packageManifests = VUE_BETA_RELEASE_PLAN.map((entry) => ({
+      entry,
+      manifest: { name: entry.name, version: entry.version },
+    }));
+    const mutations: string[] = [];
+    await expect(
+      runReleaseFinalization({
+        gitStateLoader: async () => ({ head: "abc123" }),
+        registryVerificationOptions: { attempts: 1 },
+        system: {
+          capture: async (command: string, args: string[]) => {
+            if (command !== "npm") throw new Error("Git finalization started before npm passed.");
+            const packageName = args[1].slice(0, args[1].lastIndexOf("@"));
+            const entry = VUE_BETA_RELEASE_PLAN.find(
+              (candidate) => candidate.name === packageName,
+            )!;
+            if (args[2] === "version") {
+              return { code: 0, stderr: "", stdout: JSON.stringify(entry.version) };
+            }
+            const tagVersion = packageName === "starwind" ? "3.2.0" : entry.version;
+            return {
+              code: 0,
+              stderr: "",
+              stdout: JSON.stringify({
+                [entry.tag]: tagVersion,
+                ...(entry.name === "@starwind-ui/vue" ? { latest: "0.0.8" } : {}),
+              }),
+            };
+          },
+          run: async (command: string, args: string[]) => {
+            mutations.push([command, ...args].join(" "));
+          },
+        },
+        vueBeta: true,
+        vueBetaMetadataLoader: async () => ({ packageManifests }),
+        vueLatestBaselineLoader: async () => ({ vueLatest: "0.0.8" }),
+      }),
+    ).rejects.toThrow(/starwind dist-tag latest must point to 3\.3\.0/);
+    expect(mutations).toEqual([]);
+  });
+
+  it("rejects a changed Vue latest even when Vue beta and CLI latest are correct", async () => {
+    const packageManifests = VUE_BETA_RELEASE_PLAN.map((entry) => ({
+      entry,
+      manifest: { name: entry.name, version: entry.version },
+    }));
+    const mutations: string[] = [];
+    await expect(
+      runReleaseFinalization({
+        gitStateLoader: async () => ({ head: "abc123" }),
+        registryVerificationOptions: { attempts: 1 },
+        system: {
+          capture: async (command: string, args: string[]) => {
+            if (command !== "npm") throw new Error("Git finalization started before npm passed.");
+            const packageName = args[1].slice(0, args[1].lastIndexOf("@"));
+            const entry = VUE_BETA_RELEASE_PLAN.find(
+              (candidate) => candidate.name === packageName,
+            )!;
+            if (args[2] === "version") {
+              return { code: 0, stderr: "", stdout: JSON.stringify(entry.version) };
+            }
+            return {
+              code: 0,
+              stderr: "",
+              stdout: JSON.stringify({
+                [entry.tag]: entry.version,
+                ...(entry.name === "@starwind-ui/vue" ? { latest: "0.1.0" } : {}),
+              }),
+            };
+          },
+          run: async (command: string, args: string[]) => {
+            mutations.push([command, ...args].join(" "));
+          },
+        },
+        vueBeta: true,
+        vueBetaMetadataLoader: async () => ({ packageManifests }),
+        vueLatestBaselineLoader: async () => ({ vueLatest: "0.0.8" }),
+      }),
+    ).rejects.toThrow(/@starwind-ui\/vue dist-tag latest changed.*expected 0\.0\.8, found 0\.1\.0/);
+    expect(mutations).toEqual([]);
+  });
+});
+
+describe("routine release finalization", () => {
+  const packageManifests = [
+    {
+      entry: { name: "@starwind-ui/vue", tag: "beta" },
+      manifest: { version: "0.1.1" },
+    },
+    { entry: { name: "starwind", tag: "latest" }, manifest: { version: "3.3.1" } },
+  ];
+  const plan = {
+    packages: [{ name: "@starwind-ui/vue", version: "0.1.1", tag: "beta" }],
+    vueLatest: "0.1.0",
+  };
+
+  it.each(["0.1.0", "0.1.1"])(
+    "finalizes the saved Vue-only plan with latest at %s",
+    async (latest) => {
+      const mutations: string[] = [];
+      const registryReads: string[] = [];
+      const result = runReleaseFinalization({
+        gitStateLoader: async () => ({ head: "abc123" }),
+        metadataLoader: async () => ({ packageManifests, tag: "latest" }),
+        publicationPlanLoader: async () => plan,
+        registryVerificationOptions: { attempts: 1 },
+        system: {
+          capture: async (command: string, args: string[]) => {
+            if (command === "npm") {
+              registryReads.push(args[1]);
+              return {
+                code: 0,
+                stderr: "",
+                stdout: JSON.stringify(args[2] === "version" ? "0.1.1" : { beta: "0.1.1", latest }),
+              };
+            }
+            if (command === "git" && args[0] === "ls-remote") {
+              return { code: 0, stderr: "", stdout: "" };
+            }
+            return { code: 1, stderr: "release not found", stdout: "" };
+          },
+          run: async (command: string, args: string[]) => {
+            mutations.push([command, ...args].join(" "));
+          },
+        },
+      });
+      if (latest === "0.1.0") {
+        const release = await result;
+        expect(release).toMatchObject({ tagName: "vue-v0.1.1", prerelease: true });
+        expect(mutations).toContain(`gh ${createGitHubReleaseArgs(release).join(" ")}`);
+        expect(mutations.at(-1)).toContain("--prerelease --latest=false");
+      } else {
+        await expect(result).rejects.toThrow(/dist-tag latest changed/);
+        expect(mutations).toEqual([]);
+      }
+      expect(registryReads).toEqual(["@starwind-ui/vue@0.1.1", "@starwind-ui/vue@0.1.1"]);
+    },
+  );
+
+  it("uses the CLI identity for a mixed routine Vue and CLI plan", async () => {
+    const registryReads: string[] = [];
+    const mutations: string[] = [];
+    const release = await runReleaseFinalization({
+      gitStateLoader: async () => ({ head: "abc123" }),
+      metadataLoader: async () => ({ packageManifests, tag: "latest" }),
+      publicationPlanLoader: async () => ({
+        packages: [
+          { name: "@starwind-ui/vue", tag: "beta", version: "0.1.1" },
+          { name: "starwind", tag: "latest", version: "3.3.1" },
+        ],
+        vueLatest: "0.1.0",
+      }),
+      registryVerificationOptions: { attempts: 1 },
+      system: {
+        capture: async (command: string, args: string[]) => {
+          if (command === "npm") {
+            registryReads.push(args[1]);
+            const isVue = args[1].startsWith("@starwind-ui/vue@");
+            const version = isVue ? "0.1.1" : "3.3.1";
+            return {
+              code: 0,
+              stderr: "",
+              stdout: JSON.stringify(
+                args[2] === "version"
+                  ? version
+                  : isVue
+                    ? { beta: version, latest: "0.1.0" }
+                    : { latest: version },
+              ),
+            };
+          }
+          if (command === "git" && args[0] === "ls-remote") {
+            return { code: 0, stderr: "", stdout: "" };
+          }
+          return { code: 1, stderr: "release not found", stdout: "" };
+        },
+        run: async (command: string, args: string[]) => {
+          mutations.push([command, ...args].join(" "));
+        },
+      },
+    });
+
+    expect(release).toMatchObject({
+      packages: [
+        { name: "@starwind-ui/vue", tag: "beta", version: "0.1.1" },
+        { name: "starwind", tag: "latest", version: "3.3.1" },
+      ],
+      prerelease: false,
+      preservedDistTags: { "@starwind-ui/vue": { latest: "0.1.0" } },
+      tagName: "v3.3.1",
+    });
+    expect(registryReads).toEqual([
+      "@starwind-ui/vue@0.1.1",
+      "@starwind-ui/vue@0.1.1",
+      "starwind@3.3.1",
+      "starwind@3.3.1",
+    ]);
+    expect(mutations.at(-1)).toContain("gh release create v3.3.1");
+    expect(mutations.at(-1)).toContain("--latest");
+  });
+
+  it("uses the Runtime identity for a mixed routine Runtime and Vue plan", async () => {
+    const runtimeAndVueManifests = [
+      {
+        entry: { name: "@starwind-ui/runtime", tag: "latest" },
+        manifest: { version: "1.2.1" },
+      },
+      packageManifests[0],
+    ];
+    const registryReads: string[] = [];
+    const release = await runReleaseFinalization({
+      gitStateLoader: async () => ({ head: "abc123" }),
+      metadataLoader: async () => ({ packageManifests: runtimeAndVueManifests, tag: "latest" }),
+      publicationPlanLoader: async () => ({
+        packages: [
+          { name: "@starwind-ui/runtime", tag: "latest", version: "1.2.1" },
+          { name: "@starwind-ui/vue", tag: "beta", version: "0.1.1" },
+        ],
+        vueLatest: "0.1.0",
+      }),
+      registryVerificationOptions: { attempts: 1 },
+      system: {
+        capture: async (command: string, args: string[]) => {
+          if (command === "npm") {
+            registryReads.push(args[1]);
+            const isVue = args[1].startsWith("@starwind-ui/vue@");
+            const version = isVue ? "0.1.1" : "1.2.1";
+            return {
+              code: 0,
+              stderr: "",
+              stdout: JSON.stringify(
+                args[2] === "version"
+                  ? version
+                  : isVue
+                    ? { beta: version, latest: "0.1.0" }
+                    : { latest: version },
+              ),
+            };
+          }
+          if (command === "git" && args[0] === "ls-remote") {
+            return { code: 0, stderr: "", stdout: "" };
+          }
+          return { code: 1, stderr: "release not found", stdout: "" };
+        },
+        run: async () => undefined,
+      },
+    });
+
+    expect(release).toMatchObject({
+      packages: [
+        { name: "@starwind-ui/runtime", tag: "latest", version: "1.2.1" },
+        { name: "@starwind-ui/vue", tag: "beta", version: "0.1.1" },
+      ],
+      prerelease: false,
+      preservedDistTags: { "@starwind-ui/vue": { latest: "0.1.0" } },
+      tagName: "runtime-v1.2.1",
+    });
+    expect(registryReads).toEqual([
+      "@starwind-ui/runtime@1.2.1",
+      "@starwind-ui/runtime@1.2.1",
+      "@starwind-ui/vue@0.1.1",
+      "@starwind-ui/vue@0.1.1",
+    ]);
+  });
+
+  it("leaves Git and GitHub untouched for an empty saved publication plan", async () => {
+    const unexpected = async () => {
+      throw new Error("An empty plan must perform no external commands.");
+    };
+    await expect(
+      runReleaseFinalization({
+        gitStateLoader: async () => ({ head: "abc123" }),
+        metadataLoader: async () => ({ packageManifests, tag: "latest" }),
+        publicationPlanLoader: async () => ({ ...plan, packages: [] }),
+        system: { capture: unexpected, run: unexpected },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("requires the original publication plan before querying or changing external state", async () => {
+    const unexpected = async () => {
+      throw new Error("Finalization started without its saved plan.");
+    };
+    await expect(
+      runReleaseFinalization({
+        gitStateLoader: async () => ({ head: "abc123" }),
+        metadataLoader: async () => ({ packageManifests, tag: "latest" }),
+        publicationPlanLoader: async () => {
+          throw new Error("Publication plan is missing.");
+        },
+        system: { capture: unexpected, run: unexpected },
+      }),
+    ).rejects.toThrow("Publication plan is missing.");
+  });
+
+  it("rejects an existing release tag on a different commit during read-only preflight", async () => {
+    const release = deriveReleaseIdentity(packageManifests.slice(0, 1), "latest", "abc123");
+    await expect(
+      assertReleaseIdentityAvailable(release, {
+        capture: async (command: string, args: string[]) => {
+          if (command === "git") {
+            return { code: 0, stderr: "", stdout: args[0] === "rev-parse" ? "other-sha" : "" };
+          }
+          return { code: 1, stderr: "release not found", stdout: "" };
+        },
+        run: async () => {
+          throw new Error("Preflight must not mutate state.");
+        },
+      }),
+    ).rejects.toThrow(/points to other-sha, expected abc123/);
+  });
+});

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -35,11 +35,13 @@ import {
   validatePublishGitState,
   validateReleaseChangesetConfig,
   validateReleasePackageManifests,
+  validateRoutineReleaseMetadata,
   validateVueBetaReleaseMetadata,
 } from "../release-packages.mjs";
 import {
   CHANGESET_IGNORED_PACKAGES,
   CHANGESET_PRIVATE_PACKAGE_POLICY,
+  ROUTINE_RELEASE_PACKAGE_SET,
   RUNTIME_FIXED_GROUP,
   RUNTIME_RELEASE_PACKAGE_SET,
 } from "../runtime-release-policy.mjs";
@@ -112,7 +114,110 @@ function assertNoPrivateAdapterChangesetReleases(file: string, source: string): 
   }
 }
 
+function routineManifests() {
+  return ROUTINE_RELEASE_PACKAGE_SET.map((entry) => ({
+    entry: { ...entry },
+    manifest: {
+      name: entry.name,
+      version:
+        entry.name === "starwind" ? "3.4.0" : entry.name === "@starwind-ui/vue" ? "0.2.0" : "1.3.0",
+      private: false,
+      dependencies: entry.name === "@starwind-ui/vue" ? { "@starwind-ui/runtime": "1.3.0" } : {},
+    },
+  }));
+}
+
+function routineConfig() {
+  return {
+    ignore: [...CHANGESET_IGNORED_PACKAGES],
+    privatePackages: CHANGESET_PRIVATE_PACKAGE_POLICY,
+    fixed: [RUNTIME_FIXED_GROUP],
+  };
+}
+
 describe("release package tooling", () => {
+  it("publishes routine Vue versions on explicit beta policy outside the fixed train", () => {
+    const packageManifests = routineManifests();
+    expect(
+      validateRoutineReleaseMetadata({ packageManifests, config: routineConfig() }),
+    ).toMatchObject({ ok: true, tag: "latest" });
+    const commands = createPublishCommands({
+      releasePlan: packageManifests.map(({ entry }) => entry),
+      tag: "latest",
+    });
+    expect(commands.map(({ packageName }) => packageName)).toEqual([
+      "@starwind-ui/runtime",
+      "@starwind-ui/astro",
+      "@starwind-ui/react",
+      "@starwind-ui/vue",
+      "starwind",
+    ]);
+    expect(commands[3].args).toEqual(expect.arrayContaining(["--tag", "beta"]));
+    expect(commands[4].args).toEqual(expect.arrayContaining(["--tag", "latest"]));
+    packageManifests[3].manifest.version = "1.0.0";
+    expect(validateRoutineReleaseMetadata({ packageManifests, config: routineConfig() }).ok).toBe(
+      true,
+    );
+    expect(packageManifests[3].entry.tag).toBe("beta");
+  });
+
+  it.each(["^1.3.0", "workspace:*", "1.2.0", "*"])(
+    "rejects an inexact or stale Vue Runtime dependency %s",
+    (range) => {
+      const packageManifests = routineManifests();
+      packageManifests[3].manifest.dependencies["@starwind-ui/runtime"] = range;
+      expect(
+        validateRoutineReleaseMetadata({ packageManifests, config: routineConfig() }).errors.join(
+          "\n",
+        ),
+      ).toContain("exact current");
+    },
+  );
+
+  it.each(["0.2", "^0.2.0", "0.2.0-01"])("rejects invalid Vue package version %s", (version) => {
+    const packageManifests = routineManifests();
+    packageManifests[3].manifest.version = version;
+    expect(
+      validateRoutineReleaseMetadata({ packageManifests, config: routineConfig() }).errors.join(
+        "\n",
+      ),
+    ).toContain("exact SemVer");
+  });
+
+  it("rejects private Vue or accidental fixed-group membership", () => {
+    const packageManifests = routineManifests();
+    packageManifests[3].manifest.private = true;
+    expect(
+      validateRoutineReleaseMetadata({ packageManifests, config: routineConfig() }).errors.join(
+        "\n",
+      ),
+    ).toContain("public package");
+    packageManifests[3].manifest.private = false;
+    const config = { ...routineConfig(), fixed: [[...RUNTIME_FIXED_GROUP, "@starwind-ui/vue"]] };
+    expect(
+      validateRoutineReleaseMetadata({ packageManifests, config }).errors.join("\n"),
+    ).toContain("outside");
+  });
+
+  it("permits Vue in normal resume arguments while retaining the legacy initial selector", () => {
+    expect(parseArgs(["--publish", "--resume-from", "@starwind-ui/vue"])).toMatchObject({
+      vueBeta: false,
+      resumeFrom: "@starwind-ui/vue",
+    });
+  });
+
+  it("does not finalize a publication with no commands", async () => {
+    let finalized = false;
+    await executeReleasePublication({
+      dryRun: false,
+      publishCommands: [],
+      finalize: async () => {
+        finalized = true;
+      },
+    });
+    expect(finalized).toBe(false);
+  });
+
   it("keeps the dependency-aware Runtime publish order", () => {
     expect(RELEASE_PACKAGE_SET.map((entry) => entry.name)).toEqual([
       "@starwind-ui/runtime",
@@ -587,6 +692,14 @@ describe("release package tooling", () => {
         metadataLoader: async () => ({
           packageManifests: manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }),
           tag: "beta",
+        }),
+        publicationPlanLoader: async () => ({
+          head: "abc123",
+          snapshot: [],
+          packages: manifests({ cli: "3.0.0-beta.8", runtime: "0.1.0-beta.8" }).map(
+            ({ entry, manifest }) => ({ name: entry.name, version: manifest.version, tag: "beta" }),
+          ),
+          vueLatest: null,
         }),
         registryVerificationOptions: { attempts: 1 },
         system: {

--- a/scripts/tests/release-publication-plan.test.mjs
+++ b/scripts/tests/release-publication-plan.test.mjs
@@ -1,0 +1,141 @@
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { loadPublicationPlan, preparePublicationPlan } from "../release-publication-plan.mjs";
+
+const roots = [];
+const names = [
+  "@starwind-ui/runtime",
+  "@starwind-ui/astro",
+  "@starwind-ui/react",
+  "@starwind-ui/vue",
+  "starwind",
+];
+const packageManifests = names.map((name) => ({
+  entry: { name, ...(name === "@starwind-ui/vue" ? { tag: "beta" } : {}) },
+  manifest: {
+    name,
+    version: name === "starwind" ? "3.4.0" : name === "@starwind-ui/vue" ? "0.2.0" : "1.3.0",
+  },
+}));
+const head = "1234567890abcdef1234567890abcdef12345678";
+const snapshot = packageManifests.map(({ entry, manifest }) => ({
+  name: entry.name,
+  version: manifest.version,
+  tag: entry.tag ?? "latest",
+}));
+
+async function fixture(existing = []) {
+  const repoRoot = await mkdtemp(path.join(os.tmpdir(), "starwind-publication-plan-"));
+  roots.push(repoRoot);
+  const published = new Set(existing);
+  const registry = {
+    capture: async (_command, args) => {
+      if (args[2] === "dist-tags")
+        return { code: 0, stdout: JSON.stringify({ latest: "0.1.0", beta: "0.1.0" }), stderr: "" };
+      const entry = snapshot.find(({ name, version }) => args[1] === `${name}@${version}`);
+      return published.has(entry.name)
+        ? { code: 0, stdout: JSON.stringify(entry.version), stderr: "" }
+        : { code: 1, stdout: "", stderr: "npm ERR! code E404" };
+    },
+  };
+  return { head, packageManifests, tag: "latest", repoRoot, registry, published };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("routine publication planning", () => {
+  it("keeps mixed tags and skips existing versions in dependency order", async () => {
+    const input = await fixture(names.slice(0, 3));
+    const result = await preparePublicationPlan(input);
+    expect(result).toEqual({ head, snapshot, packages: snapshot.slice(3), vueLatest: "0.1.0" });
+    expect(await loadPublicationPlan(input)).toEqual(result);
+  });
+
+  it("keeps dry-run discovery free of persistent state", async () => {
+    const input = await fixture();
+    expect((await preparePublicationPlan({ ...input, dryRun: true })).packages).toEqual(snapshot);
+    expect(await readdir(input.repoRoot)).toEqual([]);
+  });
+
+  it("returns an empty plan when all versions already exist", async () => {
+    const input = await fixture(names);
+    expect((await preparePublicationPlan(input)).packages).toEqual([]);
+  });
+
+  it("retains the original publication subset through prefix recovery", async () => {
+    const input = await fixture(names.slice(0, 3));
+    const first = await preparePublicationPlan(input);
+    input.published.add("@starwind-ui/vue");
+    expect(await preparePublicationPlan({ ...input, resumeFrom: "starwind" })).toEqual(first);
+    await expect(preparePublicationPlan(input)).rejects.toThrow(/resume-from/);
+    await expect(
+      preparePublicationPlan({ ...input, resumeFrom: "@starwind-ui/vue" }),
+    ).rejects.toThrow(/first missing/);
+  });
+
+  it("rejects missing recovery state and non-prefix publication", async () => {
+    const input = await fixture();
+    await expect(preparePublicationPlan({ ...input, resumeFrom: "starwind" })).rejects.toThrow(
+      /missing/,
+    );
+    await preparePublicationPlan(input);
+    input.published.add("starwind");
+    await expect(
+      preparePublicationPlan({ ...input, resumeFrom: "@starwind-ui/runtime" }),
+    ).rejects.toThrow(/prefix/);
+  });
+
+  it("directs a fully published saved plan to finalization", async () => {
+    const input = await fixture(names.slice(0, 3));
+    await preparePublicationPlan(input);
+    names.forEach((name) => input.published.add(name));
+    await expect(preparePublicationPlan(input)).rejects.toThrow(/release:finalize/);
+  });
+
+  it("rejects changed snapshots and a saved subset outside the original order", async () => {
+    const input = await fixture();
+    await preparePublicationPlan(input);
+    const changed = structuredClone(packageManifests);
+    changed[3].manifest.version = "0.3.0";
+    await expect(loadPublicationPlan({ ...input, packageManifests: changed })).rejects.toThrow(
+      /snapshot/,
+    );
+    const directory = path.join(
+      input.repoRoot,
+      "node_modules/.cache/starwind-release/publication-plans",
+    );
+    const file = path.join(directory, (await readdir(directory))[0]);
+    const saved = JSON.parse(await readFile(file, "utf8"));
+    saved.packages.reverse();
+    await writeFile(file, JSON.stringify(saved));
+    await expect(loadPublicationPlan(input)).rejects.toThrow(/ordered subset/);
+  });
+
+  it.each(["npm ERR! code E403", "npm ERR! code EAI_AGAIN", "npm ERR! code E500"])(
+    "fails closed on %s",
+    async (stderr) => {
+      const input = await fixture();
+      input.registry.capture = async () => ({ code: 1, stdout: "", stderr });
+      await expect(preparePublicationPlan(input)).rejects.toThrow(/could not be checked/);
+      expect(await readdir(input.repoRoot)).toEqual([]);
+    },
+  );
+
+  it("rejects malformed exact-version responses", async () => {
+    const input = await fixture();
+    input.registry.capture = async () => ({ code: 0, stdout: '"9.9.9"', stderr: "" });
+    await expect(preparePublicationPlan(input)).rejects.toThrow(/unexpected version/);
+  });
+
+  it("does not overwrite a previous saved baseline during a dry-run", async () => {
+    const input = await fixture();
+    const saved = await preparePublicationPlan(input);
+    input.published.add("@starwind-ui/runtime");
+    await preparePublicationPlan({ ...input, dryRun: true });
+    expect(await loadPublicationPlan(input)).toEqual(saved);
+  });
+});

--- a/scripts/tests/vue-cli-host-acceptance.test.ts
+++ b/scripts/tests/vue-cli-host-acceptance.test.ts
@@ -22,9 +22,8 @@ import {
   getAstroVueFixture,
   getViteVueFixture,
   getVueFixture,
-  getVueBetaPackVersion,
-  isPreviewTreeAlive,
   isNuxtComponentCollisionWarning,
+  isPreviewTreeAlive,
   isVueHydrationMismatchWarning,
   parseArgs,
   runCleanupOperations,
@@ -43,12 +42,6 @@ const packages = {
 };
 
 describe("production Vue CLI host acceptance", () => {
-  it("keeps the candidate CLI version when packing Vue beta hosts", () => {
-    expect(getVueBetaPackVersion("cli", "3.3.1")).toBe("3.3.1");
-    expect(getVueBetaPackVersion("runtime", "1.2.0")).toBe("1.2.0");
-    expect(getVueBetaPackVersion("vue", "0.1.0")).toBe("0.1.0");
-  });
-
   it("plans exact beta packages and includes Vue in public candidate acceptance", () => {
     const betaPlan = createVueBetaPackPlan({ outputDirectory: path.join(root, "packs") });
     const publicPlan = createPackPlan({ outputDirectory: path.join(root, "public-packs") });
@@ -451,12 +444,12 @@ export const StarwindCollapsibleHelper: typeof import('../app/components/starwin
         file: packages.runtime,
         version: "0.1.0-beta.8",
       },
-      "@starwind-ui/vue": { file: packages.vue, version: "0.1.0" },
+      "@starwind-ui/vue": { file: packages.vue, version: "0.2.0" },
       starwind: { file: packages.cli, version: "3.3.0" },
     };
     const installed = {
       "@starwind-ui/runtime": { name: "@starwind-ui/runtime", version: "0.1.0-beta.8" },
-      "@starwind-ui/vue": { name: "@starwind-ui/vue", version: "0.1.0" },
+      "@starwind-ui/vue": { name: "@starwind-ui/vue", version: "0.2.0" },
       starwind: { name: "starwind", version: "3.3.0" },
     };
     const assertLockfile = (lockfile: string, installedPackages = installed) =>
@@ -574,17 +567,18 @@ export const StarwindCollapsibleHelper: typeof import('../app/components/starwin
   });
 
   it("uses public Commander choices and checked-in Vue beta registry artifacts", async () => {
-    const [program, registry, primitives] = await Promise.all([
+    const [program, registry, primitives, vueManifest] = await Promise.all([
       readFile("packages/cli/src/program.ts", "utf8"),
       readFile("packages/cli/src/registry/bundled-registry.json", "utf8"),
       readFile("packages/cli/src/registry/primitive-vendoring-artifacts.json", "utf8"),
+      readFile("packages/vue/package.json", "utf8"),
     ]);
 
     expect(program).toContain('"vue",');
     expect(program).not.toContain("PRIVATE_VUE_FRAMEWORK_TARGET_POLICY");
     expect(JSON.parse(registry).setup.vue.adapterPackage).toEqual({
       name: "@starwind-ui/vue",
-      range: "0.1.0",
+      range: JSON.parse(vueManifest).version,
     });
     expect(
       JSON.parse(primitives).primitives.some(

--- a/scripts/vue-cli-host-acceptance.mjs
+++ b/scripts/vue-cli-host-acceptance.mjs
@@ -5,7 +5,6 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   access,
-  cp,
   mkdir,
   mkdtemp,
   readdir,
@@ -33,7 +32,6 @@ const VUE_VERSION = "3.5.39";
 const NUXT_3_VERSION = "3.21.0";
 const NUXT_4_VERSION = "4.2.0";
 const QUASAR_APP_VERSION = "3.0.0";
-const VUE_BETA_REGISTRY_VERSION = "0.1.0";
 const HOST = "127.0.0.1";
 const PRIVATE_PACKAGES = [
   {
@@ -672,39 +670,18 @@ export async function runVueLocalLinkAcceptance({ root, runCommand = runLoggedCo
   console.log("[vue-cli-host] isolated Runtime, Vue, and CLI local-link acceptance passed");
 }
 
-export function getVueBetaPackVersion(key, version) {
-  return key === "vue" ? VUE_BETA_REGISTRY_VERSION : version;
-}
-
 async function packVueBetaPackages(outputDirectory, logsDirectory) {
   const plan = createVueBetaPackPlan({ outputDirectory });
   await mkdir(outputDirectory, { recursive: true });
   const packages = {};
   const manifests = {};
   for (const entry of plan.packages) {
-    let packageDirectory = entry.directory;
-    const manifest = JSON.parse(
-      await readFile(path.join(packageDirectory, "package.json"), "utf8"),
-    );
-    const plannedVersion = getVueBetaPackVersion(entry.key, manifest.version);
-    if (plannedVersion !== manifest.version) {
-      packageDirectory = path.join(outputDirectory, "staged", entry.key);
-      await cp(entry.directory, packageDirectory, {
-        filter: (source) => path.basename(source) !== "node_modules",
-        recursive: true,
-      });
-      manifest.version = plannedVersion;
-      await writeFile(
-        path.join(packageDirectory, "package.json"),
-        `${JSON.stringify(manifest, null, 2)}\n`,
-        "utf8",
-      );
-    }
+    const manifest = JSON.parse(await readFile(path.join(entry.directory, "package.json"), "utf8"));
     assert.equal(manifest.name, entry.name);
     assert.equal(typeof manifest.version, "string");
     await runLoggedCommand(
       `pack-${entry.key}`,
-      { args: ["pack", "--out", entry.file], cwd: packageDirectory },
+      { args: ["pack", "--out", entry.file], cwd: entry.directory },
       logsDirectory,
     );
     packages[entry.key] = entry.file;
@@ -757,7 +734,7 @@ async function prepareManifest(project, packages, registryUrl) {
   );
 }
 
-async function loadProductionCapability() {
+async function loadProductionCapability(vueAdapterVersion) {
   const [
     initModule,
     addModule,
@@ -784,7 +761,7 @@ async function loadProductionCapability() {
       "utf8",
     ).then(JSON.parse),
   ]);
-  assert.equal(registry.setup.vue.adapterPackage.range, "0.1.0");
+  assert.equal(registry.setup.vue.adapterPackage.range, vueAdapterVersion);
   return {
     add: addModule.add,
     artifacts,
@@ -1586,7 +1563,7 @@ export async function runVueCliHostAcceptance({
           ]),
         ),
       );
-      const capability = await loadProductionCapability();
+      const capability = await loadProductionCapability(manifests.vue.version);
       const require = createRequire(path.join(REPO_ROOT, "package.json"));
       const { chromium } = require("playwright");
       browser = await chromium.launch();


### PR DESCRIPTION
Routine releases now include updated Vue packages on the `beta` npm tag while preserving Vue's existing `latest` tag. The publisher reads current manifests, skips exact versions already on npm, and saves the selected package list for recovery after a partial publish. Vue-only updates receive their own GitHub prerelease identity.

Acceptance fixtures now pack the current Vue version, and the ordinary artifact check requires Vue build output. Release documentation describes the ongoing beta policy and the normal publication command.

Validation: repository-script tests, mocked publication and recovery checks, Prettier, Biome, release-status inspection, and guarded public synchronization. This changes release tooling and documentation only. Package versions and pending Changesets are unchanged; no packages were published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `@starwind-ui/vue` to the beta release channel, with versioning based on its published package metadata.
  * Added routine release support for Runtime, Astro, React, Vue, and CLI packages.
  * Release plans now support per-package tags, saved baselines, dry runs, resumable publication, and partial-release recovery.

* **Bug Fixes**
  * Improved release validation for package artifacts, versions, dependencies, and registry metadata.
  * Prevented release finalization when publication checks fail or no packages require publishing.

* **Documentation**
  * Updated release guides with the new Vue beta process, publication plans, recovery steps, and GitHub release behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->