### PR TITLE
perf(release): reuse verified artifacts and release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,12 @@ jobs:
   scope:
     name: Detect version materialization
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     outputs:
+      verification_reused: ${{ steps.verification.outputs.reusable }}
       versioned: ${{ steps.changes.outputs.versioned }}
     steps:
       - name: Checkout Repo
@@ -27,10 +32,17 @@ jobs:
         run: |
           node scripts/detect-release-version-changes.mjs "${GITHUB_SHA}^" "$GITHUB_SHA" >> "$GITHUB_OUTPUT"
 
+      - name: Check reusable candidate verification
+        id: verification
+        if: steps.changes.outputs.versioned == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/check-release-verification.mjs >> "$GITHUB_OUTPUT"
+
   verify:
     name: Verify
     needs: scope
-    if: needs.scope.outputs.versioned == 'true'
+    if: needs.scope.outputs.versioned == 'true' && needs.scope.outputs.verification_reused != 'true'
     uses: ./.github/workflows/verify.yml
 
   release:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 .svelte-kit/
 *.tsbuildinfo
 .eslintcache
+.release-packs/
 
 # internal context
 .context/

--- a/apps/vue-demo/package.json
+++ b/apps/vue-demo/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "smoke": "pnpm build && node ../../scripts/portable-runtime/tests/smoke/vue/verify-demo.mjs"
+    "smoke": "pnpm build && pnpm smoke:built",
+    "smoke:built": "node ../../scripts/portable-runtime/tests/smoke/vue/verify-demo.mjs"
   },
   "dependencies": {
     "@starwind-ui/vue": "workspace:*",

--- a/docs/release/versioning.md
+++ b/docs/release/versioning.md
@@ -76,6 +76,35 @@ The first Vue publication is historical: it published Vue `0.1.0` on `beta` and 
 `0.1.0` because no prior `latest` existed. It also published CLI `3.3.0`. Later beta publications
 must preserve the existing `latest` value.
 
+## Release preparation and verification
+
+Run `pnpm release:preflight` before opening release-tooling fixes. It copies the current source into
+an isolated temporary repository, rehearses `release:version`, checks frozen installation, tests the
+versioned registry and release helpers, and collects metadata, component-guard, and audit failures.
+The temporary repository is removed after the check.
+
+`pnpm release:gate` audits dependencies first, builds the public packages and demos once, and packs
+archives under `node_modules/.cache/starwind-release/packs/`. Each archive has its exact packed
+manifest and SHA-256 recorded in `manifest.json`. Both complete host matrices use these archives
+with two workers. Vue hosts run in separate processes. Use `--concurrency 1` on either acceptance
+command when diagnosing a host failure.
+
+The gate writes stage timings and completed checks to
+`node_modules/.cache/starwind-release/gate.json`. A later invocation reuses a completed prefix only
+when source files, the lockfile, toolchain, built outputs, archive hashes, and the stage plan match.
+It checks registry advisories on every invocation. Run `pnpm release:gate --fresh` for a complete
+rerun. Source edits or generated drift invalidate the record.
+
+The normal dry-run and user-run publisher require matching completed gate evidence for selected
+packages. They consume the verified archives through
+[pnpm's tarball publication interface](https://pnpm.io/cli/publish), so host acceptance and publication
+use the same files. The user still owns every real npm publication and authentication step.
+
+After the version PR merges, Release can reuse its bot-dispatched Verify run when the complete
+merged tree equals the tested candidate tree. Lookup errors, an unverified candidate, or changed
+content cause Verify to run again. The published-package acceptance command always runs after npm
+publication.
+
 ## Publication plans and GitHub releases
 
 The saved plan records package order, exact versions, tags, and the Vue `latest` baseline before the

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "release:version": "tsx scripts/portable-runtime/styled-component-release.ts version && tsx scripts/portable-runtime/primitive-component-release.ts version && changeset version && pnpm install --lockfile-only --ignore-scripts --no-frozen-lockfile && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
     "local:release": "pnpm build && pnpm release:version && changeset publish",
     "release:prepare": "pnpm runtime:generate:all && pnpm runtime:registry:generate && pnpm runtime:docs:metadata",
-    "release:gate": "pnpm verify:public && pnpm runtime:generate:vue:test && pnpm test:vue-cli-host-acceptance && pnpm --filter=starwind package:check && pnpm audit:prod && pnpm demo:smoke && pnpm react-demo:smoke && pnpm vue-demo:smoke && pnpm runtime:size:check:prepared && pnpm release:candidate:acceptance",
+    "release:gate": "node scripts/release-gate.mjs",
     "release:candidate:acceptance": "node scripts/release-candidate-acceptance.mjs",
     "release:artifacts": "node scripts/check-release-artifacts.mjs",
     "publish:release:dry-run": "pnpm release:artifacts && node scripts/release-packages.mjs --dry-run",
@@ -149,7 +149,8 @@
     "unlink:global": "node -e \"const { spawnSync } = require(\\\"node:child_process\\\"); const command = process.platform === \\\"win32\\\" ? \\\"pnpm.cmd\\\" : \\\"pnpm\\\"; const name = process.argv[1]; const listed = spawnSync(command, [\\\"list\\\", \\\"--global\\\", \\\"--depth\\\", \\\"-1\\\", \\\"--json\\\"], { encoding: \\\"utf8\\\" }); if (listed.status !== 0) { process.stderr.write(listed.stderr); process.exitCode = listed.status ?? 1; } else { const dependencies = JSON.parse(listed.stdout)[0]?.dependencies ?? {}; if (dependencies[name]) { const removed = spawnSync(command, [\\\"rm\\\", \\\"--global\\\", name], { stdio: \\\"inherit\\\" }); process.exitCode = removed.status ?? 1; } }\"",
     "test:vue-cli-local-link": "pnpm exec tsx --tsconfig packages/cli/tsconfig.json scripts/vue-cli-host-acceptance.mjs --local-link-only",
     "runtime:generate:test:ci": "pnpm exec vitest run --project=portable-runtime scripts/portable-runtime/tests/runtime-adapter-contract.test.ts scripts/portable-runtime/tests/styled-adapter-contract.test.ts scripts/portable-runtime/tests/framework-surface-manifest.test.mjs scripts/portable-runtime/tests/primitive-generator-registry.test.ts scripts/portable-runtime/tests/generate-cli-registry.test.ts scripts/portable-runtime/tests/framework-adapters.test.ts",
-    "vue:test:browser:ci": "pnpm exec vitest run --config packages/vue/tests/checkbox/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/dialog/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/select/vitest.config.ts --project=browser"
+    "vue:test:browser:ci": "pnpm exec vitest run --config packages/vue/tests/checkbox/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/dialog/vitest.config.ts --project=browser && pnpm exec vitest run --config packages/vue/tests/select/vitest.config.ts --project=browser",
+    "release:preflight": "node scripts/release-preflight.mjs"
   },
   "dependencies": {
     "turbo": "^2.5.4"

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -200,11 +200,12 @@
     "test:hydration:built": "node tests/integration/run-hydration-playwright.mjs && node tests/integration/run-styled-hydration-playwright.mjs",
     "test:release": "pnpm --filter=@starwind-ui/runtime build && pnpm build && pnpm test:release:built",
     "test:release:built": "vitest run --config tests/vitest.config.ts --project=release-package",
-    "test:all": "pnpm --filter=@starwind-ui/runtime build && pnpm build && pnpm test:run && pnpm test:browser && pnpm test:hydration:built && pnpm test:release:built",
+    "test:all": "pnpm --filter=@starwind-ui/runtime build && pnpm build && pnpm test:all:built",
     "test:select:built": "pnpm build && node tests/select/run-select-playwright.mjs",
     "typecheck": "vue-tsc --noEmit -p tsconfig.json",
     "format:check": "prettier --ignore-path ../../.prettierignore --check \"**/*.{ts,vue,md,json}\"",
-    "format:write": "prettier --ignore-path ../../.prettierignore --write \"**/*.{ts,vue,md,json}\" --cache"
+    "format:write": "prettier --ignore-path ../../.prettierignore --write \"**/*.{ts,vue,md,json}\" --cache",
+    "test:all:built": "pnpm test:run && pnpm test:browser && pnpm test:hydration:built && pnpm test:release:built"
   },
   "dependencies": {
     "@starwind-ui/runtime": "1.2.1"

--- a/packages/vue/tests/integration/workspace-contract.test.ts
+++ b/packages/vue/tests/integration/workspace-contract.test.ts
@@ -75,8 +75,6 @@ describe("Vue public-beta vertical-slice workspace contract", () => {
       kind: "subset",
     });
     expect(rootPackage.scripts["release:prepare"]).toContain("runtime:generate:all");
-    expect(rootPackage.scripts["release:gate"]).toContain("vue-demo:smoke");
-    expect(rootPackage.scripts["release:gate"]).toContain("runtime:size:check:prepared");
     expect(rootPackage.scripts["release:candidate:acceptance"]).toBe(
       "node scripts/release-candidate-acceptance.mjs",
     );

--- a/scripts/check-release-verification.mjs
+++ b/scripts/check-release-verification.mjs
@@ -1,0 +1,100 @@
+import { execFile } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const VERIFY_WORKFLOW_FILE = "verify.yml";
+const VERIFY_WORKFLOW_PATH = ".github/workflows/verify.yml";
+
+async function ghApi(endpoint) {
+  const { stdout } = await execFileAsync("gh", ["api", "--method", "GET", endpoint], {
+    encoding: "utf8",
+    env: process.env,
+  });
+  return JSON.parse(stdout);
+}
+
+export async function checkReusableReleaseVerification({
+  api = ghApi,
+  baseRef = "main",
+  currentSha,
+  repository,
+}) {
+  try {
+    if (!repository || !currentSha) {
+      return { reason: "repository and current commit are required", reusable: false };
+    }
+
+    const pullRequests = await api(`repos/${repository}/commits/${currentSha}/pulls`);
+    const candidates = pullRequests.filter(
+      (pullRequest) =>
+        pullRequest.merged_at &&
+        pullRequest.merge_commit_sha === currentSha &&
+        pullRequest.base?.ref === baseRef &&
+        pullRequest.head?.repo?.full_name === repository &&
+        typeof pullRequest.head?.sha === "string",
+    );
+    if (candidates.length !== 1) {
+      return {
+        reason: "the merged commit does not identify one same-repository pull request",
+        reusable: false,
+      };
+    }
+
+    const candidateSha = candidates[0].head.sha;
+    const [currentCommit, candidateCommit, workflow] = await Promise.all([
+      api(`repos/${repository}/git/commits/${currentSha}`),
+      api(`repos/${repository}/git/commits/${candidateSha}`),
+      api(`repos/${repository}/actions/workflows/${VERIFY_WORKFLOW_FILE}`),
+    ]);
+    if (!currentCommit.tree?.sha || currentCommit.tree.sha !== candidateCommit.tree?.sha) {
+      return { reason: "the merged and verified candidate trees differ", reusable: false };
+    }
+    if (workflow.path !== VERIFY_WORKFLOW_PATH || workflow.state !== "active") {
+      return { reason: "the verification workflow identity is unavailable", reusable: false };
+    }
+
+    const runs = await api(
+      `repos/${repository}/actions/workflows/${workflow.id}/runs?event=workflow_dispatch&head_sha=${candidateSha}&status=completed&per_page=100`,
+    );
+    const successfulRun = runs.workflow_runs?.find(
+      (run) =>
+        run.workflow_id === workflow.id &&
+        run.repository?.full_name === repository &&
+        run.actor?.login === "github-actions[bot]" &&
+        run.triggering_actor?.login === "github-actions[bot]" &&
+        run.head_sha === candidateSha &&
+        run.event === "workflow_dispatch" &&
+        run.status === "completed" &&
+        run.conclusion === "success" &&
+        run.path?.split("@")[0] === VERIFY_WORKFLOW_PATH,
+    );
+    if (!successfulRun) {
+      return {
+        reason: "the exact candidate has no successful dispatched verification",
+        reusable: false,
+      };
+    }
+
+    return { candidateSha, reason: `reusing verification run ${successfulRun.id}`, reusable: true };
+  } catch (error) {
+    return {
+      reason: `verification lookup failed: ${error instanceof Error ? error.message : String(error)}`,
+      reusable: false,
+    };
+  }
+}
+
+async function main() {
+  const result = await checkReusableReleaseVerification({
+    baseRef: process.env.GITHUB_REF_NAME ?? "main",
+    currentSha: process.env.GITHUB_SHA,
+    repository: process.env.GITHUB_REPOSITORY,
+  });
+  console.error(`[release-verification] ${result.reason}`);
+  console.log(`reusable=${result.reusable}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/node22-public-consumer-smoke.mjs
+++ b/scripts/node22-public-consumer-smoke.mjs
@@ -2,6 +2,7 @@
 
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -232,11 +233,14 @@ function fileSpecifier(file) {
   return `file:${file.replaceAll("\\", "/")}`;
 }
 
-async function loadArtifactManifest(packagesDirectory) {
+export async function loadArtifactManifest(packagesDirectory) {
   const manifest = JSON.parse(
     await readFile(path.join(packagesDirectory, "manifest.json"), "utf8"),
   );
-  assert.equal(manifest.schemaVersion, 1);
+  assert(
+    manifest.schemaVersion === 1 || manifest.schemaVersion === 2,
+    `Unsupported public artifact manifest schema: ${String(manifest.schemaVersion)}.`,
+  );
   assert.match(manifest.builtWithNode, /^v24\./, "Public artifacts must be built under Node 24");
   const expectedNames = {
     astro: "@starwind-ui/astro",
@@ -249,7 +253,16 @@ async function loadArtifactManifest(packagesDirectory) {
     assert.equal(entry?.name, name);
     assert.equal(typeof entry.version, "string");
     assert.equal(typeof entry.file, "string");
-    await access(path.join(packagesDirectory, entry.file));
+    const archive = path.join(packagesDirectory, entry.file);
+    await access(archive);
+    if (manifest.schemaVersion === 2) {
+      assert.equal(typeof entry.sha256, "string", `${name} must record its archive SHA-256`);
+      assert.match(entry.sha256, /^[a-f0-9]{64}$/, `${name} must record its archive SHA-256`);
+      const actual = createHash("sha256")
+        .update(await readFile(archive))
+        .digest("hex");
+      assert.equal(actual, entry.sha256, `${name} archive SHA-256 does not match its manifest`);
+    }
   }
   return manifest;
 }

--- a/scripts/pack-public-release-artifacts.mjs
+++ b/scripts/pack-public-release-artifacts.mjs
@@ -1,10 +1,12 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { releaseSourceFingerprint } from "./release-inputs.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
@@ -111,6 +113,7 @@ export function parseArgs(argv) {
 }
 
 export async function packPublicReleaseArtifacts({ outputDirectory, vueBeta = false }) {
+  const sourceFingerprint = releaseSourceFingerprint(REPO_ROOT);
   const plan = createPackPlan({ outputDirectory, vueBeta });
   await mkdir(outputDirectory, { recursive: true });
   const artifactPackages = {};
@@ -127,13 +130,20 @@ export async function packPublicReleaseArtifacts({ outputDirectory, vueBeta = fa
       file: entry.fileName,
       name: packageManifest.name,
       version: packageManifest.version,
+      sha256: createHash("sha256")
+        .update(await readFile(entry.file))
+        .digest("hex"),
+      manifest: JSON.parse(
+        execFileSync("tar", ["-xOf", entry.file, "package/package.json"], { encoding: "utf8" }),
+      ),
     };
   }
 
   const artifactManifest = {
     builtWithNode: process.version,
     packages: artifactPackages,
-    schemaVersion: 1,
+    schemaVersion: 2,
+    sourceFingerprint,
   };
   await writeFile(
     path.join(outputDirectory, "manifest.json"),
@@ -141,6 +151,61 @@ export async function packPublicReleaseArtifacts({ outputDirectory, vueBeta = fa
     "utf8",
   );
   return artifactManifest;
+}
+
+export async function loadPublicReleaseArtifacts({
+  outputDirectory,
+  repoRoot = REPO_ROOT,
+  requireVue = false,
+}) {
+  const manifest = JSON.parse(await readFile(path.join(outputDirectory, "manifest.json"), "utf8"));
+  assert.equal(
+    manifest.schemaVersion,
+    2,
+    "Repack release artifacts with the current pack command.",
+  );
+  assert.equal(
+    manifest.sourceFingerprint,
+    releaseSourceFingerprint(repoRoot),
+    "Release sources or toolchain changed; rerun the release gate.",
+  );
+  assert(
+    manifest.packages && typeof manifest.packages === "object",
+    "Missing release archive inventory.",
+  );
+  const expectedPackages =
+    requireVue || Object.hasOwn(manifest.packages, "vue") ? VUE_BETA_PACKAGES : PUBLIC_PACKAGES;
+  assert.deepEqual(
+    Object.keys(manifest.packages).sort(),
+    expectedPackages.map(({ key }) => key).sort(),
+    "Release archive inventory is incomplete or unexpected.",
+  );
+  for (const [key, entry] of Object.entries(manifest.packages)) {
+    const expected = VUE_BETA_PACKAGES.find((candidate) => candidate.key === key);
+    assert(
+      expected && entry.name === expected.name && entry.file === expected.fileName,
+      `Unexpected release archive: ${key}`,
+    );
+    const archive = path.join(outputDirectory, entry.file);
+    assert.equal(
+      createHash("sha256")
+        .update(await readFile(archive))
+        .digest("hex"),
+      entry.sha256,
+      `Release archive changed: ${entry.name}`,
+    );
+    const packed = JSON.parse(
+      execFileSync("tar", ["-xOf", archive, "package/package.json"], { encoding: "utf8" }),
+    );
+    assert.deepEqual(packed, entry.manifest, `Packed metadata changed: ${entry.name}`);
+    const current = JSON.parse(
+      await readFile(path.join(repoRoot, expected.directory, "package.json"), "utf8"),
+    );
+    assert.equal(packed.name, current.name);
+    assert.equal(packed.version, current.version);
+    assert.equal(entry.version, current.version);
+  }
+  return manifest;
 }
 
 async function main() {

--- a/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
+++ b/scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts
@@ -382,12 +382,6 @@ describe("Vue package foundation", () => {
     expect(rootPackage.scripts["test:all"]).toContain("pnpm vue:test");
     expect(rootPackage.scripts["release:prepare"]).toContain("pnpm runtime:generate:all");
     expect(rootPackage.scripts["release:prepare"]).toContain("pnpm runtime:registry:generate");
-    expect(rootPackage.scripts["release:gate"]).toContain("pnpm vue-demo:smoke");
-    expect(rootPackage.scripts["release:gate"]).toContain("pnpm runtime:size:check:prepared");
-    expect(
-      rootPackage.scripts["release:gate"].includes("pnpm runtime:perf:vue:evidence:check"),
-    ).toBe(hasPrivateSvelte);
-    expect(rootPackage.scripts["release:gate"]).toContain("pnpm release:candidate:acceptance");
 
     const changesetConfig = JSON.parse(await readFile(".changeset/config.json", "utf8"));
     expect(changesetConfig.fixed).toEqual([

--- a/scripts/portable-runtime/tests/measure-package-sizes.test.mjs
+++ b/scripts/portable-runtime/tests/measure-package-sizes.test.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { releaseGateStages } from "../../release-gate.mjs";
 
 import {
   addSourceContributionContexts,
@@ -14,13 +15,13 @@ import {
   formatColorPickerSizeComparisonMarkdown,
   formatPackageSizeReports,
   getPackageSizeCommandMode,
-  publicComparatorInstallSpecifiers,
-  publicComparatorExpectedResolvedVersions,
-  validateInstalledPublicComparators,
   getPackageSizeMeasurementPlan,
   measureBundle,
+  publicComparatorExpectedResolvedVersions,
+  publicComparatorInstallSpecifiers,
   resolveStarwindVueBuiltPath,
   summarizeDynamicBundleOutput,
+  validateInstalledPublicComparators,
   validateInstalledZagVueComparator,
   withVueSourceContribution,
   writePackageSizeReports,
@@ -55,7 +56,7 @@ describe("package-size command prerequisites", () => {
     expect(rootPackage.scripts["runtime:size:baseline:vue"]).toBe(
       "node scripts/portable-runtime/measure-package-sizes.mjs --baseline-vue",
     );
-    expect(rootPackage.scripts["release:gate"]).toContain("pnpm runtime:size:check:prepared");
+    expect(releaseGateStages().map(([, args]) => args[0])).toContain("runtime:size:check:prepared");
     expect(rootPackage.scripts["release:gate"]).not.toContain(
       "pnpm runtime:size:check:prepared:private",
     );

--- a/scripts/portable-runtime/tests/vue-contract-gate.test.ts
+++ b/scripts/portable-runtime/tests/vue-contract-gate.test.ts
@@ -123,7 +123,6 @@ const approvedVueScriptNames = [
   "l",
   "publish:vue-beta",
   "publish:vue-beta:dry-run",
-  "release:gate",
   "release:pack:vue-beta-artifacts",
   "release:vue-beta:artifacts",
   "release:vue-beta:artifacts:record",
@@ -163,7 +162,6 @@ const approvedVueScriptNameSet = new Set<string>(approvedVueScriptNames);
 const approvedVueReleaseScriptNames = new Set([
   "publish:vue-beta",
   "publish:vue-beta:dry-run",
-  "release:gate",
   "release:pack:vue-beta-artifacts",
   "release:vue-beta:artifacts",
   "release:vue-beta:artifacts:record",
@@ -730,7 +728,8 @@ describe("Vue public-beta contract gate", () => {
       scripts: {
         build: "vue-tsc -b && vite build",
         dev: "vite",
-        smoke: "pnpm build && node ../../scripts/portable-runtime/tests/smoke/vue/verify-demo.mjs",
+        smoke: "pnpm build && pnpm smoke:built",
+        "smoke:built": "node ../../scripts/portable-runtime/tests/smoke/vue/verify-demo.mjs",
       },
     });
     for (const cohortComponent of [
@@ -907,6 +906,8 @@ describe("Vue public-beta contract gate", () => {
         : undefined,
     });
     expect(findVueScriptPolicyViolations(rootScripts)).toEqual([]);
+    expect(rootScripts["release:gate"]).toBe("node scripts/release-gate.mjs");
+
     expect(
       findVueScriptPolicyViolations({
         ...rootScripts,

--- a/scripts/release-candidate-acceptance.mjs
+++ b/scripts/release-candidate-acceptance.mjs
@@ -8,8 +8,8 @@ import { createRequire } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
-
 import { getPackageManagerCommand } from "./command-process.mjs";
+import { loadPublicReleaseArtifacts } from "./pack-public-release-artifacts.mjs";
 import {
   getFixtureFiles,
   runCommand,
@@ -734,8 +734,53 @@ export function createCandidateVerificationPlan(project, manifest = {}) {
   ];
 }
 
+export async function runCandidateProjects(projects, { concurrency = 2, runProject }) {
+  assert(
+    Number.isSafeInteger(concurrency) && concurrency > 0,
+    "Expected positive integer concurrency.",
+  );
+  let next = 0;
+  const errors = [];
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, projects.length) }, async () => {
+      while (errors.length === 0 && next < projects.length) {
+        const project = projects[next++];
+        try {
+          await runProject(project);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+    }),
+  );
+  if (errors.length === 1) throw errors[0];
+  if (errors.length) throw new AggregateError(errors, "Acceptance projects failed.");
+}
+
+export async function prepareCandidatePackages(
+  { packsDirectory, packDirectory },
+  { loadArtifacts = loadPublicReleaseArtifacts, packPackages = packWorkspacePackages } = {},
+) {
+  if (!packsDirectory) {
+    const packages = await packPackages(packDirectory);
+    return { packages, registryPackages: await getCandidateRegistryPackages(packages) };
+  }
+  const artifacts = await loadArtifacts({ outputDirectory: path.resolve(packsDirectory) });
+  const packages = {};
+  const registryPackages = {};
+  for (const key of ["runtime", "astro", "react", "vue", "cli"]) {
+    const entry = artifacts.packages[key];
+    assert(entry, `Prepared release packs are missing ${key}.`);
+    packages[key] = path.resolve(packsDirectory, entry.file);
+    if (key !== "cli") registryPackages[key] = { ...entry, file: packages[key] };
+  }
+  return { packages, registryPackages };
+}
+
 export async function runReleaseCandidateAcceptance({
   artifacts: artifactsOption,
+  concurrency = 2,
+  packsDirectory,
   keepTemp = false,
   projectIds,
 } = {}) {
@@ -743,8 +788,10 @@ export async function runReleaseCandidateAcceptance({
   const artifacts = artifactsOption
     ? path.resolve(artifactsOption)
     : await mkdtemp(path.join(os.tmpdir(), "starwind-release-candidate-artifacts-"));
-  const packages = await packWorkspacePackages(path.join(root, "packs"));
-  const registryPackages = await getCandidateRegistryPackages(packages);
+  const { packages, registryPackages } = await prepareCandidatePackages({
+    packsDirectory,
+    packDirectory: path.join(root, "packs"),
+  });
   const plan = createCandidatePlan({
     packages,
     projectIds,
@@ -788,7 +835,10 @@ export async function runReleaseCandidateAcceptance({
       await runCommand({ args: ["install"], cwd: project.directory });
     }
 
-    for (const project of plan.projects) await runProjectLifecycle(project, plan);
+    await runCandidateProjects(plan.projects, {
+      concurrency,
+      runProject: (project) => runProjectLifecycle(project, plan),
+    });
 
     const reactDemoRequire = createRequire(path.join(REPO_ROOT, "apps/react-demo/package.json"));
     const { chromium } = reactDemoRequire("playwright");
@@ -819,11 +869,23 @@ export async function runReleaseCandidateAcceptance({
 
 export function parseArgs(argv) {
   let artifacts;
+  let packsDirectory;
+  let concurrency = 2;
   let keepTemp = false;
   const projectIds = [];
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
-    if (argument === "--keep-temp") keepTemp = true;
+    if (argument === "--packs") {
+      packsDirectory = argv[++index];
+      if (!packsDirectory || packsDirectory.startsWith("--"))
+        throw new Error("Expected a path after --packs.");
+    } else if (argument === "--concurrency") {
+      concurrency = Number(argv[++index]);
+      assert(
+        Number.isSafeInteger(concurrency) && concurrency > 0,
+        "Expected positive integer concurrency.",
+      );
+    } else if (argument === "--keep-temp") keepTemp = true;
     else if (argument === "--artifacts") {
       artifacts = argv[index + 1];
       if (!artifacts) throw new Error("Expected a path after --artifacts.");
@@ -837,7 +899,13 @@ export function parseArgs(argv) {
       projectIds.push(argument.slice("--project=".length));
     } else throw new Error(`Unknown argument: ${argument}`);
   }
-  return { artifacts, keepTemp, projectIds: projectIds.length > 0 ? projectIds : undefined };
+  return {
+    artifacts,
+    concurrency,
+    packsDirectory,
+    keepTemp,
+    projectIds: projectIds.length > 0 ? projectIds : undefined,
+  };
 }
 
 async function main() {

--- a/scripts/release-finalization.mjs
+++ b/scripts/release-finalization.mjs
@@ -15,8 +15,8 @@ import { loadPublicationPlan } from "./release-publication-plan.mjs";
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const PUBLIC_REPOSITORY = "starwind-ui/starwind-ui";
-const DEFAULT_REGISTRY_VERIFICATION_ATTEMPTS = 12;
-const DEFAULT_REGISTRY_RETRY_DELAY_MS = 5_000;
+const DEFAULT_REGISTRY_VERIFICATION_ATTEMPTS = 31;
+const DEFAULT_REGISTRY_RETRY_DELAY_MS = 10_000;
 
 export function createCommandSystem({ cwd = ROOT_DIR, spawnProcess = spawn } = {}) {
   async function capture(command, args) {
@@ -125,8 +125,8 @@ function isRetryableRegistryFailure(result) {
 
 function createRegistryPropagationError(subject, attempt, finalizeCommand) {
   return new Error(
-    `${subject} did not become visible on npm after ${attempt} registry ${attempt === 1 ? "check" : "checks"}. ` +
-      `The package publication may have succeeded. Wait for npm propagation, then run ${finalizeCommand}.`,
+    `${subject} did not become visible with its expected npm state after ${attempt} registry ${attempt === 1 ? "check" : "checks"}. ` +
+      `The package publication may have succeeded and is awaiting npm propagation. Do not publish again; wait, then run ${finalizeCommand}.`,
   );
 }
 
@@ -137,10 +137,15 @@ export async function verifyPublishedPackages(release, system, options = {}) {
   const finalizeCommand = release.finalizeCommand ?? "pnpm release:finalize";
   const onRetry =
     options.onRetry ??
-    ((spec, attempt) => {
+    ((subject, attempt) => {
       console.log(
-        `[finalize] Waiting for ${spec} to become visible on npm (${attempt}/${attempts})...`,
+        `[finalize] ${subject} is awaiting npm visibility; retry ${attempt + 1}/${attempts} in ${retryDelayMs / 1_000}s.`,
       );
+    });
+  const onPublished =
+    options.onPublished ??
+    ((spec, expectedTag) => {
+      console.log(`[finalize] ${spec} is visible on npm; checking dist-tag ${expectedTag}.`);
     });
   if (!Number.isInteger(attempts) || attempts < 1) {
     throw new Error("Registry verification attempts must be a positive integer.");
@@ -151,6 +156,8 @@ export async function verifyPublishedPackages(release, system, options = {}) {
 
   for (const entry of release.packages) {
     const spec = `${entry.name}@${entry.version}`;
+    const expectedTag = entry.tag ?? release.npmTag;
+    if (!expectedTag) throw new Error(`${spec} is missing its expected npm dist-tag.`);
     for (let attempt = 1; attempt <= attempts; attempt += 1) {
       const versionResult = await system.capture("npm", ["view", spec, "version", "--json"]);
       if (versionResult.code !== 0) {
@@ -169,9 +176,7 @@ export async function verifyPublishedPackages(release, system, options = {}) {
           `${spec} resolved to unexpected version ${JSON.stringify(publishedVersion)}.`,
         );
       }
-
-      const expectedTag = entry.tag ?? release.npmTag;
-      if (!expectedTag) throw new Error(`${spec} is missing its expected npm dist-tag.`);
+      onPublished(spec, expectedTag);
       const tagsResult = await system.capture("npm", ["view", spec, "dist-tags", "--json"]);
       if (tagsResult.code !== 0) {
         if (attempt < attempts && isRetryableRegistryFailure(tagsResult)) {
@@ -189,14 +194,29 @@ export async function verifyPublishedPackages(release, system, options = {}) {
         parseJsonOutput(tagsResult, `${spec} dist-tags`);
       }
       const tags = parseJsonOutput(tagsResult, `${spec} dist-tags`);
-      if (tags?.[expectedTag] !== entry.version) {
+      const taggedVersion = tags?.[expectedTag];
+      if (taggedVersion == null) {
         if (attempt < attempts) {
-          onRetry(spec, attempt);
+          onRetry(`${spec} dist-tag ${expectedTag}`, attempt);
           await waitForRetry(retryDelayMs);
           continue;
         }
-        throw new Error(
-          `${entry.name} dist-tag ${expectedTag} must point to ${entry.version}, found ${tags?.[expectedTag] ?? "nothing"}.`,
+        throw createRegistryPropagationError(
+          `${spec} dist-tag ${expectedTag}`,
+          attempt,
+          finalizeCommand,
+        );
+      }
+      if (taggedVersion !== entry.version) {
+        if (attempt < attempts) {
+          onRetry(`${spec} dist-tag ${expectedTag}`, attempt);
+          await waitForRetry(retryDelayMs);
+          continue;
+        }
+        throw createRegistryPropagationError(
+          `${entry.name} dist-tag ${expectedTag} must point to ${entry.version}, found ${taggedVersion}`,
+          attempt,
+          finalizeCommand,
         );
       }
       for (const [preservedTag, preservedVersion] of Object.entries(

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { loadPublicReleaseArtifacts } from "./pack-public-release-artifacts.mjs";
+import { releaseOutputFingerprint, releaseSourceFingerprint } from "./release-inputs.mjs";
+import { runReleaseCommand } from "./release-preflight.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const RELEASE_PACKS = "node_modules/.cache/starwind-release/packs";
+const RECORD = "node_modules/.cache/starwind-release/gate.json";
+
+export function releaseGateStages({ privateEvidence = false } = {}) {
+  return [
+    ["static", ["check:public"]],
+    ["styled metadata", ["styled:versions:check"]],
+    ["primitive metadata", ["primitive:versions:check"]],
+    ["test ownership", ["test:homes"]],
+    ["generator types", ["runtime:generate:typecheck"]],
+    ["docs metadata", ["runtime:docs:metadata:check"]],
+    ["build", ["build:public"]],
+    ["package size", ["--filter=starwind", "package:check"]],
+    [
+      "pack",
+      [
+        "exec",
+        "node",
+        "scripts/pack-public-release-artifacts.mjs",
+        "--vue-beta",
+        "--output",
+        RELEASE_PACKS,
+      ],
+    ],
+    ["repo and generator tests", ["test:run"]],
+    ["runtime tests", ["runtime:test"]],
+    ["react tests", ["react:test"]],
+    ["vue tests", ["--filter=@starwind-ui/vue", "test:all:built"]],
+    ["vue generator tests", ["runtime:generate:vue:test"]],
+    ["astro demo", ["demo:smoke"]],
+    ["react demo", ["react-demo:smoke"]],
+    ["vue demo", ["--filter=vue-demo", "smoke:built"]],
+    ["bundle sizes", ["runtime:size:check:prepared"]],
+    ...(privateEvidence ? [["private Vue evidence", ["runtime:perf:vue:evidence:check"]]] : []),
+    ["Vue hosts", ["test:vue-cli-host-acceptance", "--packs", RELEASE_PACKS, "--concurrency", "2"]],
+    [
+      "candidate hosts",
+      ["release:candidate:acceptance", "--packs", RELEASE_PACKS, "--concurrency", "2"],
+    ],
+  ];
+}
+
+export function reusableGateRecord(record, { source, outputs, stages }) {
+  return (
+    record?.schemaVersion === 1 &&
+    record.source === source &&
+    record.outputs === outputs &&
+    JSON.stringify(record.stages) === JSON.stringify(stages) &&
+    Array.isArray(record.completed) &&
+    record.completed.length <= stages.length &&
+    record.completed.every((entry, index) => entry.name === stages[index][0]) &&
+    (!record.complete || record.completed.length === stages.length)
+  );
+}
+
+export async function assertReleaseGate({ root = ROOT } = {}) {
+  const record = JSON.parse(await readFile(path.join(root, RECORD), "utf8"));
+  assert(
+    record.complete &&
+      reusableGateRecord(record, {
+        source: releaseSourceFingerprint(root),
+        outputs: releaseOutputFingerprint(root, path.join(root, RELEASE_PACKS)),
+        stages: releaseGateStages({
+          privateEvidence: existsSync(path.join(root, "packages/svelte/package.json")),
+        }),
+      }),
+    "Release gate evidence is missing or stale; run pnpm release:gate.",
+  );
+  await loadPublicReleaseArtifacts({
+    outputDirectory: path.join(root, RELEASE_PACKS),
+    repoRoot: root,
+    requireVue: true,
+  });
+  return record;
+}
+
+export async function runReleaseGate({ root = ROOT, fresh = false, run = runReleaseCommand } = {}) {
+  const started = Date.now();
+  // Registry advisories can change without a source edit, so audit on every invocation.
+  await run(["audit:prod"], root);
+  await run(["exec", "node", "scripts/release-preflight.mjs", "--metadata"], root);
+  const stages = releaseGateStages({
+    privateEvidence: existsSync(path.join(root, "packages/svelte/package.json")),
+  });
+  const source = releaseSourceFingerprint(root);
+  const packs = path.join(root, RELEASE_PACKS);
+  const recordFile = path.join(root, RECORD);
+  let record;
+  try {
+    record = JSON.parse(await readFile(recordFile, "utf8"));
+  } catch {
+    /* A missing record requires every stage. */
+  }
+  if (
+    fresh ||
+    !reusableGateRecord(record, { source, outputs: releaseOutputFingerprint(root, packs), stages })
+  )
+    record = { schemaVersion: 1, source, stages, completed: [], complete: false };
+  record.complete = false;
+  await mkdir(path.dirname(recordFile), { recursive: true });
+  await writeFile(recordFile, `${JSON.stringify(record, null, 2)}\n`);
+  for (const [name, args] of stages) {
+    if (record.completed.some((entry) => entry.name === name)) {
+      console.log(`[release-gate] reuse ${name}`);
+      continue;
+    }
+    const start = Date.now();
+    console.log(`[release-gate] start ${name}`);
+    await run(args, root);
+    assert.equal(
+      releaseSourceFingerprint(root),
+      source,
+      `Source changed during ${name}; rerun the gate after reviewing generated drift.`,
+    );
+    record.completed.push({ name, seconds: (Date.now() - start) / 1000 });
+    record.outputs = releaseOutputFingerprint(root, packs);
+    await writeFile(recordFile, `${JSON.stringify(record, null, 2)}\n`);
+    console.log(`[release-gate] passed ${name} (${record.completed.at(-1).seconds.toFixed(1)}s)`);
+  }
+  await loadPublicReleaseArtifacts({ outputDirectory: packs, repoRoot: root, requireVue: true });
+  record.complete = true;
+  record.outputs = releaseOutputFingerprint(root, packs);
+  await writeFile(recordFile, `${JSON.stringify(record, null, 2)}\n`);
+  console.log(
+    `[release-gate] complete in ${((Date.now() - started) / 1000).toFixed(1)}s; evidence: ${recordFile}`,
+  );
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  const args = process.argv.slice(2);
+  const operation =
+    args.length === 1 && args[0] === "--check"
+      ? assertReleaseGate()
+      : args.length === 0 || (args.length === 1 && args[0] === "--fresh")
+        ? runReleaseGate({ fresh: args.includes("--fresh") })
+        : Promise.reject(new Error("Expected no arguments, --fresh, or --check."));
+  operation.catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release-inputs.mjs
+++ b/scripts/release-inputs.mjs
@@ -1,0 +1,81 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { createSpawnCommand, getPackageManagerCommand } from "./command-process.mjs";
+
+export function releaseSourceFiles(root) {
+  return [
+    ...new Set(
+      execFileSync("git", ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], {
+        cwd: root,
+        encoding: "utf8",
+      })
+        .split("\0")
+        .filter(Boolean),
+    ),
+  ].sort();
+}
+
+export function fingerprintFiles(root, files) {
+  const hash = createHash("sha256");
+  for (const file of [...files].sort()) {
+    const target = path.join(root, file);
+    hash.update(file).update("\0");
+    if (!existsSync(target)) {
+      hash.update("missing\0");
+      continue;
+    }
+    const stat = lstatSync(target);
+    if (!stat.isFile()) throw new Error(`Release input must be a regular file: ${file}`);
+    hash
+      .update(String(stat.mode & 0o111))
+      .update("\0")
+      .update(readFileSync(target))
+      .update("\0");
+  }
+  return hash.digest("hex");
+}
+
+export function releaseToolchain(root) {
+  const command = createSpawnCommand(getPackageManagerCommand("pnpm"), ["--version"]);
+  return {
+    node: process.version,
+    pnpm: execFileSync(command.command, command.args, { cwd: root, encoding: "utf8" }).trim(),
+    platform: process.platform,
+    arch: process.arch,
+  };
+}
+
+export function releaseSourceFingerprint(root) {
+  return createHash("sha256")
+    .update(JSON.stringify(releaseToolchain(root)))
+    .update(fingerprintFiles(root, releaseSourceFiles(root)))
+    .digest("hex");
+}
+
+export function releaseOutputFingerprint(root, packsDirectory) {
+  const files = [];
+  function visit(relative) {
+    const target = path.join(root, relative);
+    if (!existsSync(target)) {
+      files.push(relative);
+      return;
+    }
+    if (lstatSync(target).isDirectory()) {
+      for (const entry of readdirSync(target).sort()) visit(path.join(relative, entry));
+    } else files.push(relative);
+  }
+  for (const directory of [
+    "packages/runtime/dist",
+    "packages/react/dist",
+    "packages/vue/dist",
+    "packages/cli/dist",
+    "apps/demo/dist",
+    "apps/react-demo/dist",
+    "apps/vue-demo/dist",
+    path.relative(root, packsDirectory),
+  ])
+    visit(directory);
+  return fingerprintFiles(root, files);
+}

--- a/scripts/release-packages.mjs
+++ b/scripts/release-packages.mjs
@@ -179,6 +179,7 @@ function getResumeIndex(resumeFrom, releasePlan = RELEASE_PACKAGE_SET) {
 }
 
 export function createPublishCommands({
+  archives,
   dryRun = false,
   otp,
   releasePlan = RELEASE_PACKAGE_SET,
@@ -197,7 +198,17 @@ export function createPublishCommands({
     if (!SAFE_DIST_TAG_PATTERN.test(packageTag)) {
       throw new Error(`Invalid npm dist-tag: ${packageTag}.`);
     }
-    const args = ["publish", "--tag", packageTag, "--access", "public", "--no-git-checks"];
+    if (archives && !archives[entry.name])
+      throw new Error(`Missing verified archive: ${entry.name}`);
+    const args = [
+      "publish",
+      ...(archives ? [archives[entry.name]] : []),
+      "--tag",
+      packageTag,
+      "--access",
+      "public",
+      "--no-git-checks",
+    ];
     if (dryRun) args.push("--dry-run");
     if (otp) args.push("--otp", otp);
     return {
@@ -620,6 +631,7 @@ async function main() {
     runReleaseFinalization,
   } = await import("./release-finalization.mjs");
   let releasePlan = VUE_BETA_RELEASE_PLAN;
+  let archives;
   if (vueBeta && gitState) {
     await captureVueBetaRegistryBaseline({ head: gitState.head, resumeFrom });
   }
@@ -653,6 +665,17 @@ async function main() {
       );
     }
     releasePlan = selected.map(({ entry }) => entry);
+    const { assertReleaseGate, RELEASE_PACKS } = await import("./release-gate.mjs");
+    const { loadPublicReleaseArtifacts } = await import("./pack-public-release-artifacts.mjs");
+    await assertReleaseGate();
+    const outputDirectory = path.join(ROOT_DIR, RELEASE_PACKS);
+    const artifacts = await loadPublicReleaseArtifacts({ outputDirectory });
+    archives = Object.fromEntries(
+      Object.values(artifacts.packages).map((entry) => [
+        entry.name,
+        path.join(outputDirectory, entry.file),
+      ]),
+    );
     console.log("[publish-plan] Routine release order:");
     for (const target of formatPublishPlan(selected)) console.log(`- ${target}`);
   } else {
@@ -663,6 +686,7 @@ async function main() {
     dryRun,
     finalize: () => runReleaseFinalization({ vueBeta }),
     publishCommands: createPublishCommands({
+      archives,
       dryRun,
       otp,
       releasePlan,

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import { execFileSync, spawn } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { createSpawnCommand, getPackageManagerCommand } from "./command-process.mjs";
+import { releaseSourceFiles } from "./release-inputs.mjs";
+import { assertRoutineReleaseMetadata } from "./release-packages.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function runReleaseCommand(args, cwd = ROOT) {
+  const shape = createSpawnCommand(getPackageManagerCommand("pnpm"), args);
+  return new Promise((resolve, reject) => {
+    const child = spawn(shape.command, shape.args, { cwd, stdio: "inherit", env: process.env });
+    child.once("error", reject);
+    child.once("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error(`pnpm ${args.join(" ")} failed (${code}).`)),
+    );
+  });
+}
+
+export async function collectPreflightFailures(checks) {
+  const failures = [];
+  for (const [name, check] of checks) {
+    try {
+      await check();
+    } catch (error) {
+      failures.push(`${name}: ${error.message}`);
+    }
+  }
+  if (failures.length)
+    throw new Error(
+      `Release preflight found ${failures.length} failed check(s):\n${failures.join("\n")}`,
+    );
+}
+
+export async function rehearseRelease({ root = ROOT, run = runReleaseCommand } = {}) {
+  const candidate = await mkdtemp(path.join(os.tmpdir(), "starwind-release-preflight-"));
+  console.log(`[preflight] Disposable version rehearsal: ${candidate}`);
+  try {
+    for (const file of releaseSourceFiles(root)) {
+      const target = path.join(candidate, file);
+      await mkdir(path.dirname(target), { recursive: true });
+      try {
+        await copyFile(path.join(root, file), target);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+    const git = (...args) => execFileSync("git", args, { cwd: candidate, stdio: "pipe" });
+    git("init", "-b", "main");
+    git("config", "user.name", "Release preflight");
+    git("config", "user.email", "release-preflight@localhost");
+    git("add", ".");
+    git("commit", "--quiet", "-m", "chore: prepare disposable release rehearsal");
+    await collectPreflightFailures([
+      [
+        "version rehearsal",
+        async () => {
+          await run(["install", "--frozen-lockfile", "--ignore-scripts"], candidate);
+          await run(["release:version"], candidate);
+          await run(["install", "--frozen-lockfile", "--ignore-scripts", "--offline"], candidate);
+          await collectPreflightFailures([
+            [
+              "package metadata",
+              () => run(["exec", "node", "scripts/release-preflight.mjs", "--metadata"], candidate),
+            ],
+            ["styled versions", () => run(["styled:versions:check"], candidate)],
+            ["primitive versions", () => run(["primitive:versions:check"], candidate)],
+            [
+              "versioned registry",
+              () =>
+                run(
+                  [
+                    "exec",
+                    "vitest",
+                    "run",
+                    "--project=portable-runtime",
+                    "scripts/portable-runtime/tests/generate-cli-registry.test.ts",
+                    "scripts/portable-runtime/tests/primitive-generator-registry.test.ts",
+                  ],
+                  candidate,
+                ),
+            ],
+            [
+              "release helpers",
+              () =>
+                run(
+                  [
+                    "exec",
+                    "vitest",
+                    "run",
+                    "--project=repo-scripts",
+                    "scripts/tests/release-packages.test.ts",
+                    "scripts/tests/release-publication-plan.test.mjs",
+                  ],
+                  candidate,
+                ),
+            ],
+            [
+              "Vue release contract",
+              async () => {
+                await run(
+                  [
+                    "exec",
+                    "vitest",
+                    "run",
+                    "--project=portable-vue",
+                    "scripts/portable-runtime/tests/generate-vue-wrappers/package-foundation.test.ts",
+                  ],
+                  candidate,
+                );
+                await run(
+                  [
+                    "--filter=@starwind-ui/vue",
+                    "test:run",
+                    "packages/vue/tests/integration/workspace-contract.test.ts",
+                  ],
+                  candidate,
+                );
+              },
+            ],
+          ]);
+        },
+      ],
+      ["dependency audit", () => run(["audit:prod"], candidate)],
+    ]);
+    console.log(
+      "[preflight] Versioning, frozen install, registry, release helpers, and dependency audit passed.",
+    );
+  } finally {
+    await rm(candidate, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  const args = process.argv.slice(2);
+  const operation =
+    args.length === 1 && args[0] === "--metadata"
+      ? assertRoutineReleaseMetadata()
+      : args.length === 0
+        ? rehearseRelease()
+        : Promise.reject(new Error("Expected no arguments or --metadata."));
+  operation.catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tests/check-release-verification.test.mjs
+++ b/scripts/tests/check-release-verification.test.mjs
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { checkReusableReleaseVerification } from "../check-release-verification.mjs";
+
+const repository = "starwind-ui/starwind-ui";
+const currentSha = "merged-sha";
+const candidateSha = "candidate-sha";
+const workflow = { id: 42, path: ".github/workflows/verify.yml", state: "active" };
+
+function responses() {
+  return new Map([
+    [
+      `repos/${repository}/commits/${currentSha}/pulls`,
+      [
+        {
+          base: { ref: "main" },
+          head: { repo: { full_name: repository }, sha: candidateSha },
+          merge_commit_sha: currentSha,
+          merged_at: "2026-09-06T18:00:00Z",
+        },
+      ],
+    ],
+    [`repos/${repository}/git/commits/${currentSha}`, { tree: { sha: "tree-sha" } }],
+    [`repos/${repository}/git/commits/${candidateSha}`, { tree: { sha: "tree-sha" } }],
+    [`repos/${repository}/actions/workflows/verify.yml`, workflow],
+    [
+      `repos/${repository}/actions/workflows/42/runs?event=workflow_dispatch&head_sha=${candidateSha}&status=completed&per_page=100`,
+      {
+        workflow_runs: [
+          {
+            actor: { login: "github-actions[bot]" },
+            conclusion: "success",
+            event: "workflow_dispatch",
+            head_sha: candidateSha,
+            id: 84,
+            path: ".github/workflows/verify.yml@refs/heads/changeset-release/main",
+            repository: { full_name: repository },
+            status: "completed",
+            triggering_actor: { login: "github-actions[bot]" },
+            workflow_id: 42,
+          },
+        ],
+      },
+    ],
+  ]);
+}
+
+async function check(entries = responses()) {
+  return checkReusableReleaseVerification({
+    api: async (endpoint) => {
+      if (!entries.has(endpoint)) throw new Error(`Unexpected endpoint: ${endpoint}`);
+      return structuredClone(entries.get(endpoint));
+    },
+    currentSha,
+    repository,
+  });
+}
+
+describe("release verification reuse", () => {
+  it("reuses an exact successful candidate run when the full trees match", async () => {
+    await expect(check()).resolves.toMatchObject({ candidateSha, reusable: true });
+  });
+
+  it("falls back when the merge tree changes", async () => {
+    const entries = responses();
+    entries.set(`repos/${repository}/git/commits/${currentSha}`, { tree: { sha: "changed-tree" } });
+    await expect(check(entries)).resolves.toMatchObject({ reusable: false });
+  });
+
+  it.each([
+    ["failed", { conclusion: "failure" }],
+    ["wrong workflow", { workflow_id: 99 }],
+    ["wrong repository", { repository: { full_name: "someone/fork" } }],
+    ["wrong commit", { head_sha: "other-sha" }],
+    ["manual dispatch", { actor: { login: "maintainer" } }],
+  ])("falls back for a %s run", async (_label, change) => {
+    const entries = responses();
+    const endpoint = `repos/${repository}/actions/workflows/42/runs?event=workflow_dispatch&head_sha=${candidateSha}&status=completed&per_page=100`;
+    const value = structuredClone(entries.get(endpoint));
+    Object.assign(value.workflow_runs[0], change);
+    entries.set(endpoint, value);
+    await expect(check(entries)).resolves.toMatchObject({ reusable: false });
+  });
+
+  it("falls back for a fork, ambiguous pull request, inactive workflow, or lookup error", async () => {
+    const pullsEndpoint = `repos/${repository}/commits/${currentSha}/pulls`;
+
+    const fork = responses();
+    fork.get(pullsEndpoint)[0].head.repo.full_name = "someone/fork";
+    await expect(check(fork)).resolves.toMatchObject({ reusable: false });
+
+    const ambiguous = responses();
+    ambiguous.get(pullsEndpoint).push(structuredClone(ambiguous.get(pullsEndpoint)[0]));
+    await expect(check(ambiguous)).resolves.toMatchObject({ reusable: false });
+
+    const inactive = responses();
+    inactive.set(`repos/${repository}/actions/workflows/verify.yml`, {
+      ...workflow,
+      state: "disabled_manually",
+    });
+    await expect(check(inactive)).resolves.toMatchObject({ reusable: false });
+
+    await expect(
+      checkReusableReleaseVerification({
+        api: async () => {
+          throw new Error("API unavailable");
+        },
+        currentSha,
+        repository,
+      }),
+    ).resolves.toMatchObject({ reusable: false });
+  });
+});

--- a/scripts/tests/node22-public-consumer-smoke.test.ts
+++ b/scripts/tests/node22-public-consumer-smoke.test.ts
@@ -42,7 +42,7 @@ describe("Node 22 public consumer smoke", () => {
         };
       }
       const manifestFile = path.join(packagesDirectory, "manifest.json");
-      const save = (schemaVersion) =>
+      const save = (schemaVersion: number) =>
         writeFile(
           manifestFile,
           JSON.stringify({ builtWithNode: "v24.20.0", packages, schemaVersion }),

--- a/scripts/tests/node22-public-consumer-smoke.test.ts
+++ b/scripts/tests/node22-public-consumer-smoke.test.ts
@@ -1,3 +1,6 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -9,11 +12,75 @@ import {
   getJavaScriptTypecheckConfig,
   getPackedProjectDependencies,
   getProjectCheck,
+  loadArtifactManifest,
   parseArgs,
 } from "../node22-public-consumer-smoke.mjs";
 import { createPackPlan, parseArgs as parsePackArgs } from "../pack-public-release-artifacts.mjs";
 
 describe("Node 22 public consumer smoke", () => {
+  it("accepts legacy manifests and verifies schema 2 archive bytes", async () => {
+    const packagesDirectory = await mkdtemp(path.join(os.tmpdir(), "node-floor-artifacts-"));
+    try {
+      const packages: Record<
+        string,
+        { file: string; name: string; sha256: string; version: string }
+      > = {};
+      for (const [key, name] of Object.entries({
+        astro: "@starwind-ui/astro",
+        cli: "starwind",
+        react: "@starwind-ui/react",
+        runtime: "@starwind-ui/runtime",
+      })) {
+        const file = `${key}.tgz`;
+        const bytes = Buffer.from(`${name} archive fixture`);
+        await writeFile(path.join(packagesDirectory, file), bytes);
+        packages[key] = {
+          file,
+          name,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+          version: "1.2.3",
+        };
+      }
+      const manifestFile = path.join(packagesDirectory, "manifest.json");
+      const save = (schemaVersion) =>
+        writeFile(
+          manifestFile,
+          JSON.stringify({ builtWithNode: "v24.20.0", packages, schemaVersion }),
+        );
+
+      await save(1);
+      await expect(loadArtifactManifest(packagesDirectory)).resolves.toMatchObject({
+        schemaVersion: 1,
+      });
+      await save(2);
+      await expect(loadArtifactManifest(packagesDirectory)).resolves.toMatchObject({
+        schemaVersion: 2,
+      });
+      packages.vue = {
+        file: "missing-vue.tgz",
+        name: "@starwind-ui/vue",
+        sha256: "not-used-by-the-stable-matrix",
+        version: "0.1.1",
+      };
+      await save(2);
+      await expect(loadArtifactManifest(packagesDirectory)).resolves.toMatchObject({
+        schemaVersion: 2,
+      });
+
+      await writeFile(path.join(packagesDirectory, packages.react.file), "corrupted archive");
+      await expect(loadArtifactManifest(packagesDirectory)).rejects.toThrow(
+        "@starwind-ui/react archive SHA-256 does not match",
+      );
+
+      await save(3);
+      await expect(loadArtifactManifest(packagesDirectory)).rejects.toThrow(
+        "Unsupported public artifact manifest schema: 3",
+      );
+    } finally {
+      await rm(packagesDirectory, { force: true, recursive: true });
+    }
+  });
+
   it("packs the four public packages in publication order", () => {
     const outputDirectory = path.resolve("release-packs");
 

--- a/scripts/tests/pack-public-release-artifacts.test.ts
+++ b/scripts/tests/pack-public-release-artifacts.test.ts
@@ -1,10 +1,99 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
-import { createPackPlan } from "../pack-public-release-artifacts.mjs";
+import { createPackPlan, loadPublicReleaseArtifacts } from "../pack-public-release-artifacts.mjs";
+import { releaseSourceFingerprint } from "../release-inputs.mjs";
 
 describe("public release artifact packing", () => {
+  it("rejects source edits, archive replacement, and forged packed metadata", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "release-pack-proof-"));
+    try {
+      execFileSync("git", ["init", "--quiet"], { cwd: root });
+      await writeFile(path.join(root, ".gitignore"), "node_modules/\n");
+      const outputDirectory = path.join(root, "node_modules/packs");
+      const stage = path.join(root, "node_modules/stage/package");
+      await mkdir(outputDirectory, { recursive: true });
+      await mkdir(stage, { recursive: true });
+      const packages: Record<
+        string,
+        {
+          file: string;
+          name: string;
+          version: string;
+          manifest: { name: string; version: string };
+          sha256: string;
+        }
+      > = {};
+      for (const { key, name, fileName } of createPackPlan({ outputDirectory, vueBeta: true })
+        .packages) {
+        const directory = path.join(root, "packages", key);
+        await mkdir(directory, { recursive: true });
+        const metadata = { name, version: key === "vue" ? "0.1.1" : "1.2.1" };
+        await writeFile(path.join(directory, "package.json"), JSON.stringify(metadata));
+        await writeFile(path.join(stage, "package.json"), JSON.stringify(metadata));
+        const archive = path.join(outputDirectory, fileName);
+        execFileSync("tar", ["-czf", archive, "-C", path.dirname(stage), "package"]);
+        packages[key] = {
+          file: fileName,
+          ...metadata,
+          manifest: metadata,
+          sha256: createHash("sha256")
+            .update(await readFile(archive))
+            .digest("hex"),
+        };
+      }
+      const entry = packages.vue;
+      const metadata = entry.manifest;
+      const archive = path.join(outputDirectory, entry.file);
+      const bytes = await readFile(archive);
+      const manifest = {
+        schemaVersion: 2,
+        sourceFingerprint: releaseSourceFingerprint(root),
+        packages,
+      };
+      const save = () =>
+        writeFile(path.join(outputDirectory, "manifest.json"), JSON.stringify(manifest));
+      await save();
+      await expect(
+        loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root }),
+      ).resolves.toEqual(manifest);
+      delete manifest.packages.vue;
+      await save();
+      await expect(
+        loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root, requireVue: true }),
+      ).rejects.toThrow("inventory");
+      manifest.packages.vue = entry;
+      manifest.packages.extra = entry;
+      await save();
+      await expect(loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root })).rejects.toThrow(
+        "inventory",
+      );
+      delete manifest.packages.extra;
+      await save();
+      await writeFile(path.join(root, "new-release-input.js"), "export {};");
+      await expect(loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root })).rejects.toThrow(
+        "sources or toolchain changed",
+      );
+      await rm(path.join(root, "new-release-input.js"));
+      await writeFile(archive, "replaced");
+      await expect(loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root })).rejects.toThrow(
+        "archive changed",
+      );
+      await writeFile(archive, bytes);
+      entry.manifest = { ...metadata, version: "0.2.0" };
+      await save();
+      await expect(loadPublicReleaseArtifacts({ outputDirectory, repoRoot: root })).rejects.toThrow(
+        "Packed metadata changed",
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
   it("keeps the stable pack plan and selects Vue only for the beta plan", () => {
     const outputDirectory = path.resolve(".release-packs-test");
     expect(createPackPlan({ outputDirectory }).packages.map(({ key }) => key)).toEqual([

--- a/scripts/tests/release-candidate-acceptance.test.ts
+++ b/scripts/tests/release-candidate-acceptance.test.ts
@@ -3,7 +3,6 @@ import os from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
-
 import {
   createCandidatePlan,
   createCandidateVerificationPlan,
@@ -13,8 +12,11 @@ import {
   getCandidateWorkspacePackage,
   getCandidateWorkspacePolicy,
   parseArgs,
+  prepareCandidatePackages,
+  runCandidateProjects,
   startCandidateRegistry,
 } from "../release-candidate-acceptance.mjs";
+import { RELEASE_PACKS, releaseGateStages } from "../release-gate.mjs";
 
 const root = path.resolve("candidate-root");
 const packages = {
@@ -27,6 +29,95 @@ const packages = {
 const vueAdapterVersion = "0.2.0";
 
 describe("release candidate acceptance", () => {
+  it("bounds active projects and waits for workers before surfacing errors", async () => {
+    let active = 0;
+    let maximum = 0;
+    const started: number[] = [];
+    const releases: (() => void)[] = [];
+    const failure = new Error("host failed");
+    const execution = runCandidateProjects([0, 1, 2], {
+      concurrency: 2,
+      runProject: async (id: number) => {
+        started.push(id);
+        maximum = Math.max(maximum, ++active);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        active--;
+        if (id === 0) throw failure;
+      },
+    });
+    const rejection = expect(execution).rejects.toThrow("host failed");
+    expect(started).toEqual([0, 1]);
+    releases[0]();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(active).toBe(1);
+    expect(started).toEqual([0, 1]);
+    releases[1]();
+    await rejection;
+    expect(active).toBe(0);
+    expect(maximum).toBe(2);
+  });
+
+  it("runs every selected project with diagnostic concurrency one", async () => {
+    const seen: number[] = [];
+    await runCandidateProjects([0, 1, 2], {
+      concurrency: 1,
+      runProject: async (id: number) => {
+        seen.push(id);
+      },
+    });
+    expect(seen).toEqual([0, 1, 2]);
+    await expect(
+      runCandidateProjects([], { concurrency: 0, runProject: async () => {} }),
+    ).rejects.toThrow(/concurrency/i);
+    expect(parseArgs(["--packs", "/tmp/packs", "--concurrency", "1"])).toMatchObject({
+      packsDirectory: "/tmp/packs",
+      concurrency: 1,
+    });
+    expect(parseArgs([]).concurrency).toBe(2);
+    expect(() => parseArgs(["--concurrency", "1.5"])).toThrow(/concurrency/i);
+  });
+
+  it("reuses validated prepared packs and their packed registry metadata", async () => {
+    const entries = Object.fromEntries(
+      ["runtime", "astro", "react", "vue", "cli"].map((key) => [
+        key,
+        {
+          file: `${key}.tgz`,
+          name: key === "cli" ? "starwind" : `@starwind-ui/${key}`,
+          version: "9.8.7",
+          manifest: { name: `packed-${key}`, dependencies: { runtime: "9.8.7" } },
+        },
+      ]),
+    );
+    const loaded = await prepareCandidatePackages(
+      { packsDirectory: "/tmp/shared-packs", packDirectory: "/tmp/unused" },
+      {
+        loadArtifacts: async ({ outputDirectory }: { outputDirectory: string }) => {
+          expect(outputDirectory).toBe(path.resolve("/tmp/shared-packs"));
+          return { packages: entries };
+        },
+        packPackages: async () => {
+          throw new Error("must reuse packs");
+        },
+      },
+    );
+    expect(loaded.packages.vue).toBe(path.resolve("/tmp/shared-packs/vue.tgz"));
+    expect(loaded.registryPackages.vue.manifest).toEqual(entries.vue.manifest);
+    await expect(
+      prepareCandidatePackages(
+        { packsDirectory: "/tmp/shared-packs" },
+        {
+          loadArtifacts: async () => {
+            throw new Error("stale packs");
+          },
+          packPackages: async () => {
+            throw new Error("must not fall back to packing");
+          },
+        },
+      ),
+    ).rejects.toThrow("stale packs");
+  });
+
   it("covers supported Astro, React, and Vue versions plus each supported React host", () => {
     expect(getCandidateMatrix()).toEqual([
       expect.objectContaining({ framework: "astro", id: "astro-5", packageManager: "pnpm" }),
@@ -322,7 +413,15 @@ describe("release candidate acceptance", () => {
   it("runs once in the release gate and stays out of the public sync and publish commands", async () => {
     const manifest = JSON.parse(await readFile("package.json", "utf8"));
 
-    expect(manifest.scripts["release:gate"].match(/release:candidate:acceptance/g)).toHaveLength(1);
+    expect(manifest.scripts["release:gate"]).toBe("node scripts/release-gate.mjs");
+    expect(
+      releaseGateStages().filter(([, args]) => args[0] === "release:candidate:acceptance"),
+    ).toEqual([
+      [
+        "candidate hosts",
+        ["release:candidate:acceptance", "--packs", RELEASE_PACKS, "--concurrency", "2"],
+      ],
+    ]);
     expect(manifest.scripts["sync-public-runtime"] ?? "").not.toContain(
       "release:candidate:acceptance",
     );

--- a/scripts/tests/release-finalization.test.ts
+++ b/scripts/tests/release-finalization.test.ts
@@ -119,6 +119,138 @@ describe("Vue beta release finalization", () => {
     ).rejects.toThrow(/pnpm release:vue-beta:finalize/);
   });
 
+  it("retries until npm exposes a published package and its dist-tag", async () => {
+    const release = {
+      packages: [{ name: "starwind", tag: "latest", version: "3.3.2" }],
+    };
+    const waits: number[] = [];
+    const retries: string[] = [];
+    let tagChecks = 0;
+
+    await verifyPublishedPackages(
+      release,
+      {
+        capture: async (_command: string, args: string[]) => {
+          if (args[2] === "version") {
+            return { code: 0, stderr: "", stdout: JSON.stringify("3.3.2") };
+          }
+          tagChecks += 1;
+          return {
+            code: 0,
+            stderr: "",
+            stdout: JSON.stringify({ latest: tagChecks === 1 ? "3.3.1" : "3.3.2" }),
+          };
+        },
+      },
+      {
+        attempts: 2,
+        onRetry: (subject: string) => retries.push(subject),
+        retryDelayMs: 10_000,
+        wait: async (delayMs: number) => waits.push(delayMs),
+      },
+    );
+
+    expect(tagChecks).toBe(2);
+    expect(retries).toEqual(["starwind@3.3.2 dist-tag latest"]);
+    expect(waits).toEqual([10_000]);
+  });
+
+  it("leaves a recovery path when an old dist-tag does not propagate", async () => {
+    const waits: number[] = [];
+    let tagChecks = 0;
+
+    await expect(
+      verifyPublishedPackages(
+        {
+          packages: [{ name: "starwind", tag: "latest", version: "3.3.2" }],
+        },
+        {
+          capture: async (_command: string, args: string[]) => {
+            if (args[2] === "version") {
+              return { code: 0, stderr: "", stdout: JSON.stringify("3.3.2") };
+            }
+            tagChecks += 1;
+            return { code: 0, stderr: "", stdout: JSON.stringify({ latest: "3.3.1" }) };
+          },
+        },
+        {
+          attempts: 2,
+          onRetry: () => undefined,
+          retryDelayMs: 10_000,
+          wait: async (delayMs: number) => waits.push(delayMs),
+        },
+      ),
+    ).rejects.toThrow(
+      /latest must point to 3\.3\.2, found 3\.3\.1 did not become visible with its expected npm state.*pnpm release:finalize/,
+    );
+
+    expect(tagChecks).toBe(2);
+    expect(waits).toEqual([10_000]);
+  });
+
+  it("fails without retrying on a permanent npm registry error", async () => {
+    const waits: number[] = [];
+    let checks = 0;
+
+    await expect(
+      verifyPublishedPackages(
+        {
+          packages: [{ name: "starwind", tag: "latest", version: "3.3.2" }],
+        },
+        {
+          capture: async () => {
+            checks += 1;
+            return { code: 1, stderr: "npm error E401", stdout: "" };
+          },
+        },
+        {
+          attempts: 31,
+          onRetry: () => undefined,
+          wait: async (delayMs: number) => waits.push(delayMs),
+        },
+      ),
+    ).rejects.toThrow(/version could not be verified: npm error E401/);
+
+    expect(checks).toBe(1);
+    expect(waits).toEqual([]);
+  });
+
+  it("preserves Vue latest while its beta tag propagates", async () => {
+    const waits: number[] = [];
+    let tagChecks = 0;
+
+    await verifyPublishedPackages(
+      {
+        packages: [{ name: "@starwind-ui/vue", tag: "beta", version: "0.1.1" }],
+        preservedDistTags: { "@starwind-ui/vue": { latest: "0.1.0" } },
+      },
+      {
+        capture: async (_command: string, args: string[]) => {
+          if (args[2] === "version") {
+            return { code: 0, stderr: "", stdout: JSON.stringify("0.1.1") };
+          }
+          tagChecks += 1;
+          return {
+            code: 0,
+            stderr: "",
+            stdout: JSON.stringify(
+              tagChecks === 1 ? { latest: "0.1.0" } : { beta: "0.1.1", latest: "0.1.0" },
+            ),
+          };
+        },
+      },
+      {
+        attempts: 2,
+        onRetry: () => undefined,
+        retryDelayMs: 10_000,
+        wait: async (delayMs: number) => waits.push(delayMs),
+      },
+    );
+
+    expect(tagChecks).toBe(2);
+    expect(waits).toEqual([10_000]);
+  });
+
   it("verifies Vue beta and CLI latest before finalization mutates Git or GitHub", async () => {
     const packageManifests = VUE_BETA_RELEASE_PLAN.map((entry) => ({
       entry,

--- a/scripts/tests/release-gate.test.mjs
+++ b/scripts/tests/release-gate.test.mjs
@@ -1,0 +1,140 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { releaseGateStages, reusableGateRecord, runReleaseGate } from "../release-gate.mjs";
+
+const roots = [];
+const recordFile = path.join("node_modules", ".cache", "starwind-release", "gate.json");
+
+async function createFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "starwind-release-gate-test-"));
+  roots.push(root);
+  execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Release gate test"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "release-gate-test@localhost"], { cwd: root });
+  await writeFile(path.join(root, ".gitignore"), "node_modules/\n");
+  await writeFile(path.join(root, "package.json"), '{"name":"fixture"}\n');
+  await writeFile(path.join(root, "tracked-input.txt"), "initial\n");
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "--quiet", "-m", "fixture"], { cwd: root });
+  return root;
+}
+
+async function loadRecord(root) {
+  return JSON.parse(await readFile(path.join(root, recordFile), "utf8"));
+}
+
+function callCount(calls, command) {
+  return calls.filter(([first]) => first === command).length;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("release gate checkpoints", () => {
+  const stages = [
+    ["build", ["build:public"]],
+    ["hosts", ["test:hosts"]],
+  ];
+  const inputs = { source: "source-and-toolchain", outputs: "built-files-and-packs", stages };
+  const record = {
+    ...inputs,
+    schemaVersion: 1,
+    completed: [{ name: "build", seconds: 1 }],
+    complete: false,
+  };
+  it("resumes a completed prefix only while every recorded input matches", () => {
+    expect(reusableGateRecord(record, inputs)).toBe(true);
+    for (const changes of [
+      { source: "edited" },
+      { outputs: "repacked" },
+      { stages: stages.slice(1) },
+    ]) {
+      expect(reusableGateRecord(record, { ...inputs, ...changes })).toBe(false);
+    }
+    expect(reusableGateRecord({ ...record, completed: [{ name: "hosts" }] }, inputs)).toBe(false);
+    expect(reusableGateRecord({ ...record, complete: true }, inputs)).toBe(false);
+    expect(
+      reusableGateRecord(
+        { ...record, completed: [{ name: "build" }, { name: "hosts" }], complete: true },
+        inputs,
+      ),
+    ).toBe(true);
+    expect(reusableGateRecord(null, inputs)).toBe(false);
+  });
+  it("builds and packs before prepared tests, retaining both complete host matrices", () => {
+    const publicStages = releaseGateStages();
+    const index = (name) => publicStages.findIndex(([candidate]) => candidate === name);
+    expect(index("build")).toBeLessThan(index("pack"));
+    for (const stage of ["vue tests", "vue demo", "Vue hosts", "candidate hosts"])
+      expect(index("pack")).toBeLessThan(index(stage));
+    expect(publicStages.find(([name]) => name === "vue tests")[1]).toContain("test:all:built");
+    expect(publicStages.find(([name]) => name === "vue demo")[1]).toContain("smoke:built");
+    expect(releaseGateStages({ privateEvidence: true })).toHaveLength(publicStages.length + 1);
+  });
+
+  it("reuses a completed prefix after a later stage fails", async () => {
+    const root = await createFixture();
+    const calls = [];
+    const run = async (args) => {
+      calls.push(args);
+      if (args[0] === "styled:versions:check") throw new Error("stop after static");
+    };
+
+    await expect(runReleaseGate({ root, run })).rejects.toThrow("stop after static");
+    await expect(runReleaseGate({ root, run })).rejects.toThrow("stop after static");
+
+    expect(callCount(calls, "audit:prod")).toBe(2);
+    expect(callCount(calls, "check:public")).toBe(1);
+    expect(callCount(calls, "styled:versions:check")).toBe(2);
+    await expect(loadRecord(root)).resolves.toMatchObject({
+      complete: false,
+      completed: [{ name: "static" }],
+    });
+  });
+
+  it("starts stages again when a failed stage changes built output", async () => {
+    const root = await createFixture();
+    const calls = [];
+    const run = async (args) => {
+      calls.push(args);
+      if (args[0] === "styled:versions:check") {
+        await mkdir(path.join(root, "packages", "runtime", "dist"), { recursive: true });
+        await writeFile(path.join(root, "packages", "runtime", "dist", "index.js"), "changed\n");
+        throw new Error("output changed");
+      }
+    };
+
+    await expect(runReleaseGate({ root, run })).rejects.toThrow("output changed");
+    await expect(runReleaseGate({ root, run })).rejects.toThrow("output changed");
+
+    expect(callCount(calls, "audit:prod")).toBe(2);
+    expect(callCount(calls, "check:public")).toBe(2);
+    expect(callCount(calls, "styled:versions:check")).toBe(2);
+  });
+
+  it("rejects source drift before recording a successful stage", async () => {
+    const root = await createFixture();
+    const calls = [];
+
+    await expect(
+      runReleaseGate({
+        root,
+        run: async (args) => {
+          calls.push(args);
+          if (args[0] === "check:public") {
+            await writeFile(path.join(root, "tracked-input.txt"), "generated drift\n");
+          }
+        },
+      }),
+    ).rejects.toThrow(/Source changed during static/);
+
+    expect(callCount(calls, "audit:prod")).toBe(1);
+    expect(callCount(calls, "check:public")).toBe(1);
+    await expect(loadRecord(root)).resolves.toMatchObject({ complete: false, completed: [] });
+  });
+});

--- a/scripts/tests/release-inputs.test.mjs
+++ b/scripts/tests/release-inputs.test.mjs
@@ -1,0 +1,33 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it } from "vitest";
+import { releaseOutputFingerprint, releaseSourceFingerprint } from "../release-inputs.mjs";
+
+const roots = [];
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+it("invalidates release evidence for edited and new source, dependencies, and built artifacts", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "release-inputs-test-"));
+  roots.push(root);
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+  await writeFile(path.join(root, ".gitignore"), "node_modules/\npackages/*/dist/\n");
+  await writeFile(path.join(root, "source.js"), "export const value = 1;");
+  execFileSync("git", ["add", "."], { cwd: root });
+  const original = releaseSourceFingerprint(root);
+  await writeFile(path.join(root, "source.js"), "export const value = 2;");
+  expect(releaseSourceFingerprint(root)).not.toBe(original);
+  await writeFile(path.join(root, "source.js"), "export const value = 1;");
+  expect(releaseSourceFingerprint(root)).toBe(original);
+  await writeFile(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'");
+  expect(releaseSourceFingerprint(root)).not.toBe(original);
+  await rm(path.join(root, "pnpm-lock.yaml"));
+  const packs = path.join(root, "node_modules/packs");
+  const outputs = releaseOutputFingerprint(root, packs);
+  await mkdir(path.join(root, "packages/vue/dist"), { recursive: true });
+  await writeFile(path.join(root, "packages/vue/dist/index.js"), "export {};");
+  expect(releaseOutputFingerprint(root, packs)).not.toBe(outputs);
+  expect(releaseSourceFingerprint(root)).toBe(original);
+});

--- a/scripts/tests/release-packages.test.ts
+++ b/scripts/tests/release-packages.test.ts
@@ -138,6 +138,22 @@ function routineConfig() {
 }
 
 describe("release package tooling", () => {
+  it("publishes the verified archive and preserves the explicit Vue beta tag", () => {
+    const entry = ROUTINE_RELEASE_PACKAGE_SET.find(({ name }) => name === "@starwind-ui/vue")!;
+    const archive = path.resolve("prepared/vue.tgz");
+    const [command] = createPublishCommands({
+      dryRun: true,
+      releasePlan: [entry],
+      archives: { [entry.name]: archive },
+      tag: "latest",
+    });
+    expect(command.args.slice(0, 4)).toEqual(["publish", archive, "--tag", "beta"]);
+    expect(command.args).toContain("--dry-run");
+    expect(() => createPublishCommands({ releasePlan: [entry], archives: {} })).toThrow(
+      "Missing verified archive",
+    );
+  });
+
   it("publishes routine Vue versions on explicit beta policy outside the fixed train", () => {
     const packageManifests = routineManifests();
     expect(
@@ -551,19 +567,7 @@ describe("release package tooling", () => {
     );
     expect(root.scripts?.["publish:beta:dry-run"]).toBe("pnpm publish:release:dry-run");
     expect(root.scripts?.["publish:beta"]).toBe("pnpm publish:release");
-    expect(commandPhases(root.scripts?.["release:gate"])).toEqual([
-      "pnpm verify:public",
-      "pnpm runtime:generate:vue:test",
-      "pnpm test:vue-cli-host-acceptance",
-      "pnpm --filter=starwind package:check",
-      "pnpm audit:prod",
-      "pnpm demo:smoke",
-      "pnpm react-demo:smoke",
-      "pnpm vue-demo:smoke",
-      "pnpm runtime:size:check:prepared",
-      ...(hasPrivateSvelte ? ["pnpm runtime:perf:vue:evidence:check"] : []),
-      "pnpm release:candidate:acceptance",
-    ]);
+    expect(root.scripts?.["release:gate"]).toBe("node scripts/release-gate.mjs");
     expect(root.scripts?.["publish:release:dry-run"]).not.toContain("release:prepare");
     expect(root.scripts?.["publish:release:dry-run"]).not.toContain("release:gate");
     expect(root.scripts?.["runtime:size:check"]).toBe(

--- a/scripts/tests/release-preflight.test.mjs
+++ b/scripts/tests/release-preflight.test.mjs
@@ -1,0 +1,105 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { collectPreflightFailures, rehearseRelease } from "../release-preflight.mjs";
+
+const roots = [];
+
+async function createFixture() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "starwind-release-preflight-test-"));
+  roots.push(root);
+  execFileSync("git", ["init", "-b", "main"], { cwd: root, stdio: "pipe" });
+  execFileSync("git", ["config", "user.name", "Release preflight test"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "release-preflight-test@localhost"], { cwd: root });
+  await writeFile(path.join(root, "package.json"), '{"name":"fixture"}\n');
+  await writeFile(path.join(root, "release-input.txt"), "committed\n");
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "--quiet", "-m", "fixture"], { cwd: root });
+  await writeFile(path.join(root, "release-input.txt"), "working edit\n");
+  await writeFile(path.join(root, "untracked-release-input.txt"), "untracked edit\n");
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })));
+});
+
+describe("release preflight", () => {
+  it("reports every independent preflight failure", async () => {
+    const calls = [];
+
+    await expect(
+      collectPreflightFailures([
+        ["first", async () => calls.push("first")],
+        [
+          "second",
+          async () => {
+            calls.push("second");
+            throw new Error("second failure");
+          },
+        ],
+        [
+          "third",
+          async () => {
+            calls.push("third");
+            throw new Error("third failure");
+          },
+        ],
+      ]),
+    ).rejects.toThrow(
+      "Release preflight found 2 failed check(s):\nsecond: second failure\nthird: third failure",
+    );
+
+    expect(calls).toEqual(["first", "second", "third"]);
+  });
+
+  it("copies working release inputs into a disposable successful rehearsal", async () => {
+    const root = await createFixture();
+    const calls = [];
+    let candidate;
+    let copiedInputs;
+
+    await rehearseRelease({
+      root,
+      run: async (args, cwd) => {
+        candidate ??= cwd;
+        calls.push(args);
+        copiedInputs ??= await Promise.all([
+          readFile(path.join(cwd, "release-input.txt"), "utf8"),
+          readFile(path.join(cwd, "untracked-release-input.txt"), "utf8"),
+        ]);
+      },
+    });
+
+    expect(copiedInputs).toEqual(["working edit\n", "untracked edit\n"]);
+    expect(calls.at(-1)).toEqual(["audit:prod"]);
+    expect(calls).toContainEqual(["release:version"]);
+    expect(calls).toContainEqual(["install", "--frozen-lockfile", "--ignore-scripts", "--offline"]);
+    expect(existsSync(candidate)).toBe(false);
+  });
+
+  it("runs the audit and removes the rehearsal when versioning fails", async () => {
+    const root = await createFixture();
+    const calls = [];
+    let candidate;
+
+    await expect(
+      rehearseRelease({
+        root,
+        run: async (args, cwd) => {
+          candidate ??= cwd;
+          calls.push(args);
+          if (args[0] === "release:version") throw new Error("version rehearsal failed");
+        },
+      }),
+    ).rejects.toThrow(/version rehearsal: version rehearsal failed/);
+
+    expect(calls).toContainEqual(["audit:prod"]);
+    expect(existsSync(candidate)).toBe(false);
+  });
+});

--- a/scripts/tests/root-verification-scripts.test.ts
+++ b/scripts/tests/root-verification-scripts.test.ts
@@ -148,25 +148,14 @@ describe("root verification scripts", () => {
             name !== "audit:prod" && commandPhases(command).includes("pnpm audit:prod"),
         )
         .map(([name]) => name),
-    ).toEqual(["release:gate"]);
+    ).toEqual([]);
   });
 
   it("runs the complete candidate gate once before the package dry-run", async () => {
     const pkg = await readRootPackage();
 
-    expect(commandPhases(pkg.scripts?.["release:gate"])).toEqual([
-      "pnpm verify:public",
-      "pnpm runtime:generate:vue:test",
-      "pnpm test:vue-cli-host-acceptance",
-      "pnpm --filter=starwind package:check",
-      "pnpm audit:prod",
-      "pnpm demo:smoke",
-      "pnpm react-demo:smoke",
-      "pnpm vue-demo:smoke",
-      "pnpm runtime:size:check:prepared",
-      ...(hasPrivateSvelte ? ["pnpm runtime:perf:vue:evidence:check"] : []),
-      "pnpm release:candidate:acceptance",
-    ]);
+    expect(pkg.scripts?.["release:gate"]).toBe("node scripts/release-gate.mjs");
+    expect(pkg.scripts?.["release:preflight"]).toBe("node scripts/release-preflight.mjs");
     expect(pkg.scripts?.["runtime:size:check:prepared"]).toContain("--private-vue");
     expect(commandPhases(pkg.scripts?.["publish:release:dry-run"])).toEqual([
       "pnpm release:artifacts",
@@ -267,11 +256,27 @@ describe("root verification scripts", () => {
     const source = await readFile(".github/workflows/release.yml", "utf8");
     const workflow = parse(source) as Workflow;
     expect(workflow.concurrency).toMatchObject({ "cancel-in-progress": true });
+    expect(workflow.jobs.scope).toMatchObject({
+      outputs: {
+        verification_reused: "${{ steps.verification.outputs.reusable }}",
+        versioned: "${{ steps.changes.outputs.versioned }}",
+      },
+      permissions: { actions: "read", contents: "read", "pull-requests": "read" },
+    });
     expect(workflow.jobs.verify).toMatchObject({
-      if: "needs.scope.outputs.versioned == 'true'",
+      if: "needs.scope.outputs.versioned == 'true' && needs.scope.outputs.verification_reused != 'true'",
       needs: "scope",
       uses: "./.github/workflows/verify.yml",
     });
+    expect(workflow.jobs.scope.steps).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "verification",
+          if: "steps.changes.outputs.versioned == 'true'",
+          run: 'node scripts/check-release-verification.mjs >> "$GITHUB_OUTPUT"',
+        }),
+      ]),
+    );
     expect(workflow.jobs.release.needs).toEqual(["scope", "verify"]);
     expect(workflow.jobs.release.steps).toEqual(
       expect.arrayContaining([

--- a/scripts/tests/vue-cli-host-acceptance.test.ts
+++ b/scripts/tests/vue-cli-host-acceptance.test.ts
@@ -551,7 +551,10 @@ export const StarwindCollapsibleHelper: typeof import('../app/components/starwin
   it("stages verified shared archives outside the repository without weakening source isolation", async () => {
     const shared = await mkdtemp(path.join(process.cwd(), "node_modules/vue-shared-packs-"));
     const fixture = await mkdtemp(path.join(os.tmpdir(), "vue-staged-packs-"));
-    const entries = {};
+    const entries: Record<
+      string,
+      { file: string; manifest: { name: string; version: string }; sha256: string }
+    > = {};
     try {
       for (const key of ["runtime", "vue", "cli"]) {
         const bytes = Buffer.from(`verified-${key}`);

--- a/scripts/tests/vue-cli-host-acceptance.test.ts
+++ b/scripts/tests/vue-cli-host-acceptance.test.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -26,7 +27,9 @@ import {
   isPreviewTreeAlive,
   isVueHydrationMismatchWarning,
   parseArgs,
+  prepareVueHostPackages,
   runCleanupOperations,
+  runVueHostWorkers,
   runWithCleanup,
   shouldCaptureVueHydrationWarnings,
   shouldPreserveVueHostRoot,
@@ -499,23 +502,210 @@ export const StarwindCollapsibleHelper: typeof import('../app/components/starwin
     ).toThrow(/Runtime dependency/);
   });
 
+  it("checks exact archive provenance through workspace and pack directory symlinks", async () => {
+    const fixture = await mkdtemp(path.join(os.tmpdir(), "vue-pack-paths-"));
+    try {
+      const workspace = path.join(fixture, "actual/workspace");
+      const archives = path.join(fixture, "actual/packs");
+      const workspaceAlias = path.join(fixture, "workspace-alias");
+      const packsAlias = path.join(fixture, "packs-alias");
+      await mkdir(workspace, { recursive: true });
+      await mkdir(archives, { recursive: true });
+      await symlink(workspace, workspaceAlias, process.platform === "win32" ? "junction" : "dir");
+      await symlink(archives, packsAlias, process.platform === "win32" ? "junction" : "dir");
+      const versions = { runtime: "0.1.0-beta.8", vue: "0.2.0", cli: "3.3.0" };
+      let lockfile = createPackedLockfile(packages);
+      const expected: Record<string, { direct?: boolean; file: string; version: string }> = {};
+      const installed: Record<string, { name: string; version: string }> = {};
+      for (const key of ["runtime", "vue", "cli"] as const) {
+        const name = key === "cli" ? "starwind" : `@starwind-ui/${key}`;
+        const file = path.join(archives, `${key}.tgz`);
+        await writeFile(file, key);
+        lockfile = lockfile.replaceAll(
+          relativePackageFile(packages[key]),
+          path.relative(workspace, file).replaceAll("\\", "/"),
+        );
+        expected[name] = {
+          direct: key !== "runtime",
+          file: path.join(packsAlias, `${key}.tgz`),
+          version: versions[key],
+        };
+        installed[name] = { name, version: versions[key] };
+      }
+      const check = () =>
+        assertPackedVueHostProvenance({
+          expected,
+          installed,
+          lockfile,
+          lockfileDirectory: workspaceAlias,
+        });
+      expect(check).not.toThrow();
+      await writeFile(path.join(archives, "other.tgz"), "runtime");
+      expected["@starwind-ui/runtime"].file = path.join(packsAlias, "other.tgz");
+      expect(check).toThrow(/exactly one package resolution/);
+    } finally {
+      await rm(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it("stages verified shared archives outside the repository without weakening source isolation", async () => {
+    const shared = await mkdtemp(path.join(process.cwd(), "node_modules/vue-shared-packs-"));
+    const fixture = await mkdtemp(path.join(os.tmpdir(), "vue-staged-packs-"));
+    const entries = {};
+    try {
+      for (const key of ["runtime", "vue", "cli"]) {
+        const bytes = Buffer.from(`verified-${key}`);
+        await writeFile(path.join(shared, `${key}.tgz`), bytes);
+        entries[key] = {
+          file: `${key}.tgz`,
+          manifest: { name: key, version: "9.8.7" },
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        };
+      }
+      const outputDirectory = path.join(fixture, "packs");
+      const prepare = () =>
+        prepareVueHostPackages(
+          { packsDirectory: shared, outputDirectory },
+          {
+            loadArtifacts: async () => ({ packages: entries }),
+            packPackages: async () => {
+              throw new Error("must reuse packs");
+            },
+          },
+        );
+      const prepared = await prepare();
+      expect(prepared.manifests.vue.version).toBe("9.8.7");
+      for (const key of ["runtime", "vue", "cli"]) {
+        expect(prepared.packages[key]).toBe(path.join(outputDirectory, `${key}.tgz`));
+        expect(await readFile(prepared.packages[key])).toEqual(
+          await readFile(path.join(shared, `${key}.tgz`)),
+        );
+      }
+      const project = {
+        id: "fixture",
+        directory: fixture,
+        sourceIsolationFiles: ["vite.config.ts"],
+      };
+      await writeFile(
+        path.join(fixture, "package.json"),
+        JSON.stringify({ dependencies: { starwind: `file:${prepared.packages.cli}` } }),
+      );
+      await expect(assertNoWorkspaceSourceAliases(project)).resolves.toBeUndefined();
+      await writeFile(
+        path.join(fixture, "vite.config.ts"),
+        `export default { alias: ${JSON.stringify(path.resolve("packages/vue/src"))} };`,
+      );
+      await expect(assertNoWorkspaceSourceAliases(project)).rejects.toThrow(/contains/);
+      await writeFile(path.join(shared, "vue.tgz"), "changed after validation");
+      await expect(prepare()).rejects.toThrow(/archive changed/i);
+    } finally {
+      await rm(shared, { recursive: true, force: true });
+      await rm(fixture, { recursive: true, force: true });
+    }
+    expect(parseArgs(["--packs", "/tmp/shared-packs", "--concurrency", "1"])).toMatchObject({
+      packsDirectory: "/tmp/shared-packs",
+      concurrency: 1,
+    });
+    expect(parseArgs([]).concurrency).toBe(2);
+    expect(() => parseArgs(["--concurrency", "0"])).toThrow(/concurrency/i);
+  });
+
+  it("dispatches bounded workers with isolated roots and the same staged packs", async () => {
+    const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "vue-workers-"));
+    const contexts: { root: string; prepared: { packages: typeof packages } }[] = [];
+    let active = 0;
+    let maximum = 0;
+    let releaseWorkers!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseWorkers = resolve;
+    });
+    let markBothStarted!: () => void;
+    const bothStarted = new Promise<void>((resolve) => {
+      markBothStarted = resolve;
+    });
+    try {
+      const execution = runVueHostWorkers(
+        ["one", "two", "three"].map((id) => ({ id })),
+        {
+          root: fixtureRoot,
+          prepared: { packages },
+          concurrency: 2,
+        },
+        async (_phase: string, command: { command: string; args: string[] }) => {
+          expect(command.command).toBe(process.execPath);
+          expect(command.args[1]).toBe("--tsconfig");
+          expect(command.args[2]).toBe(path.resolve("packages/cli/tsconfig.json"));
+          contexts.push(JSON.parse(await readFile(command.args.at(-1)!, "utf8")));
+          maximum = Math.max(maximum, ++active);
+          if (active === 2) markBothStarted();
+          await gate;
+          active--;
+        },
+      );
+      await bothStarted;
+      expect(active).toBe(2);
+      releaseWorkers();
+      await execution;
+      expect(maximum).toBe(2);
+      expect(new Set(contexts.map((context) => context.root)).size).toBe(3);
+      expect(
+        contexts.every(
+          (context) => JSON.stringify(context.prepared.packages) === JSON.stringify(packages),
+        ),
+      ).toBe(true);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("propagates a real isolated worker failure with its diagnostics", async () => {
+    const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), "vue-worker-error-"));
+    try {
+      await expect(
+        runVueHostWorkers([{ id: "unknown-host" }], {
+          root: fixtureRoot,
+          prepared: { packages, manifests: {} },
+          concurrency: 1,
+        }),
+      ).rejects.toThrow(/Unknown Vue host acceptance project id/);
+      expect(
+        await readFile(path.join(fixtureRoot, "logs/unknown-host-worker.log"), "utf8"),
+      ).toContain("Unknown Vue host acceptance project id");
+      const archive = path.join(fixtureRoot, "changed.tgz");
+      await writeFile(archive, "changed");
+      await expect(
+        runVueHostWorkers([{ id: "unknown-host" }], {
+          root: fixtureRoot,
+          prepared: {
+            packages: { ...packages, runtime: archive },
+            manifests: {},
+            archiveHashes: { runtime: "original-hash" },
+          },
+          concurrency: 1,
+        }),
+      ).rejects.toThrow(/Staged release archive changed/);
+    } finally {
+      await rm(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
   it("retains failed roots and supports explicit successful retention", () => {
     expect(shouldPreserveVueHostRoot({ failed: true, keepTemp: false })).toBe(true);
     expect(shouldPreserveVueHostRoot({ failed: false, keepTemp: true })).toBe(true);
     expect(shouldPreserveVueHostRoot({ failed: false, keepTemp: false })).toBe(false);
-    expect(parseArgs(["--keep-temp"])).toEqual({
+    expect(parseArgs(["--keep-temp"])).toMatchObject({
       keepTemp: true,
       localLinkOnly: false,
       projectIds: undefined,
       rootDirectory: undefined,
     });
-    expect(parseArgs(["--local-link-only"])).toEqual({
+    expect(parseArgs(["--local-link-only"])).toMatchObject({
       keepTemp: false,
       localLinkOnly: true,
       projectIds: undefined,
       rootDirectory: undefined,
     });
-    expect(parseArgs(["--project", "nuxt-4", "--root", "/tmp/vue-host"])).toEqual({
+    expect(parseArgs(["--project", "nuxt-4", "--root", "/tmp/vue-host"])).toMatchObject({
       keepTemp: false,
       localLinkOnly: false,
       projectIds: ["nuxt-4"],

--- a/scripts/vue-cli-host-acceptance.mjs
+++ b/scripts/vue-cli-host-acceptance.mjs
@@ -3,6 +3,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import {
   access,
   mkdir,
@@ -21,7 +22,8 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
 
 import { runLoggedCommand } from "./cli-host-acceptance.mjs";
-import { startCandidateRegistry } from "./release-candidate-acceptance.mjs";
+import { loadPublicReleaseArtifacts } from "./pack-public-release-artifacts.mjs";
+import { runCandidateProjects, startCandidateRegistry } from "./release-candidate-acceptance.mjs";
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(SCRIPT_DIR, "..");
@@ -271,12 +273,24 @@ export function shouldPreserveVueHostRoot({ failed, keepTemp }) {
 
 export function parseArgs(argv) {
   let keepTemp = false;
+  let packsDirectory;
+  let concurrency = 2;
   let localLinkOnly = false;
   const projectIds = [];
   let rootDirectory;
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
-    if (argument === "--keep-temp") keepTemp = true;
+    if (argument === "--packs") {
+      packsDirectory = argv[++index];
+      if (!packsDirectory || packsDirectory.startsWith("--"))
+        throw new Error("Expected a path after --packs.");
+    } else if (argument === "--concurrency") {
+      concurrency = Number(argv[++index]);
+      assert(
+        Number.isSafeInteger(concurrency) && concurrency > 0,
+        "Expected positive integer concurrency.",
+      );
+    } else if (argument === "--keep-temp") keepTemp = true;
     else if (argument === "--local-link-only") localLinkOnly = true;
     else if (argument === "--project") {
       const projectId = argv[index + 1];
@@ -291,6 +305,8 @@ export function parseArgs(argv) {
     } else throw new Error(`Unknown argument: ${argument}`);
   }
   return {
+    concurrency,
+    packsDirectory,
     keepTemp,
     localLinkOnly,
     projectIds: projectIds.length > 0 ? projectIds : undefined,
@@ -421,12 +437,24 @@ function matchesPackedFile(value, file, lockfileDirectory) {
   const marker = value.indexOf("file:");
   if (marker === -1) return false;
   const reference = value.slice(marker).replace(/(\.tgz)\(.*$/, "$1");
-  return samePath(path.resolve(lockfileDirectory, reference.slice("file:".length)), file);
+  return samePath(
+    path.resolve(canonicalPath(lockfileDirectory), reference.slice("file:".length)),
+    file,
+  );
+}
+
+function canonicalPath(value) {
+  try {
+    return realpathSync(value);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+    return path.resolve(value);
+  }
 }
 
 function samePath(left, right) {
   const normalize = (value) => {
-    const normalized = path.normalize(path.resolve(value));
+    const normalized = canonicalPath(value);
     return process.platform === "win32" ? normalized.toLowerCase() : normalized;
   };
   return normalize(left) === normalize(right);
@@ -1523,101 +1551,192 @@ function formatError(error) {
   return error instanceof Error ? (error.stack ?? error.message) : String(error);
 }
 
+export async function prepareVueHostPackages(
+  { packsDirectory, outputDirectory, logsDirectory },
+  { loadArtifacts = loadPublicReleaseArtifacts, packPackages = packVueBetaPackages } = {},
+) {
+  if (!packsDirectory) return packPackages(outputDirectory, logsDirectory);
+  const artifacts = await loadArtifacts({ outputDirectory: path.resolve(packsDirectory) });
+  const manifests = {};
+  const packages = {};
+  const archiveHashes = {};
+  await mkdir(outputDirectory, { recursive: true });
+  for (const key of ["runtime", "vue", "cli"]) {
+    const entry = artifacts.packages[key];
+    assert(entry, `Prepared release packs are missing ${key}.`);
+    manifests[key] = entry.manifest;
+    const bytes = await readFile(path.resolve(packsDirectory, entry.file));
+    assert.equal(
+      createHash("sha256").update(bytes).digest("hex"),
+      entry.sha256,
+      `Release archive changed: ${entry.name}`,
+    );
+    packages[key] = path.resolve(outputDirectory, entry.file);
+    await writeFile(packages[key], bytes);
+    archiveHashes[key] = entry.sha256;
+  }
+  return { manifests, packages, archiveHashes };
+}
+
+export function createVueHostWorkerCommand(contextFile) {
+  return {
+    command: process.execPath,
+    args: [
+      fileURLToPath(import.meta.resolve("tsx/cli")),
+      "--tsconfig",
+      path.join(REPO_ROOT, "packages/cli/tsconfig.json"),
+      fileURLToPath(import.meta.url),
+      "--worker",
+      contextFile,
+    ],
+    cwd: REPO_ROOT,
+    timeoutMs: 30 * 60_000,
+  };
+}
+
+export async function runVueHostWorkers(
+  projects,
+  { root, prepared, concurrency = 2 },
+  runCommand = runLoggedCommand,
+) {
+  const logs = path.join(root, "logs");
+  await mkdir(logs, { recursive: true });
+  await runCandidateProjects(projects, {
+    concurrency,
+    runProject: async ({ id }) => {
+      const workerRoot = path.join(root, "hosts", id);
+      await mkdir(workerRoot, { recursive: true });
+      const contextFile = path.join(logs, `${id}-worker.json`);
+      await writeFile(
+        contextFile,
+        JSON.stringify({
+          root: workerRoot,
+          projectIds: [id],
+          prepared,
+        }),
+      );
+      await runCommand(`${id}-worker`, createVueHostWorkerCommand(contextFile), logs);
+    },
+  });
+}
+
+async function runVueHostProject({ root, projectIds, packages, manifests }) {
+  const rootLogs = path.join(root, "logs");
+  let browser;
+  let registry;
+  await runWithCleanup(async () => {
+    const plan = createVueCliHostAcceptancePlan({ packages, root });
+    if (projectIds) {
+      const requested = new Set(projectIds);
+      plan.projects = plan.projects.filter(({ id }) => requested.has(id));
+      assert.equal(plan.projects.length, requested.size, "Unknown Vue host acceptance project id.");
+    }
+    registry = await startCandidateRegistry(
+      Object.fromEntries(
+        ["runtime", "vue"].map((key) => [
+          key,
+          {
+            file: packages[key],
+            manifest: manifests[key],
+            name: manifests[key].name,
+            version: manifests[key].version,
+          },
+        ]),
+      ),
+    );
+    const capability = await loadProductionCapability(manifests.vue.version);
+    const require = createRequire(path.join(REPO_ROOT, "package.json"));
+    const { chromium } = require("playwright");
+    browser = await chromium.launch();
+    for (const project of plan.projects) {
+      const logs = path.join(rootLogs, project.id);
+      if (project.scaffold) await runLoggedCommand("01-scaffold", project.scaffold, logs);
+      else await createOfficialVueHostFixture(project);
+      const preservedBytes = await capturePreservedVueHostBytes(project);
+      await prepareManifest(project, packages, registry.url);
+      await runLoggedCommand("02-install", packageCommand(project.directory, ["install"]), logs);
+      if (project.ssrInstall) await runLoggedCommand("02-ssr-install", project.ssrInstall, logs);
+      if (project.prepare) await runLoggedCommand("02-prepare", project.prepare, logs);
+      try {
+        await runProductionLifecycle(project, capability, logs);
+      } catch (error) {
+        throw new Error(
+          `${project.id} production CLI lifecycle failed. Expected setup, repeat setup, search, add, update, remove, and Primitive checks to pass. Evidence: ${logs}.\n${formatError(error)}`,
+          { cause: error },
+        );
+      }
+      await runLoggedCommand(
+        "09-sync-lockfile",
+        packageCommand(project.directory, ["install", "--no-frozen-lockfile"]),
+        logs,
+      );
+      await assertPreservedVueHostBytes(project, preservedBytes);
+      await writeFixture(project);
+      await verifyPackedProvenance(project, packages, manifests);
+      await verifyPackedVueExports(project, logs);
+      await assertRegistryVueHostProvenance(project);
+      await assertNoWorkspaceSourceAliases(project);
+      await runLoggedCommand("09-typecheck", project.check, logs);
+      await runLoggedCommand("10-build", project.build, logs);
+      await assertNuxtComponentDiscovery(project, logs);
+      if (project.postBuild) await runLoggedCommand("11-output-install", project.postBuild, logs);
+      await assertPreservedVueHostBytes(project, preservedBytes);
+      if (project.preview) await verifyBrowser(project, logs, browser);
+    }
+  }, [
+    async () => {
+      if (browser) await browser.close();
+    },
+    async () => {
+      if (registry) await registry.close();
+    },
+  ]);
+}
+
 export async function runVueCliHostAcceptance({
   keepTemp = false,
   localLinkOnly = false,
   projectIds,
   rootDirectory,
   skipLocalLink = true,
+  packsDirectory,
+  concurrency = 2,
 } = {}) {
   return runWithTemporaryVueHostRoot({ keepTemp, rootDirectory }, async (root) => {
     if (localLinkOnly || !skipLocalLink) await runVueLocalLinkAcceptance({ root });
     if (localLinkOnly) return { root };
-
-    const rootLogs = path.join(root, "logs");
-    const packsDirectory = path.join(root, "packs");
-    let browser;
-    let registry;
-    await runWithCleanup(async () => {
-      const { manifests, packages } = await packVueBetaPackages(packsDirectory, rootLogs);
-      const plan = createVueCliHostAcceptancePlan({ packages, root });
-      if (projectIds) {
-        const requested = new Set(projectIds);
-        plan.projects = plan.projects.filter(({ id }) => requested.has(id));
-        assert.equal(
-          plan.projects.length,
-          requested.size,
-          "Unknown Vue host acceptance project id.",
-        );
-      }
-      registry = await startCandidateRegistry(
-        Object.fromEntries(
-          ["runtime", "vue"].map((key) => [
-            key,
-            {
-              file: packages[key],
-              manifest: manifests[key],
-              name: manifests[key].name,
-              version: manifests[key].version,
-            },
-          ]),
-        ),
-      );
-      const capability = await loadProductionCapability(manifests.vue.version);
-      const require = createRequire(path.join(REPO_ROOT, "package.json"));
-      const { chromium } = require("playwright");
-      browser = await chromium.launch();
-      for (const project of plan.projects) {
-        const logs = path.join(rootLogs, project.id);
-        if (project.scaffold) await runLoggedCommand("01-scaffold", project.scaffold, logs);
-        else await createOfficialVueHostFixture(project);
-        const preservedBytes = await capturePreservedVueHostBytes(project);
-        await prepareManifest(project, packages, registry.url);
-        await runLoggedCommand("02-install", packageCommand(project.directory, ["install"]), logs);
-        if (project.ssrInstall) await runLoggedCommand("02-ssr-install", project.ssrInstall, logs);
-        if (project.prepare) await runLoggedCommand("02-prepare", project.prepare, logs);
-        try {
-          await runProductionLifecycle(project, capability, logs);
-        } catch (error) {
-          throw new Error(
-            `${project.id} production CLI lifecycle failed. Expected setup, repeat setup, search, add, update, remove, and Primitive checks to pass. Evidence: ${logs}.\n${formatError(error)}`,
-            { cause: error },
-          );
-        }
-        await runLoggedCommand(
-          "09-sync-lockfile",
-          packageCommand(project.directory, ["install", "--no-frozen-lockfile"]),
-          logs,
-        );
-        await assertPreservedVueHostBytes(project, preservedBytes);
-        await writeFixture(project);
-        await verifyPackedProvenance(project, packages, manifests);
-        await verifyPackedVueExports(project, logs);
-        await assertRegistryVueHostProvenance(project);
-        await assertNoWorkspaceSourceAliases(project);
-        await runLoggedCommand("09-typecheck", project.check, logs);
-        await runLoggedCommand("10-build", project.build, logs);
-        await assertNuxtComponentDiscovery(project, logs);
-        if (project.postBuild) await runLoggedCommand("11-output-install", project.postBuild, logs);
-        await assertPreservedVueHostBytes(project, preservedBytes);
-        if (project.preview) await verifyBrowser(project, logs, browser);
-      }
-    }, [
-      async () => {
-        if (browser) await browser.close();
-      },
-      async () => {
-        if (registry) await registry.close();
-      },
-    ]);
-    console.log(
-      "[vue-cli-host] packed Vite Vue, Astro Vue, Nuxt 3/4, Laravel/Inertia, and Quasar SPA/SSR acceptance passed",
-    );
+    const prepared = await prepareVueHostPackages({
+      packsDirectory,
+      outputDirectory: path.join(root, "packs"),
+      logsDirectory: path.join(root, "logs"),
+    });
+    const plan = createVueCliHostAcceptancePlan({ packages: prepared.packages, root });
+    const requested = projectIds ? new Set(projectIds) : undefined;
+    const projects = plan.projects.filter(({ id }) => !requested || requested.has(id));
+    if (requested)
+      assert.equal(projects.length, requested.size, "Unknown Vue host acceptance project id.");
+    await runVueHostWorkers(projects, { root, prepared, concurrency });
+    console.log("[vue-cli-host] packed Vue host acceptance passed");
     return { root };
   });
 }
 
 async function main() {
+  if (process.argv[2] === "--worker") {
+    assert.equal(process.argv.length, 4, "Expected one Vue worker context file.");
+    const context = JSON.parse(await readFile(process.argv[3], "utf8"));
+    const prepared = context.prepared;
+    for (const [key, hash] of Object.entries(prepared.archiveHashes ?? {})) {
+      const bytes = await readFile(prepared.packages[key]);
+      assert.equal(
+        createHash("sha256").update(bytes).digest("hex"),
+        hash,
+        `Staged release archive changed: ${key}`,
+      );
+    }
+    await runVueHostProject({ ...context, ...prepared });
+    return;
+  }
   await runVueCliHostAcceptance(parseArgs(process.argv.slice(2)));
 }
 export async function createOfficialVueHostFixture(project) {


### PR DESCRIPTION
Release preparation repeated builds, packing, and acceptance checks even when the verified inputs had not changed. The gate now builds and packs once, verifies the archive bytes, and lets both complete host matrices use those artifacts with two workers. Matching source, toolchain, outputs, archives, and stage order permit checkpoint reuse; the dependency audit still runs on each invocation.

A disposable preflight collects release failures before the full gate. Post-merge Release reuses candidate Verify only for identical complete Git trees with trusted successful-run evidence. npm finalization now tolerates propagation of versions and old dist-tags and provides a finalize-only recovery command. Vue remains on the beta channel.

Validation:
- Complete public release gate passed all 20 stages, including seven Vue hosts and eleven candidate projects.
- An unchanged gate rerun completed in 1.6 seconds, including the dependency audit.
- Source, lockfile, built-output, archive, and untracked-source mutations all rejected evidence reuse.
- All five prepared tarball publication dry-runs passed; Vue used beta and the other packages used latest.
- Focused release and sync tests passed, including 27 archive and Vue host tests. Public static checks, generator types, Biome, Prettier, frozen installation, and guarded projection checks passed.
- The archive-staging regression starts with repository-contained inputs and verifies copying outside the repository while retaining source-alias rejection.
- One unchanged Vue browser test failed during navigation and passed on resume. The production audit retains one existing low-severity advisory; the configured high-severity check passed.

Release impact: internal tooling, test commands, and documentation. No package release is scheduled. Real npm publication remains a user-run step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Process**
  - Added automated preflight and release-gate checks covering builds, tests, demos, package audits, and host acceptance.
  - Release checks can reuse verified results and resume completed stages when inputs remain unchanged.
  - Publishing now uses verified, hash-checked release archives.

- **Reliability**
  - Improved validation of release packages, metadata, source changes, and archive integrity.
  - Added retry handling for package visibility and distribution-tag propagation.

- **Documentation**
  - Documented release preparation, verification, artifact reuse, and troubleshooting options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->