### PR TITLE
fix(release): refresh Vue release dependencies and metadata

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,10 +2,6 @@ auto-install-peers=true
 node-linker=hoisted
 lockfile=true
 
-# make working with workspace packages easier
-prefer-workspace-packages=true
-link-workspace-packages=true
-
 # This prevents the examples to have the `workspace:` prefix
 save-workspace-protocol=true
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "primitive:versions:check": "tsx scripts/portable-runtime/primitive-component-release.ts check",
     "primitive:versions:stage": "tsx scripts/portable-runtime/primitive-component-release.ts stage",
     "release:status": "tsx scripts/portable-runtime/changeset-status.ts",
-    "release:version": "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
+    "release:version": "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
     "local:release": "pnpm build && pnpm release:version && changeset publish",
     "release:prepare": "pnpm runtime:generate:all && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
     "release:gate": "pnpm verify:public && pnpm runtime:generate:vue:test && pnpm test:vue-cli-host-acceptance && pnpm --filter=starwind package:check && pnpm audit:prod && pnpm demo:smoke && pnpm react-demo:smoke && pnpm vue-demo:smoke && pnpm runtime:size:check:prepared && pnpm release:candidate:acceptance",

--- a/packages/cli/tests/commands/add.integration.test.ts
+++ b/packages/cli/tests/commands/add.integration.test.ts
@@ -61,6 +61,9 @@ const mockLoadRegistry = vi.mocked(loadRegistry);
 const mockParseRegistrySource = vi.mocked(parseRegistrySource);
 const mockMultiselect = vi.mocked(clackPrompts.multiselect);
 const mockPromptLog = vi.mocked(clackPrompts.log);
