### PR TITLE
fix(deps): require patched fast-uri resolution

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   ajv@>=6.0.0 <7.0.0: 6.14.0
   brace-expansion@<2.0.0: 1.1.18
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
   nanoid@<3.3.18: 3.3.18
@@ -2797,8 +2797,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -6510,7 +6510,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7337,7 +7337,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,14 +32,13 @@ minimumReleaseAgeExclude:
   - "@astrojs/markdown-remark"
   - js-yaml@4.3.1
   - svgo@4.0.2
-  - fast-uri@3.1.5
   - sharp@0.35.0
 
 overrides:
   ajv@>=6.0.0 <7.0.0: 6.14.0
   brace-expansion@<2.0.0: 1.1.18
   brace-expansion@>=4.0.0 <5.0.9: 5.0.9
-  fast-uri@>=3.0.0 <3.1.5: 3.1.5
+  fast-uri@>=3.0.0 <3.1.6: 3.1.6
   js-yaml@>=3.0.0 <3.15.1: 3.15.1
   js-yaml@>=4.0.0 <4.3.1: 4.3.1
   nanoid@<3.3.18: 3.3.18


### PR DESCRIPTION
The production audit failed after lockfile refresh reapplied the old fast-uri override and selected vulnerable 3.1.5. Raise the override floor to patched 3.1.6 and remove the obsolete release-age exception for 3.1.5.

Private and public frozen installs pass. The production audit now passes its high-severity threshold, with the four fast-uri high advisories removed. One existing low advisory remains in the private demo's esbuild development tooling. Formatting and guarded sync checks pass.

Package versions and release intents are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution so versions of `fast-uri` below 3.1.6 use version 3.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->