### PR TITLE
fix(release): reconcile Vue versions and public lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,37 +381,6 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@24.12.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
 
-  packages/svelte:
-    dependencies:
-      '@starwind-ui/runtime':
-        specifier: workspace:*
-        version: link:../runtime
-    devDependencies:
-      '@sveltejs/package':
-        specifier: 2.5.8
-        version: 2.5.8(svelte@5.29.0)(typescript@5.9.3)
-      '@sveltejs/vite-plugin-svelte':
-        specifier: 6.2.1
-        version: 6.2.1(svelte@5.29.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
-      '@types/node':
-        specifier: ^24.12.4
-        version: 24.12.4
-      svelte:
-        specifier: 5.29.0
-        version: 5.29.0
-      svelte-check:
-        specifier: 4.4.8
-        version: 4.4.8(picomatch@4.0.4)(svelte@5.29.0)(typescript@5.9.3)
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vite:
-        specifier: 7.3.5
-        version: 7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)
-      vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.12.4)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
-
   packages/vue:
     dependencies:
       '@starwind-ui/runtime':
@@ -1770,13 +1739,6 @@ packages:
     peerDependencies:
       acorn: ^8.9.0
 
-  '@sveltejs/package@2.5.8':
-    resolution: {integrity: sha512-zeBbsXYvHiBu56v4gJaGQoEHzg96w0E1j3dOMX8vo56s6vI5eQ57ZEZhudjwjnegnVitRRu5MrmhO0eNvaonIw==}
-    engines: {node: ^16.14 || >=18}
-    hasBin: true
-    peerDependencies:
-      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
-
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2':
     resolution: {integrity: sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==}
     engines: {node: ^20.19 || ^22.12 || >=24}
@@ -2553,9 +2515,6 @@ packages:
       supports-color:
         optional: true
 
-  dedent-js@1.0.1:
-    resolution: {integrity: sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==}
-
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -2757,6 +2716,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2837,8 +2797,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.6:
-    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -3985,9 +3945,6 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  scule@1.3.0:
-    resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4165,12 +4122,6 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
-
-  svelte2tsx@0.7.59:
-    resolution: {integrity: sha512-Itj7Wz9WIiGFl/uJa58+rf43ajezaljKK/KTOHq5abUjto56xe+o5SOzLwSoeJ5hma9NZEstpZiazFW2q1nZPQ==}
-    peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
-      typescript: ^4.9.4 || ^5.0.0 || ^6.0.0
 
   svelte@5.29.0:
     resolution: {integrity: sha512-ZF1FXoTsDbTlHShZs0kTznahQhU8drBXF2Vx1dt635MW/OHpy+iWvAHsIRp+ia25L1Vrczq9EsuMdLXM+cjknw==}
@@ -6008,17 +5959,6 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/package@2.5.8(svelte@5.29.0)(typescript@5.9.3)':
-    dependencies:
-      chokidar: 5.0.0
-      kleur: 4.1.5
-      sade: 1.8.1
-      semver: 7.8.5
-      svelte: 5.29.0
-      svelte2tsx: 0.7.59(svelte@5.29.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - typescript
-
   '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.29.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.29.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 6.2.1(svelte@5.29.0)(vite@7.3.5(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.22.4)(yaml@2.9.0))
@@ -6570,7 +6510,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.6
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6981,8 +6921,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  dedent-js@1.0.1: {}
 
   deep-is@0.1.4: {}
 
@@ -7399,7 +7337,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.6: {}
+  fast-uri@3.1.5: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -8512,8 +8450,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  scule@1.3.0: {}
-
   semver@6.3.1: {}
 
   semver@7.8.1: {}
@@ -8744,13 +8680,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
-
-  svelte2tsx@0.7.59(svelte@5.29.0)(typescript@5.9.3):
-    dependencies:
-      dedent-js: 1.0.1
-      scule: 1.3.0
-      svelte: 5.29.0
-      typescript: 5.9.3
 
   svelte@5.29.0:
     dependencies:

--- a/scripts/portable-runtime/styled-component-release.ts
+++ b/scripts/portable-runtime/styled-component-release.ts
@@ -72,6 +72,10 @@ const RELEASE_MANAGED_PACKAGES = new Set([
   "@starwind-ui/astro",
   "@starwind-ui/react",
 ]);
+const FINGERPRINT_RELEASE_MANAGED_PACKAGES = new Set([
+  ...RELEASE_MANAGED_PACKAGES,
+  "@starwind-ui/vue",
+]);
 const FIXED_GROUP_PACKAGES = [
   "@starwind-ui/runtime",
   "@starwind-ui/astro",
@@ -155,7 +159,7 @@ export function createStyledRegistryFingerprint(component: StyledRegistryCompone
   delete (normalized as Partial<StyledRegistryComponent>).sourceVersion;
   for (const target of Object.values(normalized.targets ?? {})) {
     for (const requirement of target.packageRequirements ?? []) {
-      if (RELEASE_MANAGED_PACKAGES.has(requirement.name)) {
+      if (FINGERPRINT_RELEASE_MANAGED_PACKAGES.has(requirement.name)) {
         requirement.range = "<release-managed>";
       }
     }

--- a/scripts/portable-runtime/tests/styled-component-release.test.ts
+++ b/scripts/portable-runtime/tests/styled-component-release.test.ts
@@ -234,12 +234,24 @@ describe("styled component release intents", () => {
 
   it("normalizes release-managed package ranges without hiding installable source changes", () => {
     const before = registryComponent("accordion", "2.0.1");
+    before.targets!.vue = structuredClone(before.targets!.react!);
+    before.targets!.vue.packageRequirements[0] = {
+      name: "@starwind-ui/vue",
+      range: "0.1.0",
+    };
     const releaseOnly = structuredClone(before);
     releaseOnly.version = "2.0.2";
     releaseOnly.sourceVersion = "2.0.2";
     releaseOnly.targets!.astro!.packageRequirements[0].range = "^0.1.0-beta.3";
+    releaseOnly.targets!.vue!.packageRequirements[0].range = "0.1.1";
     expect(createStyledRegistryFingerprint(before)).toBe(
       createStyledRegistryFingerprint(releaseOnly),
+    );
+
+    const externalDependencyChange = structuredClone(releaseOnly);
+    externalDependencyChange.targets!.vue!.packageRequirements[1].range = "^2.0.0";
+    expect(createStyledRegistryFingerprint(before)).not.toBe(
+      createStyledRegistryFingerprint(externalDependencyChange),
     );
 
     releaseOnly.targets!.astro!.files[0].content = "changed source";


### PR DESCRIPTION
The Version Packages check treated Vue's expected package version update as a source edit in every Styled component. Include Vue in release-range normalization for source fingerprints while preserving behavior-intent eligibility and checks for file or external dependency changes.

Refresh the public lockfile to remove the private Svelte workspace and its exclusive dependencies. Shared Svelte comparison dependencies remain. The existing override resolves fast-uri to 3.1.5.

Validation: 18 release-guard tests passed, the corrected fingerprint check found zero source changes across all 55 components in the generated release candidate, and public frozen installation passed. Formatting and lint passed. No package version or release intent changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when comparing styled registry components by normalizing managed Vue package version ranges.
  * Preserved detection of meaningful changes to external dependency version ranges.

* **Tests**
  * Expanded coverage to verify Vue package range normalization and external dependency change detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->