+const vuePackage = JSON.parse(
+  readFileSync(new URL("../../../vue/package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 const defaultRegistryFixture = {
   $schema: "https://starwind.dev/registry-schema.v2.json",
@@ -382,7 +385,7 @@ describe.sequential("add command integration", () => {
       'from "@starwind-ui/vue/button"',
     );
     expect(mockInstallDependencies).toHaveBeenCalledWith(
-      ["@starwind-ui/vue@0.1.0", "tailwind-variants@^3.2.2", "vue@>=3.5"],
+      [`@starwind-ui/vue@${vuePackage.version}`, "tailwind-variants@^3.2.2", "vue@>=3.5"],
       "pnpm",
     );
     expect(mockLoadRegistry).not.toHaveBeenCalled();

--- a/packages/cli/tests/commands/init.test.ts
+++ b/packages/cli/tests/commands/init.test.ts
@@ -49,26 +49,25 @@ vi.mock("../../src/commands/migrate.js", () => ({
 
 import type { Task } from "@clack/prompts";
 import * as clackPrompts from "@clack/prompts";
-
+import { init } from "../../src/commands/init.js";
+import { migrate } from "../../src/commands/migrate.js";
 import * as astroConfig from "../../src/utils/astro-config.js";
 import * as astroReactIntegration from "../../src/utils/astro-react-integration.js";
 import * as astroVueIntegration from "../../src/utils/astro-vue-integration.js";
 import * as config from "../../src/utils/config.js";
 import { CONFIG_SCHEMA_V2_URL } from "../../src/utils/config.js";
 import * as env from "../../src/utils/env.js";
-import * as fsUtils from "../../src/utils/fs.js";
 import { PRIVATE_VUE_FRAMEWORK_TARGET_POLICY } from "../../src/utils/framework-target-policy.js";
+import * as fsUtils from "../../src/utils/fs.js";
 import * as hostPlanner from "../../src/utils/host-planner.js";
 import * as layout from "../../src/utils/layout.js";
 import * as packageManager from "../../src/utils/package-manager.js";
 import * as reactProject from "../../src/utils/react-project.js";
-import * as snippets from "../../src/utils/snippets.js";
 import * as sleepUtils from "../../src/utils/sleep.js";
+import * as snippets from "../../src/utils/snippets.js";
 import * as tsconfig from "../../src/utils/tsconfig.js";
 import * as viteConfig from "../../src/utils/vite-config.js";
 import * as vueProject from "../../src/utils/vue-project.js";
-import { init } from "../../src/commands/init.js";
-import { migrate } from "../../src/commands/migrate.js";
 
 const actualVueProject = await vi.importActual<typeof import("../../src/utils/vue-project.js")>(
   "../../src/utils/vue-project.js",
@@ -77,12 +76,16 @@ const actualVueProject = await vi.importActual<typeof import("../../src/utils/vu
 const runtimePackage = JSON.parse(
   readFileSync(new URL("../../../runtime/package.json", import.meta.url), "utf8"),
 ) as { version: string };
+const vuePackage = JSON.parse(
+  readFileSync(new URL("../../../vue/package.json", import.meta.url), "utf8"),
+) as { version: string };
 const registryVersionManifest = JSON.parse(
   readFileSync(new URL("../../registry/styled-component-versions.json", import.meta.url), "utf8"),
 ) as { registryVersion: string };
 const CURRENT_ASTRO_SPEC = `@starwind-ui/astro@${runtimePackage.version}`;
 const CURRENT_REACT_SPEC = `@starwind-ui/react@${runtimePackage.version}`;
-const CURRENT_VUE_SPEC = "@starwind-ui/vue@0.1.0";
+const CURRENT_VUE_SPEC = `@starwind-ui/vue@${vuePackage.version}`;
+const FIXTURE_VUE_SPEC = "@starwind-ui/vue@0.1.0";
 const ASTRO_SETUP_REQUIREMENTS = [
   "@tabler/icons@^3",
   "@tailwindcss/forms@^0.5",
@@ -508,7 +511,7 @@ describe("init command", () => {
       },
     );
     expect(mockInstallDependencies.mock.calls).toEqual([
-      [[CURRENT_VUE_SPEC], "pnpm"],
+      [[FIXTURE_VUE_SPEC], "pnpm"],
       [
         ["@tailwindcss/vite@^4", "tailwindcss@^4", "tw-animate-css@^1", "@tailwindcss/forms@^0.5"],
         "pnpm",
@@ -839,7 +842,7 @@ describe("init command", () => {
 
     expect(mockDetectHostPlan).toHaveBeenCalled();
     expect(mockInstallDependencies).toHaveBeenCalledWith(
-      expect.arrayContaining(["@starwind-ui/vue@0.1.0"]),
+      expect.arrayContaining([CURRENT_VUE_SPEC]),
       "pnpm",
     );
     expect(mockUpdateConfig).toHaveBeenCalledWith(expect.objectContaining({ framework: "vue" }), {

--- a/packages/cli/tests/utils/runtime-component.test.ts
+++ b/packages/cli/tests/utils/runtime-component.test.ts
@@ -60,6 +60,9 @@ const mockInstallDependencies = vi.mocked(packageManager.installDependenciesWith
 const mockConfirm = vi.mocked(clackPrompts.confirm);
 const mockIsCancel = vi.mocked(clackPrompts.isCancel);
 const mockPromptLog = vi.mocked(clackPrompts.log);
+const vuePackage = JSON.parse(
+  readFileSync(new URL("../../../vue/package.json", import.meta.url), "utf8"),
+) as { version: string };
 
 const runtimeConfig: StarwindConfig = {
   $schema: "https://starwind.dev/config-schema.v2.json",
@@ -2445,7 +2448,7 @@ describe.sequential("runtime component installs", () => {
       file.path.endsWith("/ThemeToggle.vue"),
     )!.content!;
     expect(themeToggle.targets!.vue!.packageRequirements).toEqual([
-      { name: "@starwind-ui/vue", range: "0.1.0" },
+      { name: "@starwind-ui/vue", range: vuePackage.version },
       { name: "tailwind-variants", range: "^3.2.2" },
       { name: "vue", range: ">=3.5" },
     ]);
@@ -2466,7 +2469,7 @@ describe.sequential("runtime component installs", () => {
     ).toContain('from "@starwind-ui/vue/combobox"');
 
     expect(mockInstallDependencies).toHaveBeenCalledWith(
-      ["@starwind-ui/vue@0.1.0", "tailwind-variants@^3.2.2", "vue@>=3.5"],
+      [`@starwind-ui/vue@${vuePackage.version}`, "tailwind-variants@^3.2.2", "vue@>=3.5"],
       "pnpm",
     );
     expect(mockUpdateConfig).toHaveBeenCalledWith(

--- a/packages/vue/tests/integration/workspace-contract.test.ts
+++ b/packages/vue/tests/integration/workspace-contract.test.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
+import semver from "semver";
 import { describe, expect, it } from "vitest";
 
 import { approvedTestHomePrefixes } from "../../../../scripts/check-test-homes.mjs";
@@ -37,6 +38,7 @@ describe("Vue public-beta vertical-slice workspace contract", () => {
       private?: boolean;
       version: string;
     }>("packages/vue/package.json");
+    const runtimePackage = await readRepoJson<{ version: string }>("packages/runtime/package.json");
     const demoPackage = await readRepoJson<{ name: string; private: boolean }>(
       "apps/vue-demo/package.json",
     );
@@ -45,10 +47,10 @@ describe("Vue public-beta vertical-slice workspace contract", () => {
     );
 
     expect(vuePackage).toMatchObject({
-      dependencies: { "@starwind-ui/runtime": "1.2.0" },
+      dependencies: { "@starwind-ui/runtime": runtimePackage.version },
       name: "@starwind-ui/vue",
-      version: "0.1.0",
     });
+    expect(semver.valid(vuePackage.version)).toBe(vuePackage.version);
     expect(vuePackage.private).toBeUndefined();
     expect(demoPackage).toMatchObject({ name: "vue-demo", private: true });
     expect(changesets.fixed.flat()).not.toContain("@starwind-ui/vue");

--- a/packages/vue/tests/release/release-package.test.ts
+++ b/packages/vue/tests/release/release-package.test.ts
@@ -1313,10 +1313,13 @@ describe("release-like @starwind-ui/vue package", () => {
   });
 
   it("keeps Runtime declared and Vue external across built ESM chunks", async () => {
-    const packageJson = JSON.parse(
-      await readFile(path.join(repoRoot, "packages/vue/package.json"), "utf8"),
-    );
-    expect(packageJson.dependencies).toEqual({ "@starwind-ui/runtime": "1.2.0" });
+    const [packageJson, runtimePackageJson] = await Promise.all([
+      readFile(path.join(repoRoot, "packages/vue/package.json"), "utf8").then(JSON.parse),
+      readFile(path.join(repoRoot, "packages/runtime/package.json"), "utf8").then(JSON.parse),
+    ]);
+    expect(packageJson.dependencies).toEqual({
+      "@starwind-ui/runtime": runtimePackageJson.version,
+    });
     expect(packageJson.peerDependencies).toEqual({ vue: ">=3.5" });
 
     const javaScript = await readJavaScriptTree(path.join(repoRoot, "packages/vue/dist"));

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - packages/*
   - apps/*
+# Resolve exact release dependencies to the matching local package before publication.
+linkWorkspacePackages: true
+preferWorkspacePackages: true
+
 onlyBuiltDependencies:
   - '@biomejs/biome'
   - esbuild

--- a/scripts/portable-runtime/generate-cli-registry.ts
+++ b/scripts/portable-runtime/generate-cli-registry.ts
@@ -186,7 +186,6 @@ type WriteRuntimeRegistryOptions = BuildRuntimeRegistryOptions & {
 
 type TargetDefinition = {
   adapterPackage: string;
-  adapterPackageRange?: string;
   collectPackageImportSources?: (args: {
     group: StyledOutputComponentGroup;
     primitiveImportBase: string;
@@ -246,7 +245,6 @@ function createTargetDefinitions(
 
     return {
       adapterPackage,
-      adapterPackageRange: getExactAdapterPackageRange(registration),
       collectPackageImportSources:
         registration.cliRegistry.styledArtifact.collectPackageImportSources,
       generatedImportCandidateExtensions:
@@ -508,7 +506,7 @@ function buildRegistrySetup(
     setup[target.target] = {
       adapterPackage: {
         name: target.adapterPackage,
-        range: target.adapterPackageRange ?? getPackageRange(target.adapterPackage, packageRanges),
+        range: getPackageRange(target.adapterPackage, packageRanges),
       },
       packageRequirements,
     };
@@ -775,11 +773,16 @@ async function readGeneratedComponentFiles(options: {
   );
 }
 
-async function loadPackageRanges(
+export async function loadPackageRanges(
   repoRoot: string,
   targetRegistrations: readonly CliRegistryTargetRegistration[],
 ): Promise<Map<string, string>> {
   const ranges = new Map<string, string>();
+  const exactAdapterPackages = new Set(
+    targetRegistrations
+      .filter((registration) => registration.cliRegistry.exactAdapterPackageVersion)
+      .map((registration) => getCliRegistryAdapterPackage(registration.target)),
+  );
   const packageMetadataSources = [
     ...new Set(
       targetRegistrations.flatMap(
@@ -789,7 +792,7 @@ async function loadPackageRanges(
   ];
 
   for (const packageMetadataSource of packageMetadataSources) {
-    await addPackageVersionRange(ranges, repoRoot, packageMetadataSource);
+    await addPackageVersionRange(ranges, repoRoot, packageMetadataSource, exactAdapterPackages);
     await addPackageDependencyRanges(ranges, repoRoot, packageMetadataSource);
   }
 
@@ -1036,10 +1039,20 @@ async function addPackageVersionRange(
   ranges: Map<string, string>,
   repoRoot: string,
   packageJsonPath: string,
+  exactPackageNames: ReadonlySet<string>,
 ): Promise<void> {
   const packageJson = await readPackageJson(repoRoot, packageJsonPath);
   const name = getPackageName(packageJson, packageJsonPath);
 
+  if (exactPackageNames.has(name)) {
+    if (semver.valid(packageJson.version) !== packageJson.version) {
+      throw new Error(
+        `CLI registry adapter package ${name} requires an exact package version; received "${packageJson.version}" from ${packageJsonPath}.`,
+      );
+    }
+    ranges.set(name, packageJson.version);
+    return;
+  }
   ranges.set(name, packageJson.version === "0.0.0" ? "*" : `^${packageJson.version}`);
 }
 
@@ -1099,10 +1112,7 @@ function collectPackageRequirements(options: {
 
   return [...packageNames].sort().map((name) => ({
     name,
-    range:
-      name === options.target.adapterPackage && options.target.adapterPackageRange
-        ? options.target.adapterPackageRange
-        : getPackageRange(name, options.packageRanges),
+    range: getPackageRange(name, options.packageRanges),
   }));
 }
 
@@ -1206,19 +1216,6 @@ function getCliRegistryAdapterPackage(target: FrameworkAdapterRegisteredTarget):
   }
 
   return packageName;
-}
-
-function getExactAdapterPackageRange(
-  registration: CliRegistryTargetRegistration,
-): string | undefined {
-  const version = registration.cliRegistry.exactAdapterPackageVersion;
-  if (version === undefined) return undefined;
-  if (semver.valid(version) !== version) {
-    throw new Error(
-      `CLI registry target "${registration.target}" requires an exact adapter package version; received "${version}".`,
-    );
-  }
-  return version;
 }
 
 function normalizeArtifactDir(artifactDir: string): string {

--- a/scripts/portable-runtime/renderers/framework-adapters/types.ts
+++ b/scripts/portable-runtime/renderers/framework-adapters/types.ts
@@ -1,12 +1,12 @@
 import type { StyledAdapterContract } from "../../contracts/styled/types.js";
 import type {
-  StyledOutputComponentGroup,
-  StyledOutputModel,
-} from "../styled-output-model/types.js";
-import type {
   AdapterColorPickerComponentProjection,
   AdapterColorPickerIndexProjection,
 } from "../primitive-output-model/index.js";
+import type {
+  StyledOutputComponentGroup,
+  StyledOutputModel,
+} from "../styled-output-model/types.js";
 
 export type FrameworkAdapterTarget = "astro" | "react" | "solid" | "svelte" | "vue" | (string & {});
 
@@ -141,7 +141,7 @@ export type FrameworkAdapterTargetPrimitiveEditableContentMarker = {
 };
 
 export type FrameworkAdapterTargetCliRegistryMetadata = {
-  exactAdapterPackageVersion?: string;
+  exactAdapterPackageVersion?: true;
   generatedImportCandidateExtensions: readonly string[];
   packageMetadataSources?: readonly string[];
   primitiveArtifact?: {

--- a/scripts/portable-runtime/renderers/framework-adapters/vue/index.ts
+++ b/scripts/portable-runtime/renderers/framework-adapters/vue/index.ts
@@ -51,7 +51,7 @@ async function readGeneratedFiles(directory: string, root: string = directory): 
 const vueFrameworkAdapterTargetDefinition = {
   adapter: vueFrameworkAdapter,
   cliRegistry: {
-    exactAdapterPackageVersion: "0.1.0",
+    exactAdapterPackageVersion: true,
     generatedImportCandidateExtensions: [".vue", ".ts", ".js"],
     packageMetadataSources: [
       "packages/vue/package.json",

--- a/scripts/portable-runtime/tests/framework-adapters.test.ts
+++ b/scripts/portable-runtime/tests/framework-adapters.test.ts
@@ -876,7 +876,7 @@ describe("Framework Adapter seam", () => {
         {
           adapterTarget: "vue",
           cliRegistry: {
-            exactAdapterPackageVersion: "0.1.0",
+            exactAdapterPackageVersion: true,
             generatedImportCandidateExtensions: [".vue", ".ts", ".js"],
             packageMetadataSources: [
               "packages/vue/package.json",

--- a/scripts/portable-runtime/tests/generate-cli-registry.test.ts
+++ b/scripts/portable-runtime/tests/generate-cli-registry.test.ts
@@ -47,7 +47,11 @@ import {
 const runtimePackage = JSON.parse(
   await readFile(new URL("../../../packages/runtime/package.json", import.meta.url), "utf8"),
 ) as { version: string };
+const vuePackage = JSON.parse(
+  await readFile(new URL("../../../packages/vue/package.json", import.meta.url), "utf8"),
+) as { version: string };
 const CURRENT_BETA_PACKAGE_RANGE = `^${runtimePackage.version}`;
+const CURRENT_VUE_PACKAGE_VERSION = vuePackage.version;
 const STABLE_TARGET_POLICY = createCliRegistryBuildPolicy([
   astroFrameworkAdapterTarget,
   reactFrameworkAdapterTarget,
@@ -172,7 +176,7 @@ describe("generateCliRegistry", () => {
     );
     expect(firstRegistry.setup).toEqual({
       vue: {
-        adapterPackage: { name: "@starwind-ui/vue", range: "0.1.0" },
+        adapterPackage: { name: "@starwind-ui/vue", range: CURRENT_VUE_PACKAGE_VERSION },
         packageRequirements: [{ name: "vue", range: ">=3.5" }],
       },
     });
@@ -206,7 +210,7 @@ describe("generateCliRegistry", () => {
       expect(
         target.packageRequirements.find(({ name }) => name === "@starwind-ui/vue")?.range,
         componentName,
-      ).toBe("0.1.0");
+      ).toBe(CURRENT_VUE_PACKAGE_VERSION);
       expect(packageNames, componentName).toContain("vue");
       expect(packageNames, componentName).not.toEqual(
         expect.arrayContaining([
@@ -431,7 +435,7 @@ describe("generateCliRegistry", () => {
         ],
       },
       vue: {
-        adapterPackage: { name: "@starwind-ui/vue", range: "0.1.0" },
+        adapterPackage: { name: "@starwind-ui/vue", range: CURRENT_VUE_PACKAGE_VERSION },
         packageRequirements: [{ name: "vue", range: ">=3.5" }],
       },
     });
@@ -1488,7 +1492,7 @@ describe("generateCliRegistry", () => {
       "packages/cli/registry/styled-component-versions.json",
     );
     expect(Object.keys(versionManifest.components).sort()).toEqual(contractNames);
-    expect(versionManifest.sourceVersions).toEqual(versionManifest.components);
+    expect(Object.keys(versionManifest.sourceVersions).sort()).toEqual(contractNames);
   });
 
   it("generates Astro primitive vendoring artifacts from source with Runtime package requirements", async () => {
@@ -1690,9 +1694,10 @@ describe("generateCliRegistry", () => {
   });
 
   it("generates default primitive artifacts for every current primitive contract", async () => {
-    const artifactSet = await buildPrimitiveVendoringArtifacts({
-      tempRoot,
-    });
+    const [artifactSet, versionManifest] = await Promise.all([
+      buildPrimitiveVendoringArtifacts({ tempRoot }),
+      loadPrimitiveVersionManifest(),
+    ]);
     const artifactComponents = artifactSet.primitives.map((primitive) => primitive.component);
     const artifactsByComponent = new Map(
       artifactSet.primitives.map((primitive) => [
@@ -1713,7 +1718,12 @@ describe("generateCliRegistry", () => {
     for (const artifact of artifactSet.primitives) {
       const registration = getPrimitiveFrameworkAdapterTarget(artifact.framework);
 
-      expect(artifact.sourceVersion, artifact.component).toBe(artifact.version);
+      expect(artifact.version, artifact.component).toBe(
+        versionManifest.primitives[artifact.component],
+      );
+      expect(artifact.sourceVersion, artifact.component).toBe(
+        versionManifest.sourceVersions[artifact.component],
+      );
       assertSafeInstallPaths(artifact.files, DEFAULT_PRIMITIVE_INSTALL_ROOT);
       assertInstallGraphSourceClosure({
         files: artifact.files,
@@ -1918,7 +1928,7 @@ describe("generateCliRegistry", () => {
       "packages/cli/registry/primitive-versions.json",
     );
     expect(Object.keys(versionManifest.primitives).sort()).toEqual(contractNames);
-    expect(versionManifest.sourceVersions).toEqual(versionManifest.primitives);
+    expect(Object.keys(versionManifest.sourceVersions).sort()).toEqual(contractNames);
   });
 
   it("publishes deterministic, source-closed Color Picker candidates for Astro and React", async () => {

--- a/scripts/portable-runtime/tests/generate-cli-registry.test.ts
+++ b/scripts/portable-runtime/tests/generate-cli-registry.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { compileScript, compileTemplate, parse } from "@vue/compiler-sfc";
@@ -27,6 +27,7 @@ import {
   DEFAULT_REGISTRY_VERSION_MANIFEST,
   getLocalGeneratedImportCandidates,
   isValidRegistryPackageName,
+  loadPackageRanges,
   loadPrimitiveVersionManifest,
   loadRegistryVersionManifest,
   type RuntimeRegistry,
@@ -87,6 +88,27 @@ describe("generateCliRegistry", () => {
     expect(() =>
       createCliRegistryBuildPolicy([vueFrameworkAdapterTarget, vueFrameworkAdapterTarget]),
     ).toThrow(/Duplicate CLI registry target "vue"/);
+  });
+
+  it("derives Vue's exact adapter range from its current package manifest", async () => {
+    const repoRoot = path.join(tempRoot, "later-vue-version");
+    for (const source of vueFrameworkAdapterTarget.cliRegistry.packageMetadataSources ?? []) {
+      const packageJson = JSON.parse(await readFile(source, "utf8")) as {
+        name: string;
+        version: string;
+      };
+      if (packageJson.name === "@starwind-ui/vue") packageJson.version = "0.2.0";
+      if (packageJson.name === "@starwind-ui/runtime") packageJson.version = "4.5.6";
+      const destination = path.join(repoRoot, source);
+      await mkdir(path.dirname(destination), { recursive: true });
+      await writeFile(destination, `${JSON.stringify(packageJson, null, 2)}\n`);
+    }
+
+    const packageRanges = await loadPackageRanges(repoRoot, [vueFrameworkAdapterTarget]);
+
+    expect(packageRanges.get("@starwind-ui/vue")).toBe("0.2.0");
+    expect(packageRanges.get("@starwind-ui/runtime")).toBe("^4.5.6");
+    expect(packageRanges.get("vue")).toBe(">=3.5");
   });
 
   it("keeps generated artifacts stable across release-only version changes", async () => {

--- a/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
+++ b/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
@@ -295,7 +295,10 @@ describe("Vue package foundation", () => {
   });
 
   it("pins a public-beta package with exact ESM and declaration exports", async () => {
-    const packageJson = JSON.parse(await readFile("packages/vue/package.json", "utf8"));
+    const [packageJson, runtimePackageJson] = await Promise.all([
+      readFile("packages/vue/package.json", "utf8").then(JSON.parse),
+      readFile("packages/runtime/package.json", "utf8").then(JSON.parse),
+    ]);
     const packageMetadataSources =
       vueFrameworkAdapterTarget.cliRegistry.packageMetadataSources ?? [];
 
@@ -321,7 +324,9 @@ describe("Vue package foundation", () => {
       expect(contract.import).toMatch(/^\.\/dist\/.+\.js$/);
       expect(contract.types).toMatch(/^\.\/dist\/.+\.d\.ts$/);
     }
-    expect(packageJson.dependencies).toEqual({ "@starwind-ui/runtime": "1.2.0" });
+    expect(packageJson.dependencies).toEqual({
+      "@starwind-ui/runtime": runtimePackageJson.version,
+    });
     expect(packageJson.peerDependencies).toEqual({ vue: ">=3.5" });
 
     const readme = await readFile("packages/vue/README.md", "utf8");
@@ -361,6 +366,7 @@ describe("Vue package foundation", () => {
   });
 
   it("exposes Vue as public beta through public generation and release verification", async () => {
+    const vuePackageJson = JSON.parse(await readFile("packages/vue/package.json", "utf8"));
     expect(vueFrameworkAdapterTarget.publicSupport).toEqual({
       cliRegistry: true,
       demoIntegration: true,
@@ -405,7 +411,7 @@ describe("Vue package foundation", () => {
       await readFile("packages/cli/src/registry/bundled-registry.json", "utf8"),
     );
     expect(bundledRegistry.setup.vue).toEqual({
-      adapterPackage: { name: "@starwind-ui/vue", range: "0.1.0" },
+      adapterPackage: { name: "@starwind-ui/vue", range: vuePackageJson.version },
       packageRequirements: [{ name: "vue", range: ">=3.5" }],
     });
     const vueRegistryComponents = bundledRegistry.components.filter(
@@ -416,7 +422,7 @@ describe("Vue package foundation", () => {
     );
     for (const component of vueRegistryComponents) {
       expect(component.targets.vue.packageRequirements).toEqual(
-        expect.arrayContaining([{ name: "@starwind-ui/vue", range: "0.1.0" }]),
+        expect.arrayContaining([{ name: "@starwind-ui/vue", range: vuePackageJson.version }]),
       );
       expect(component.targets.svelte).toBeUndefined();
     }

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -151,6 +151,7 @@ const approvedVueScriptNames = [
   "vue:build",
   "vue:link",
   "vue:test",
+  "vue:test:browser:ci",
   "vue:typecheck",
   "vue:unlink",
   "vue:verify",

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, sep } from "node:path";
 
+import semver from "semver";
 import { describe, expect, it } from "vitest";
 
 import { PUBLIC_FRAMEWORK_TARGET_POLICY } from "../../../packages/cli/src/utils/framework-target-policy.js";
@@ -105,6 +106,7 @@ type PackageManifest = Partial<
   name?: string;
   private?: boolean;
   scripts?: Record<string, string>;
+  version?: string;
 };
 
 type TextSurface = {
@@ -687,15 +689,25 @@ describe("Vue public-beta contract gate", () => {
       }
     }
 
+    const runtimeManifest = JSON.parse(
+      readFileSync(join(process.cwd(), "packages/runtime/package.json"), "utf8"),
+    ) as PackageManifest;
+    const runtimeVersion = runtimeManifest.version ?? "";
+    expect(runtimeManifest).toMatchObject({
+      name: "@starwind-ui/runtime",
+    });
+    expect(semver.valid(runtimeVersion)).toBe(runtimeVersion);
+
     const vueManifest = JSON.parse(
       readFileSync(join(process.cwd(), "packages/vue/package.json"), "utf8"),
     ) as PackageManifest;
+    const vueVersion = vueManifest.version ?? "";
     expect(vueManifest).toMatchObject({
-      dependencies: { "@starwind-ui/runtime": "1.2.0" },
+      dependencies: { "@starwind-ui/runtime": runtimeVersion },
       name: "@starwind-ui/vue",
       peerDependencies: { vue: ">=3.5" },
-      version: "0.1.0",
     });
+    expect(semver.valid(vueVersion)).toBe(vueVersion);
     expect(vueManifest.private).not.toBe(true);
     expect(Object.keys(vueManifest.exports ?? {}).sort()).toEqual(
       Object.keys(vuePackageExports).sort(),

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -1,11 +1,13 @@
+import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
+import { valid as validSemver } from "semver";
 import { describe, expect, it } from "vitest";
-import { parse as parseYaml } from "yaml";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 import { createSpawnCommand, getPackageManagerCommand } from "../command-process.mjs";
 import { hasPrivateSvelte } from "../portable-runtime/tests/workspace-support.js";
 import {
@@ -253,10 +255,9 @@ describe("release package tooling", () => {
       readJson<PackageJson>("packages/vue/package.json"),
       hasPrivateSvelte ? readJson<PackageJson>("packages/svelte/package.json") : undefined,
     ]);
-    expect(vuePackage).toMatchObject({
-      name: "@starwind-ui/vue",
-      version: "0.1.0",
-    });
+    expect(vuePackage.name).toBe("@starwind-ui/vue");
+    expect(vuePackage.private).not.toBe(true);
+    expect(validSemver(vuePackage.version)).toBe(vuePackage.version);
     if (sveltePackage) {
       expect(sveltePackage).toMatchObject({
         dependencies: { "@starwind-ui/runtime": "workspace:*" },
@@ -411,10 +412,100 @@ describe("release package tooling", () => {
     ).toThrow(/@starwind-ui\/svelte/);
   });
 
+  it("refreshes exact local release dependencies before a clean frozen install", async () => {
+    const fixture = await mkdtemp(path.join(tmpdir(), "starwind-release-lockfile-"));
+    const workspace = parseYaml(await readFile("pnpm-workspace.yaml", "utf8"));
+    const runPnpm = (args: string[]) => {
+      const command = createSpawnCommand(getPackageManagerCommand("pnpm"), args);
+      try {
+        return execFileSync(command.command, command.args, {
+          cwd: fixture,
+          env: { ...process.env, CI: "true" },
+          encoding: "utf8",
+          stdio: "pipe",
+          timeout: 30_000,
+        });
+      } catch (error) {
+        const failure = error as Error & { stdout?: string; stderr?: string };
+        throw new Error(`${failure.message}\n${failure.stdout ?? ""}\n${failure.stderr ?? ""}`, {
+          cause: error,
+        });
+      }
+    };
+    const writeVersions = async (version: string) => {
+      await writeFile(
+        path.join(fixture, "packages/runtime/package.json"),
+        JSON.stringify({
+          name: "@starwind-ui/runtime",
+          version,
+        }),
+      );
+      await writeFile(
+        path.join(fixture, "packages/vue/package.json"),
+        JSON.stringify({
+          name: "@starwind-ui/vue",
+          version: "0.1.0",
+          dependencies: { "@starwind-ui/runtime": version },
+        }),
+      );
+    };
+    try {
+      await mkdir(path.join(fixture, "packages/runtime"), { recursive: true });
+      await mkdir(path.join(fixture, "packages/vue"), { recursive: true });
+      await writeFile(
+        path.join(fixture, "package.json"),
+        JSON.stringify({ name: "release-fixture", private: true }),
+      );
+      await writeFile(path.join(fixture, ".npmrc"), await readFile(".npmrc", "utf8"));
+      await writeFile(
+        path.join(fixture, "pnpm-workspace.yaml"),
+        stringifyYaml({
+          packages: ["packages/*"],
+          ...(workspace.linkWorkspacePackages === undefined
+            ? {}
+            : { linkWorkspacePackages: workspace.linkWorkspacePackages }),
+          ...(workspace.preferWorkspacePackages === undefined
+            ? {}
+            : { preferWorkspacePackages: workspace.preferWorkspacePackages }),
+        }),
+      );
+      await writeVersions("99.999.997");
+      runPnpm([
+        "install",
+        "--lockfile-only",
+        "--offline",
+        "--ignore-scripts",
+        "--no-frozen-lockfile",
+        "--link-workspace-packages",
+      ]);
+      await writeVersions("99.999.998");
+      expect(() =>
+        runPnpm(["install", "--frozen-lockfile", "--offline", "--ignore-scripts"]),
+      ).toThrow(/ERR_PNPM_OUTDATED_LOCKFILE/);
+      const root = await readJson<PackageJson>("package.json");
+      const phases = commandPhases(root.scripts?.["release:version"]);
+      const refresh = phases[phases.indexOf("changeset version") + 1];
+      // Run the release refresh against unpublished versions with registry access disabled.
+      expect(refresh).toBe("pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile");
+      runPnpm([...refresh.split(" ").slice(1), "--offline"]);
+      const lockfile = parseYaml(await readFile(path.join(fixture, "pnpm-lock.yaml"), "utf8"));
+      expect(lockfile.importers["packages/vue"].dependencies["@starwind-ui/runtime"]).toEqual({
+        specifier: "99.999.998",
+        version: "link:../runtime",
+      });
+      runPnpm(["install", "--frozen-lockfile", "--offline", "--ignore-scripts"]);
+      expect(
+        await realpath(path.join(fixture, "packages/vue/node_modules/@starwind-ui/runtime")),
+      ).toBe(await realpath(path.join(fixture, "packages/runtime")));
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  }, 60_000);
+
   it("exposes generic release commands and beta compatibility aliases", async () => {
     const root = await readJson<PackageJson>("package.json");
     expect(root.scripts?.["release:version"]).toBe(
-      "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
+      "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
     );
     expect(root.scripts?.version).toBe("pnpm release:version");
     expect(root.scripts?.["styled:versions:stage"]).toBe(

--- a/scripts/tests/root-verification-scripts.test.ts
+++ b/scripts/tests/root-verification-scripts.test.ts
@@ -91,6 +91,7 @@ describe("root verification scripts", () => {
       "tsx scripts/portable-runtime/styled-component-release.ts version",
       "tsx scripts/portable-runtime/primitive-component-release.ts version",
       "changeset version",
+      "pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile",
       "pnpm runtime:registry:generate",
       "pnpm runtime:docs:metadata",
     ]);


### PR DESCRIPTION
Version Packages updates Vue's exact Runtime dependency while leaving the lockfile stale, which blocks a frozen install of the generated release. Refresh the lockfile immediately after Changesets and configure local workspace resolution in pnpm 11's supported YAML settings so unpublished Runtime versions resolve locally.

The CLI registry now derives Vue's exact adapter version from its package manifest. Tests that read the live workspace follow those versions while fixed test fixtures remain independent.

Validation includes an offline fixture that bumps an unpublished local dependency and completes a frozen install, release-helper tests, registry generation checks, and lint. These changes repair release preparation; they do not publish packages or promote Vue out of beta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release and Package Management**
  - Release versioning now refreshes the lockfile automatically before installation.
  - Workspace package resolution is managed consistently through the workspace configuration.
  - Adapter and package versions are derived from package metadata, reducing reliance on fixed release values.
  - Exact package versions are preserved where required for reliable installations.

- **Validation**
  - Release and package checks now validate semver-compliant versions and dependency relationships dynamically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->